### PR TITLE
release 0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ tests/
 - `develop` 是日常开发和功能集成分支；开始新任务前应切换到最新的 `develop`。
 - 功能、修复和文档变更应从 `develop` 派生分支，所有协作者的 PR 必须以 `develop` 为目标分支。
 - 只有项目维护者发起的版本发布合并可以从 `develop` 进入 `main`，不得绕过 `develop` 直接提交功能或修复。
+- **所有变更必须先合入 `develop`；除项目维护者发起的 `develop` → `main` 版本发布 PR 外，禁止任何功能、修复、文档、CI、构建或维护分支直接向 `main` 发起 PR。**
 - 更完整的协作流程见 `CONTRIBUTING.md`。
 
 ### 强制原则

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.en.md
+++ b/README.en.md
@@ -203,7 +203,7 @@ Expected response:
 {
   "data": {
     "status": "ok",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "protocol": "openai-chat-completions"
   }
 }

--- a/README.en.md
+++ b/README.en.md
@@ -74,15 +74,24 @@ npm start
 
 ### Command-line client
 
-The CLI connects to a running Scriverse server to query or edit work data. Install it globally to use the `scriverse` command:
+The CLI can start Scriverse locally or connect to any running server to query and edit work data. Install it globally to use the `scriverse` command:
 
 ```bash
 npm install --global @musnows/scriverse
-scriverse auth login --server https://your-scriverse.example.com --api-key-file ./api-key.txt
+scriverse serve --data-dir ./scriverse-data
+```
+
+`serve` listens on `http://127.0.0.1:13210` by default. Starting a local server is not required for the other CLI commands; you can save a remote server as the default target:
+
+```bash
+scriverse connect https://your-scriverse.example.com
+scriverse auth login --api-key-file ./api-key.txt
 scriverse work list
 ```
 
-Run `scriverse --help` for all authentication, work, manuscript, resource, history, and search commands. The CLI requires Node.js `>= 22.5.0`.
+The CLI stores credentials per server. Every data command accepts `--server <url>` to override the default for that invocation, for example `scriverse work list --server https://another.example.com`; authenticate to that server first with `auth login --server <url>`. Run `scriverse connect` to show the current default server.
+
+Run `scriverse --help` for all local server, default server, authentication, work, manuscript, resource, history, and search commands. The CLI requires Node.js `>= 22.5.0`.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -80,15 +80,24 @@ npm start
 
 ### 命令行工具
 
-CLI 用于连接已运行的 Scriverse 服务，查询或编辑作品数据。全局安装后可直接使用 `scriverse` 命令：
+CLI 既可以启动本地 Scriverse，也可以连接任意已运行的服务来查询或编辑作品数据。全局安装后可直接使用 `scriverse` 命令：
 
 ```bash
 npm install --global @musnows/scriverse
-scriverse auth login --server https://your-scriverse.example.com --api-key-file ./api-key.txt
+scriverse serve --data-dir ./scriverse-data
+```
+
+`serve` 默认监听 `http://127.0.0.1:13210`。启动本地服务不是使用其他 CLI 命令的前置条件；可以保存远程服务作为默认目标：
+
+```bash
+scriverse connect https://your-scriverse.example.com
+scriverse auth login --api-key-file ./api-key.txt
 scriverse work list
 ```
 
-使用 `scriverse --help` 查看认证、作品、正文、资源、历史版本和搜索等全部命令。CLI 要求 Node.js `>= 22.5.0`。
+CLI 会按服务器保存登录凭据。所有连接服务的数据命令都可以使用 `--server <url>` 临时覆盖默认服务器，例如 `scriverse work list --server https://another.example.com`；使用前需先通过 `auth login --server <url>` 登录该服务器。执行 `scriverse connect` 可查看当前默认服务器。
+
+使用 `scriverse --help` 查看本地服务、默认服务器、认证、作品、正文、资源、历史版本和搜索等全部命令。CLI 要求 Node.js `>= 22.5.0`。
 
 ## 环境变量
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ curl http://127.0.0.1:13210/api/health
 {
   "data": {
     "status": "ok",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "protocol": "openai-chat-completions"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@musnows/scriverse",
   "version": "0.2.0",
-  "description": "Command-line client for the Scriverse long-form fiction workspace",
+  "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",
   "homepage": "https://scriverse.top/",
@@ -20,12 +20,7 @@
   ],
   "type": "module",
   "files": [
-    "dist/cli.js",
-    "dist/cli.js.map",
-    "dist/cli-core.js",
-    "dist/cli-core.js.map",
-    "dist/cli-contract.js",
-    "dist/cli-contract.js.map"
+    "dist/**/*"
   ],
   "bin": {
     "scriverse": "dist/cli.js"
@@ -40,7 +35,7 @@
     "dev": "tsx watch src/server.ts",
     "cli": "tsx src/cli.ts",
     "clean": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true })\"",
-    "build": "npm run clean && tsc -p tsconfig.build.json",
+    "build": "npm run clean && tsc -p tsconfig.build.json && node scripts/copy-public.mjs",
     "prepack": "npm run build",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/scripts/copy-public.mjs
+++ b/scripts/copy-public.mjs
@@ -1,0 +1,3 @@
+import { cpSync } from "node:fs";
+
+cpSync(new URL("../src/public/", import.meta.url), new URL("../dist/public/", import.meta.url), { recursive: true });

--- a/src/app.ts
+++ b/src/app.ts
@@ -316,6 +316,7 @@ export type RuntimeOptions = {
   masterSecret: string;
   fetchImpl?: typeof fetch;
   serveUi?: boolean;
+  publicPath?: string;
   security?: RuntimeSecurityOptions;
   disableUserAuth?: boolean;
   /** 测试用：在验证码接口中回显答案 */
@@ -1054,7 +1055,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   app.get("/api/works/:workId/audit-logs", (request, response) => data(response, store.listAuditLogs(request.params.workId)));
 
   if (options.serveUi ?? true) {
-    const publicPath = join(process.cwd(), "src", "public");
+    const publicPath = options.publicPath ?? join(process.cwd(), "src", "public");
     app.use(express.static(publicPath, {
       index: "index.html",
       maxAge: 0,

--- a/src/app.ts
+++ b/src/app.ts
@@ -374,7 +374,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   app.use(createSecurityHeadersMiddleware());
 
   app.get("/api/health", (_request, response) => {
-    data(response, { status: "ok", version: "0.2.0", protocol: "openai-chat-completions" });
+    data(response, { status: "ok", version: "0.3.0", protocol: "openai-chat-completions" });
   });
 
   if (options.security?.auth) app.use(createBasicAuthMiddleware(options.security.auth));

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -1,13 +1,15 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { cliResourceDefinitions, cliResourceTypes, cliWorkDefinition, type CliResourceType } from "./cli-contract.js";
+import type { LocalServerOptions } from "./server-runtime.js";
 
 type OutputStream = { write(chunk: string): unknown };
 type InputStream = NodeJS.ReadableStream & AsyncIterable<Buffer | string>;
 
 type CliDependencies = {
   fetchImpl?: typeof fetch;
+  serveImpl?: (options: LocalServerOptions) => Promise<{ url: string; port: number; dataDirectory: string; databasePath: string }>;
   stdin?: InputStream;
   stdout?: OutputStream;
   stderr?: OutputStream;
@@ -21,17 +23,27 @@ type ParsedArguments = {
   options: Map<string, string[]>;
 };
 
-type CliConfig = {
-  version: 1;
-  server: string;
+type CliUser = {
+  userId: string;
+  username: string;
+  displayName: string;
+  role: "admin" | "user";
+};
+
+type CliServerCredentials = {
   apiKey: string;
   apiKeyPrefix: string | null;
-  user: {
-    userId: string;
-    username: string;
-    displayName: string;
-    role: "admin" | "user";
-  };
+  user: CliUser;
+};
+
+type CliConfig = {
+  version: 2;
+  defaultServer: string | null;
+  servers: Record<string, CliServerCredentials>;
+};
+
+type CliRequestConfig = CliServerCredentials & {
+  server: string;
 };
 
 type RequestOptions = {
@@ -92,7 +104,7 @@ function optionValues(parsed: ParsedArguments, name: string): string[] {
 }
 
 function assertAllowedOptions(parsed: ParsedArguments, allowed: string[]): void {
-  const allowedSet = new Set(["config", "compact", "help", ...allowed]);
+  const allowedSet = new Set(["config", "compact", "help", "server", ...allowed]);
   for (const name of parsed.options.keys()) {
     if (!allowedSet.has(name)) throw new CliError("CLI_OPTION_UNKNOWN", `当前命令不支持 --${name}`);
   }
@@ -141,6 +153,27 @@ function normalizeServer(value: string): string {
   return url.origin;
 }
 
+function emptyConfig(): CliConfig {
+  return { version: 2, defaultServer: null, servers: {} };
+}
+
+function validUser(value: unknown): value is CliUser {
+  if (!value || typeof value !== "object") return false;
+  const user = value as Partial<CliUser>;
+  return typeof user.userId === "string"
+    && typeof user.username === "string"
+    && typeof user.displayName === "string"
+    && (user.role === "admin" || user.role === "user");
+}
+
+function validCredentials(value: unknown): value is CliServerCredentials {
+  if (!value || typeof value !== "object") return false;
+  const credentials = value as Partial<CliServerCredentials>;
+  return typeof credentials.apiKey === "string"
+    && (typeof credentials.apiKeyPrefix === "string" || credentials.apiKeyPrefix === null)
+    && validUser(credentials.user);
+}
+
 function readConfig(path: string): CliConfig {
   if (!existsSync(path)) throw new CliError("CLI_LOGIN_REQUIRED", "请先执行 auth login");
   let parsed: unknown;
@@ -150,11 +183,36 @@ function readConfig(path: string): CliConfig {
     throw new CliError("CLI_CONFIG_INVALID", `CLI 配置文件无法读取：${path}`);
   }
   if (!parsed || typeof parsed !== "object") throw new CliError("CLI_CONFIG_INVALID", "CLI 配置内容无效");
-  const value = parsed as Partial<CliConfig>;
-  if (value.version !== 1 || typeof value.server !== "string" || typeof value.apiKey !== "string" || !value.user || typeof value.user.userId !== "string") {
+  const value = parsed as Record<string, unknown>;
+  const legacyServer = typeof value.server === "string" ? value.server : null;
+  if (value.version === 1 && legacyServer && validCredentials(value)) {
+    const server = normalizeServer(legacyServer);
+    return {
+      version: 2,
+      defaultServer: server,
+      servers: {
+        [server]: {
+          apiKey: value.apiKey,
+          apiKeyPrefix: value.apiKeyPrefix,
+          user: value.user
+        }
+      }
+    };
+  }
+  if (value.version !== 2 || (value.defaultServer !== null && typeof value.defaultServer !== "string") || !value.servers || typeof value.servers !== "object" || Array.isArray(value.servers)) {
     throw new CliError("CLI_CONFIG_INVALID", "CLI 配置字段不完整，请重新登录");
   }
-  return value as CliConfig;
+  const defaultServer = value.defaultServer === null ? null : normalizeServer(value.defaultServer);
+  const servers: Record<string, CliServerCredentials> = {};
+  for (const [serverValue, credentials] of Object.entries(value.servers)) {
+    if (!validCredentials(credentials)) throw new CliError("CLI_CONFIG_INVALID", "CLI 服务器凭据字段不完整，请重新登录");
+    servers[normalizeServer(serverValue)] = credentials;
+  }
+  return { version: 2, defaultServer, servers };
+}
+
+function readOptionalConfig(path: string): CliConfig {
+  return existsSync(path) ? readConfig(path) : emptyConfig();
 }
 
 function writeConfig(path: string, config: CliConfig): void {
@@ -225,7 +283,22 @@ async function editInput(parsed: ParsedArguments, dependencies: Required<Pick<Cl
   return input;
 }
 
-async function apiRequest(fetchImpl: typeof fetch, config: CliConfig, path: string, options: RequestOptions = {}): Promise<unknown> {
+function selectedServer(parsed: ParsedArguments, config: CliConfig): string {
+  const configured = option(parsed, "server");
+  if (configured) return normalizeServer(configured);
+  if (config.defaultServer) return config.defaultServer;
+  throw new CliError("CLI_SERVER_REQUIRED", "请先执行 connect <url>，或使用 --server 指定服务器");
+}
+
+function requestConfig(parsed: ParsedArguments, path: string): CliRequestConfig {
+  const config = readConfig(path);
+  const server = selectedServer(parsed, config);
+  const credentials = config.servers[server];
+  if (!credentials) throw new CliError("CLI_LOGIN_REQUIRED", `请先对 ${server} 执行 auth login`);
+  return { server, ...credentials };
+}
+
+async function apiRequest(fetchImpl: typeof fetch, config: CliRequestConfig, path: string, options: RequestOptions = {}): Promise<unknown> {
   const response = await fetchImpl(`${config.server}${path}`, {
     method: options.method ?? "GET",
     headers: {
@@ -371,10 +444,17 @@ function summarizeTreeList(type: "volume" | "chapter", tree: unknown): unknown[]
 function helpText(): string {
   return `Scriverse CLI
 
+本地服务：
+  scriverse serve [--host <host>] [--port <port>] [--data-dir <path>]
+
+默认服务器：
+  scriverse connect <url>
+  scriverse connect
+
 认证：
-  scriverse auth login --server <url> [--api-key <key> | --api-key-file <path>]
-  scriverse auth status
-  scriverse auth logout
+  scriverse auth login [--server <url>] [--api-key <key> | --api-key-file <path>]
+  scriverse auth status [--server <url>]
+  scriverse auth logout [--server <url>]
 
 查询：
   scriverse work list
@@ -400,6 +480,7 @@ AI 编辑辅助：
 
 全局选项：
   --config <path>  指定登录配置文件
+  --server <url>   仅为当前子命令覆盖默认服务器
   --compact        输出单行 JSON
 `;
 }
@@ -433,11 +514,53 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
   }
 
   const path = configPath(parsed, dependencies);
+  if (group === "serve") {
+    assertAllowedOptions(parsed, ["host", "port", "data-dir", "database-path"]);
+    assertPositionCount(parsed.positionals, 1);
+    const host = (option(parsed, "host") ?? dependencies.env.HOST ?? "127.0.0.1").trim();
+    if (!host) throw new CliError("CLI_HOST_INVALID", "监听地址不能为空");
+    const port = Number(option(parsed, "port") ?? dependencies.env.PORT ?? 13210);
+    if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+      throw new CliError("CLI_PORT_INVALID", "端口必须是 1 到 65535 之间的整数");
+    }
+    const dataDirectoryValue = option(parsed, "data-dir") ?? dependencies.env.DATA_DIR ?? join(dependencies.cwd, ".data");
+    const dataDirectory = isAbsolute(dataDirectoryValue) ? dataDirectoryValue : resolve(dependencies.cwd, dataDirectoryValue);
+    const databasePathValue = option(parsed, "database-path") ?? dependencies.env.DATABASE_PATH ?? join(dataDirectory, "novel.db");
+    const databasePath = isAbsolute(databasePathValue) ? databasePathValue : resolve(dependencies.cwd, databasePathValue);
+    const result = await dependencies.serveImpl({ host, port, dataDirectory, databasePath, env: dependencies.env });
+    emitJson(dependencies.stdout, {
+      running: true,
+      url: result.url,
+      port: result.port,
+      dataDirectory: result.dataDirectory,
+      databasePath: result.databasePath
+    }, compact);
+    return;
+  }
+
+  if (group === "connect") {
+    assertAllowedOptions(parsed, []);
+    assertPositionCount(parsed.positionals, 2);
+    const config = readOptionalConfig(path);
+    const requested = parsed.positionals[1];
+    if (requested) {
+      config.defaultServer = normalizeServer(requested);
+      writeConfig(path, config);
+    }
+    emitJson(dependencies.stdout, {
+      defaultServer: config.defaultServer,
+      authenticated: config.defaultServer ? Boolean(config.servers[config.defaultServer]) : false,
+      configPath: path
+    }, compact);
+    return;
+  }
+
   if (group === "auth") {
     if (action === "login") {
       assertAllowedOptions(parsed, ["server", "api-key", "api-key-file"]);
       assertPositionCount(parsed.positionals, 2);
-      const server = normalizeServer(option(parsed, "server") ?? "");
+      const existing = readOptionalConfig(path);
+      const server = selectedServer(parsed, existing);
       const directKey = option(parsed, "api-key");
       const keyFile = option(parsed, "api-key-file");
       const environmentKey = dependencies.env.SCRIVERSE_API_KEY?.trim();
@@ -446,46 +569,57 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
         throw new CliError("CLI_API_KEY_REQUIRED", "请通过 --api-key、--api-key-file 或 SCRIVERSE_API_KEY 三者之一提供 API Key");
       }
       const apiKey = supplied[0]!;
-      const temporary: CliConfig = {
-        version: 1,
+      const temporary: CliRequestConfig = {
         server,
         apiKey,
         apiKeyPrefix: null,
         user: { userId: "", username: "", displayName: "", role: "user" }
       };
       const session = await apiRequest(dependencies.fetchImpl, temporary, "/api/cli/session") as {
-        user?: CliConfig["user"];
+        user?: CliUser;
         apiKeyPrefix?: string | null;
       };
       if (!session.user?.userId) throw new CliError("CLI_RESPONSE_INVALID", "服务端没有返回有效用户信息");
-      const config: CliConfig = {
-        version: 1,
-        server,
+      existing.defaultServer ??= server;
+      existing.servers[server] = {
         apiKey,
         apiKeyPrefix: session.apiKeyPrefix ?? null,
         user: session.user
       };
-      writeConfig(path, config);
-      emitJson(dependencies.stdout, { authenticated: true, server, user: config.user, apiKeyPrefix: config.apiKeyPrefix, configPath: path }, compact);
+      writeConfig(path, existing);
+      emitJson(dependencies.stdout, { authenticated: true, server, user: session.user, apiKeyPrefix: session.apiKeyPrefix ?? null, configPath: path }, compact);
       return;
     }
     if (action === "status") {
       assertAllowedOptions(parsed, []);
       assertPositionCount(parsed.positionals, 2);
       if (!existsSync(path)) {
-        emitJson(dependencies.stdout, { authenticated: false, configPath: path }, compact);
+        emitJson(dependencies.stdout, { authenticated: false, defaultServer: null, configPath: path }, compact);
         return;
       }
       const config = readConfig(path);
-      const session = await apiRequest(dependencies.fetchImpl, config, "/api/cli/session");
-      emitJson(dependencies.stdout, { ...(session as Record<string, unknown>), server: config.server, configPath: path }, compact);
+      const server = selectedServer(parsed, config);
+      const credentials = config.servers[server];
+      if (!credentials) {
+        emitJson(dependencies.stdout, { authenticated: false, server, defaultServer: config.defaultServer, configPath: path }, compact);
+        return;
+      }
+      const session = await apiRequest(dependencies.fetchImpl, { server, ...credentials }, "/api/cli/session");
+      emitJson(dependencies.stdout, { ...(session as Record<string, unknown>), server, defaultServer: config.defaultServer, configPath: path }, compact);
       return;
     }
     if (action === "logout") {
       assertAllowedOptions(parsed, []);
       assertPositionCount(parsed.positionals, 2);
-      rmSync(path, { force: true });
-      emitJson(dependencies.stdout, { authenticated: false, configPath: path }, compact);
+      if (!existsSync(path)) {
+        emitJson(dependencies.stdout, { authenticated: false, defaultServer: null, configPath: path }, compact);
+        return;
+      }
+      const config = readConfig(path);
+      const server = selectedServer(parsed, config);
+      delete config.servers[server];
+      writeConfig(path, config);
+      emitJson(dependencies.stdout, { authenticated: false, server, defaultServer: config.defaultServer, configPath: path }, compact);
       return;
     }
     throw new CliError("CLI_COMMAND_UNKNOWN", "未知 auth 命令");
@@ -516,7 +650,7 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
   if (!["work", "manuscript", "search", "audit", "resource"].includes(group)) {
     throw new CliError("CLI_COMMAND_UNKNOWN", "未知命令；使用 --help 查看可用命令");
   }
-  const config = readConfig(path);
+  const config = requestConfig(parsed, path);
   if (group === "work") {
     if (action === "list") {
       assertAllowedOptions(parsed, []);
@@ -634,6 +768,12 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
 export async function runCli(args: string[], inputDependencies: CliDependencies = {}): Promise<number> {
   const dependencies: Required<CliDependencies> = {
     fetchImpl: inputDependencies.fetchImpl ?? fetch,
+    serveImpl: inputDependencies.serveImpl ?? (async (options) => {
+      const { installServerShutdownHandlers, startLocalServer } = await import("./server-runtime.js");
+      const running = await startLocalServer(options);
+      installServerShutdownHandlers(running);
+      return running;
+    }),
     stdin: inputDependencies.stdin ?? process.stdin,
     stdout: inputDependencies.stdout ?? process.stdout,
     stderr: inputDependencies.stderr ?? process.stderr,

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,0 +1,101 @@
+import type { Server } from "node:http";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { createRuntime, type Runtime } from "./app.js";
+import { loadMasterSecret } from "./credential-vault.js";
+import { resolveRuntimeSecurity, type RuntimeSecurityOptions } from "./security.js";
+
+export type LocalServerOptions = {
+  host: string;
+  port: number;
+  dataDirectory: string;
+  databasePath: string;
+  env: NodeJS.ProcessEnv;
+};
+
+export type RunningLocalServer = {
+  server: Server;
+  runtime: Runtime;
+  url: string;
+  host: string;
+  port: number;
+  dataDirectory: string;
+  databasePath: string;
+  security: RuntimeSecurityOptions;
+  close: () => Promise<void>;
+};
+
+const publicPath = fileURLToPath(new URL("./public/", import.meta.url));
+
+export async function startLocalServer(options: LocalServerOptions): Promise<RunningLocalServer> {
+  const security = resolveRuntimeSecurity(options.env);
+  const runtime = createRuntime({
+    databasePath: options.databasePath,
+    masterSecret: loadMasterSecret(join(options.dataDirectory, "master.key"), options.env.AI_NOVEL_MASTER_KEY),
+    publicPath,
+    security
+  });
+
+  return await new Promise<RunningLocalServer>((resolveStart, rejectStart) => {
+    const server = runtime.app.listen(options.port, options.host);
+    const handleStartupError = (error: Error): void => {
+      runtime.close();
+      rejectStart(error);
+    };
+    server.once("error", handleStartupError);
+    server.once("listening", () => {
+      server.off("error", handleStartupError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        runtime.close();
+        rejectStart(new Error("Scriverse server did not expose a TCP port"));
+        return;
+      }
+      const port = address.port;
+      const displayHost = options.host.includes(":") ? `[${options.host}]` : options.host;
+      let closed = false;
+      const close = async (): Promise<void> => {
+        if (closed) return;
+        closed = true;
+        server.closeAllConnections();
+        try {
+          await new Promise<void>((resolveClose, rejectClose) => {
+            server.close((error) => error ? rejectClose(error) : resolveClose());
+          });
+        } finally {
+          runtime.close();
+        }
+      };
+      resolveStart({
+        server,
+        runtime,
+        url: `http://${displayHost}:${port}`,
+        host: options.host,
+        port,
+        dataDirectory: options.dataDirectory,
+        databasePath: options.databasePath,
+        security,
+        close
+      });
+    });
+  });
+}
+
+export function installServerShutdownHandlers(running: RunningLocalServer): void {
+  let shuttingDown = false;
+  const shutdown = (signal: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`Received ${signal}, shutting down`);
+    void running.close().then(
+      () => { process.exitCode = 0; },
+      (error: unknown) => {
+        console.error(error instanceof Error ? error.message : "Failed to stop Scriverse server");
+        process.exitCode = 1;
+      }
+    );
+  };
+  process.once("SIGINT", () => shutdown("SIGINT"));
+  process.once("SIGTERM", () => shutdown("SIGTERM"));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,29 +1,16 @@
 import { join } from "node:path";
-import { createRuntime } from "./app.js";
-import { loadMasterSecret } from "./credential-vault.js";
-import { resolveRuntimeSecurity } from "./security.js";
+import { installServerShutdownHandlers, startLocalServer } from "./server-runtime.js";
 
 const port = Number(process.env.PORT ?? 13210);
 const host = process.env.HOST ?? "127.0.0.1";
 const dataDirectory = process.env.DATA_DIR ?? join(process.cwd(), ".data");
-const security = resolveRuntimeSecurity(process.env);
-const runtime = createRuntime({
+const running = await startLocalServer({
+  port,
+  host,
+  dataDirectory,
   databasePath: process.env.DATABASE_PATH ?? join(dataDirectory, "novel.db"),
-  masterSecret: loadMasterSecret(join(dataDirectory, "master.key"), process.env.AI_NOVEL_MASTER_KEY),
-  security
+  env: process.env
 });
 
-const server = runtime.app.listen(port, host, () => {
-  console.log(`AI novel workbench listening on http://${host}:${port} (user authentication enabled${security.auth ? ", deployment gateway enabled" : ""})`);
-});
-
-function shutdown(signal: string): void {
-  console.log(`Received ${signal}, shutting down`);
-  server.close(() => {
-    runtime.close();
-    process.exit(0);
-  });
-}
-
-process.on("SIGINT", () => shutdown("SIGINT"));
-process.on("SIGTERM", () => shutdown("SIGTERM"));
+console.log(`Scriverse listening on ${running.url} (user authentication enabled${running.security.auth ? ", deployment gateway enabled" : ""})`);
+installServerShutdownHandlers(running);

--- a/tests/e2e/real-cli.ts
+++ b/tests/e2e/real-cli.ts
@@ -224,7 +224,9 @@ async function run(): Promise<void> {
   const help = cli(["--help"]);
   assert.match(help.stdout, /Scriverse CLI/u);
   assert.doesNotMatch(help.stdout, /用户管理|供应商管理/u);
-  assert.deepEqual(cliJson(["auth", "status"]), { authenticated: false, configPath });
+  assert.deepEqual(cliJson(["auth", "status"]), { authenticated: false, defaultServer: null, configPath });
+  assert.deepEqual(cliJson(["connect", baseUrl]), { defaultServer: baseUrl, authenticated: false, configPath });
+  assert.deepEqual(cliJson(["auth", "status"]), { authenticated: false, server: baseUrl, defaultServer: baseUrl, configPath });
   const schemaList = cliJson(["schema", "list"]) as { prohibited: string[]; resources: unknown[] };
   assert.ok(schemaList.prohibited.includes("用户管理"));
   assert.equal(schemaList.resources.length, 11);
@@ -246,7 +248,7 @@ async function run(): Promise<void> {
   const keyPath = textFile("admin-api-key", `${adminKey}\n`);
   chmodSync(keyPath, 0o600);
 
-  const login = cliJson(["auth", "login", "--server", baseUrl, "--api-key-file", keyPath]) as {
+  const login = cliJson(["auth", "login", "--api-key-file", keyPath]) as {
     authenticated: boolean;
     user: { userId: string };
   };
@@ -474,16 +476,16 @@ async function run(): Promise<void> {
   assert.equal(deleteResponse.status, 403);
   checked("server-scope", "raw API key calls could not access another user work, platform management or deletion");
 
-  assert.deepEqual(cliJson(["auth", "logout"]), { authenticated: false, configPath });
+  assert.deepEqual(cliJson(["auth", "logout"]), { authenticated: false, server: baseUrl, defaultServer: baseUrl, configPath });
   cliError(["work", "list"], "CLI_LOGIN_REQUIRED");
   const writerKeyPath = textFile("writer-api-key", writerKey);
-  cliJson(["auth", "login", "--server", baseUrl, "--api-key-file", writerKeyPath]);
+  cliJson(["auth", "login", "--api-key-file", writerKeyPath]);
   const writerWorks = cliJson(["work", "list"]) as Array<Record<string, unknown>>;
   assert.deepEqual(writerWorks.map((item) => item.id), [writerWork.id]);
   cliError(["work", "get", workId], "WORK_ACCESS_DENIED");
   await resetApiKey(writer);
   cliError(["auth", "status"], "API_KEY_INVALID");
-  assert.deepEqual(cliJson(["auth", "logout"]), { authenticated: false, configPath });
+  assert.deepEqual(cliJson(["auth", "logout"]), { authenticated: false, server: baseUrl, defaultServer: baseUrl, configPath });
   checked("identity-isolation", "logout blocked data commands, writer key saw only writer data, and key rotation invalidated the saved login");
 
   await stopServer();

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startLocalServer, type RunningLocalServer } from "../../src/server-runtime.js";
+
+const roots: string[] = [];
+const runningServers: RunningLocalServer[] = [];
+
+afterEach(async () => {
+  for (const running of runningServers.splice(0)) await running.close();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("本地服务运行时", () => {
+  it("使用隔离数据目录启动 API 和完整网页", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-serve-"));
+    roots.push(root);
+    const databasePath = join(root, "novel.db");
+    const running = await startLocalServer({
+      host: "127.0.0.1",
+      port: 0,
+      dataDirectory: root,
+      databasePath,
+      env: { NODE_ENV: "test" }
+    });
+    runningServers.push(running);
+
+    const health = await fetch(`${running.url}/api/health`).then((response) => response.json()) as { data: { status: string } };
+    const page = await fetch(running.url).then((response) => response.text());
+
+    expect(health.data.status).toBe("ok");
+    expect(page).toContain("叙界");
+    expect(existsSync(databasePath)).toBe(true);
+    expect(existsSync(join(root, "master.key"))).toBe(true);
+  });
+});

--- a/tests/unit/cli-core.test.ts
+++ b/tests/unit/cli-core.test.ts
@@ -72,7 +72,13 @@ describe("Scriverse CLI 核心", () => {
     expect(stderr.text()).toBe("");
     expect(JSON.parse(stdout.text())).toMatchObject({ authenticated: true, apiKeyPrefix: "scrv_test" });
     expect(statSync(path).mode & 0o777).toBe(0o600);
-    expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({ apiKey: "scrv_test_key", user: { userId: "user-1" } });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+      version: 2,
+      defaultServer: "http://127.0.0.1:13210",
+      servers: {
+        "http://127.0.0.1:13210": { apiKey: "scrv_test_key", user: { userId: "user-1" } }
+      }
+    });
 
     const statusOutput = outputCapture();
     expect(await runCli(["auth", "status", "--config", path], {
@@ -88,6 +94,116 @@ describe("Scriverse CLI 核心", () => {
       stderr: stderr.stream
     })).toBe(0);
     expect(JSON.parse(logoutOutput.text())).toMatchObject({ authenticated: false });
+  });
+
+  it("保存默认服务器，并允许子命令临时覆盖到已登录的其他服务器", async () => {
+    const root = temporaryRoot();
+    const path = join(root, "cli.json");
+    const stderr = outputCapture();
+    const connectOutput = outputCapture();
+
+    expect(await runCli(["connect", "https://default.example.com", "--config", path], {
+      stdout: connectOutput.stream,
+      stderr: stderr.stream
+    })).toBe(0);
+    expect(JSON.parse(connectOutput.text())).toMatchObject({
+      defaultServer: "https://default.example.com",
+      authenticated: false
+    });
+
+    const loginOutput = outputCapture();
+    const loginFetch = (async () => new Response(JSON.stringify({
+      data: {
+        authenticated: true,
+        apiKeyPrefix: "scrv_ove",
+        user: { userId: "user-2", username: "override", displayName: "Override", role: "user" }
+      }
+    }), { status: 200, headers: { "Content-Type": "application/json" } })) as typeof fetch;
+    expect(await runCli([
+      "auth", "login",
+      "--server", "https://override.example.com",
+      "--api-key", "scrv_override",
+      "--config", path
+    ], {
+      fetchImpl: loginFetch,
+      stdout: loginOutput.stream,
+      stderr: stderr.stream
+    })).toBe(0);
+    expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+      defaultServer: "https://default.example.com",
+      servers: { "https://override.example.com": { apiKey: "scrv_override" } }
+    });
+
+    writeFileSync(path, JSON.stringify({
+      version: 2,
+      defaultServer: "https://default.example.com",
+      servers: {
+        "https://default.example.com": {
+          apiKey: "scrv_default",
+          apiKeyPrefix: "scrv_def",
+          user: { userId: "user-1", username: "default", displayName: "Default", role: "admin" }
+        },
+        "https://override.example.com": {
+          apiKey: "scrv_override",
+          apiKeyPrefix: "scrv_ove",
+          user: { userId: "user-2", username: "override", displayName: "Override", role: "user" }
+        }
+      }
+    }));
+    const requestedUrls: string[] = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      requestedUrls.push(String(input));
+      const server = String(input).startsWith("https://override.example.com") ? "override" : "default";
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer scrv_${server}`);
+      return new Response(JSON.stringify({ data: [] }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as typeof fetch;
+
+    expect(await runCli(["work", "list", "--config", path], {
+      fetchImpl,
+      stdout: outputCapture().stream,
+      stderr: stderr.stream
+    })).toBe(0);
+    expect(await runCli(["work", "list", "--server", "https://override.example.com", "--config", path], {
+      fetchImpl,
+      stdout: outputCapture().stream,
+      stderr: stderr.stream
+    })).toBe(0);
+    expect(requestedUrls).toEqual([
+      "https://default.example.com/api/works",
+      "https://override.example.com/api/works"
+    ]);
+    expect(stderr.text()).toBe("");
+  });
+
+  it("解析 serve 选项并启动隔离的数据目录", async () => {
+    const root = temporaryRoot();
+    const stdout = outputCapture();
+    const stderr = outputCapture();
+    let received: Record<string, unknown> | null = null;
+
+    expect(await runCli([
+      "serve",
+      "--host", "0.0.0.0",
+      "--port", "14321",
+      "--data-dir", "local-data"
+    ], {
+      cwd: root,
+      env: {},
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+      serveImpl: async (options) => {
+        received = options;
+        return { url: "http://0.0.0.0:14321", port: 14321, dataDirectory: options.dataDirectory, databasePath: options.databasePath };
+      }
+    })).toBe(0);
+    expect(received).toMatchObject({
+      host: "0.0.0.0",
+      port: 14321,
+      dataDirectory: join(root, "local-data"),
+      databasePath: join(root, "local-data", "novel.db")
+    });
+    expect(JSON.parse(stdout.text())).toMatchObject({ running: true, url: "http://0.0.0.0:14321" });
+    expect(stderr.text()).toBe("");
   });
 
   it("通过字段文件和 changeNote 生成适合长正文的版本化编辑请求", async () => {


### PR DESCRIPTION
## Scriverse 0.3.0

This release adds a self-hosted startup path to the npm CLI while keeping remote-server usage independent.

### Highlights

- start the complete local system with `scriverse serve`
- select a persistent default server with `scriverse connect`
- store credentials per server and override the target per command with `--server`
- package the server runtime and browser assets in `@musnows/scriverse`
- retain the scoped npm publishing fixes completed after `v0.2.0`
- document the mandatory `develop`-first pull request flow for repository agents

### Validation

- `npm run check` (40 test files, 213 tests)
- compiled CLI real E2E
- packaged `scriverse serve` health-check and graceful-shutdown smoke test
- npm package dry run

After merge, publishing GitHub Release `v0.3.0` will trigger the npm and Docker Hub release workflows.
