### PR TITLE
fix(cli): publish scoped npm package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.5.0
+          node-version: 24
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
@@ -48,5 +48,3 @@ jobs:
 
       - name: Publish package
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,52 @@
+name: Publish npm package
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Verify and publish CLI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.5.0
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Verify release version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PACKAGE_VERSION="$(node --print "require('./package.json').version")"
+          if [ -n "$RELEASE_TAG" ] && [ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version v$PACKAGE_VERSION"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check package
+        run: npm run check
+
+      - name: Publish package
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22.5.0
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
@@ -48,3 +48,5 @@ jobs:
 
       - name: Publish package
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.en.md
+++ b/README.en.md
@@ -72,6 +72,18 @@ npm run build
 npm start
 ```
 
+### Command-line client
+
+The CLI connects to a running Scriverse server to query or edit work data. Install it globally to use the `scriverse` command:
+
+```bash
+npm install --global scriverse
+scriverse auth login --server https://your-scriverse.example.com --api-key-file ./api-key.txt
+scriverse work list
+```
+
+Run `scriverse --help` for all authentication, work, manuscript, resource, history, and search commands. The CLI requires Node.js `>= 22.5.0`.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/README.en.md
+++ b/README.en.md
@@ -77,7 +77,7 @@ npm start
 The CLI connects to a running Scriverse server to query or edit work data. Install it globally to use the `scriverse` command:
 
 ```bash
-npm install --global scriverse
+npm install --global @musnows/scriverse
 scriverse auth login --server https://your-scriverse.example.com --api-key-file ./api-key.txt
 scriverse work list
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm start
 CLI 用于连接已运行的 Scriverse 服务，查询或编辑作品数据。全局安装后可直接使用 `scriverse` 命令：
 
 ```bash
-npm install --global scriverse
+npm install --global @musnows/scriverse
 scriverse auth login --server https://your-scriverse.example.com --api-key-file ./api-key.txt
 scriverse work list
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ npm run build
 npm start
 ```
 
+### 命令行工具
+
+CLI 用于连接已运行的 Scriverse 服务，查询或编辑作品数据。全局安装后可直接使用 `scriverse` 命令：
+
+```bash
+npm install --global scriverse
+scriverse auth login --server https://your-scriverse.example.com --api-key-file ./api-key.txt
+scriverse work list
+```
+
+使用 `scriverse --help` 查看认证、作品、正文、资源、历史版本和搜索等全部命令。CLI 要求 Node.js `>= 22.5.0`。
+
 ## 环境变量
 
 | 变量 | 默认值 | 说明 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "scriverse",
       "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",
         "mammoth": "^1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "scriverse",
+  "name": "@musnows/scriverse",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "scriverse",
+      "name": "@musnows/scriverse",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scriverse",
+  "name": "@musnows/scriverse",
   "version": "0.2.0",
   "description": "Command-line client for the Scriverse long-form fiction workspace",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,37 @@
 {
   "name": "scriverse",
   "version": "0.2.0",
-  "private": true,
+  "description": "Command-line client for the Scriverse long-form fiction workspace",
+  "license": "MIT",
+  "author": "musnows",
+  "homepage": "https://scriverse.top/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/musnows/Scriverse.git"
+  },
+  "bugs": {
+    "url": "https://github.com/musnows/Scriverse/issues"
+  },
+  "keywords": [
+    "scriverse",
+    "novel",
+    "writing",
+    "cli"
+  ],
   "type": "module",
+  "files": [
+    "dist/cli.js",
+    "dist/cli.js.map",
+    "dist/cli-core.js",
+    "dist/cli-core.js.map",
+    "dist/cli-contract.js",
+    "dist/cli-contract.js.map"
+  ],
   "bin": {
     "scriverse": "dist/cli.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "engines": {
     "node": ">=22.5.0"
@@ -14,6 +41,7 @@
     "cli": "tsx src/cli.ts",
     "clean": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\"",
     "build": "npm run clean && tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --maxWorkers=1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://scriverse.top/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/musnows/Scriverse.git"
+    "url": "git+https://github.com/musnows/Scriverse.git"
   },
   "bugs": {
     "url": "https://github.com/musnows/Scriverse/issues"


### PR DESCRIPTION
## What changed

- publish the Scriverse CLI as `@musnows/scriverse`
- add npm package metadata, packed-file boundaries, and CLI installation docs
- add a GitHub Actions workflow for release-driven npm publishing
- preserve the installed `scriverse` command

## Why

The first npm release used the unscoped `scriverse` name. The package now lives under the maintainer-owned `@musnows` scope, while the old package is deprecated with a migration notice.

## Validation

- `npm run check` (39 test files, 210 tests)
- `npm pack --dry-run --json`
- `actionlint .github/workflows/npm-publish.yml`
- published `@musnows/scriverse@0.2.0` as a public package