### PR TITLE
release 0.3.0 publishing fix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,12 +4,18 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Docker image tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: docker-publish-${{ github.ref }}
+  group: docker-publish-${{ github.event.release.tag_name || inputs.tag || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -42,8 +48,8 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ github.event.release.tag_name }}
-            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=${{ github.event.release.tag_name || inputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
 
       - name: Build and push image
         uses: docker/build-push-action@v7

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.5.0
+          node-version: 22.12.0
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY tsconfig.json tsconfig.build.json ./
+COPY scripts ./scripts
 COPY src ./src
 RUN npm run build
 


### PR DESCRIPTION
## Summary

- use Node.js 22.12.0 for npm publishing checks
- include the public asset copy script in Docker builds
- allow manually rebuilding an existing release tag

## Validation

- `npm run check`
- YAML syntax validation
- `git diff --check`

This PR repairs publishing for the existing v0.3.0 release after the original npm and Docker workflows failed.