### PR TITLE
feat(logging): add structured runtime observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN npm run build
 FROM node:22-bookworm-slim AS runtime
 
 ENV NODE_ENV=production \
+    LOG_LEVEL=info \
     HOST=0.0.0.0 \
     PORT=13210 \
     DATA_DIR=/app/.data

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2,6 +2,7 @@ import type { AiMessage, ContextScope, TaskType } from "./domain.js";
 import { CredentialVault } from "./credential-vault.js";
 import { PLATFORM_AI_WORK_ID, type Row } from "./database.js";
 import { AppError, notFound } from "./errors.js";
+import { logger, sanitizeError } from "./logger.js";
 import { currentRequestActor } from "./request-context.js";
 import { fetchSafeAiEndpoint } from "./security.js";
 import { Store, type AiConversationContext } from "./store.js";
@@ -31,6 +32,15 @@ type ModelInput = {
   enabled?: boolean;
   note?: string;
 };
+
+export function aiErrorForLog(error: unknown): Record<string, unknown> {
+  const sanitized = sanitizeError(error);
+  const message = typeof sanitized.message === "string" ? sanitized.message : "AI operation failed";
+  const httpStatus = message.match(/^HTTP (\d{3}):/u)?.[1];
+  if (httpStatus) return { name: sanitized.name ?? "Error", message: `Provider returned HTTP ${httpStatus}` };
+  if (message.includes("returned invalid JSON")) return { name: sanitized.name ?? "Error", message: "Provider returned invalid JSON" };
+  return sanitized;
+}
 
 type ProviderRow = Row & {
   id: string;
@@ -776,6 +786,7 @@ export class AiManager {
   ) {
     this.contextBuilder = new ContextBuilder(store);
     this.store.setAnalysisTaskQueuedHandler((workId) => this.scheduleAutoRun(workId));
+    logger.info("ai.manager.ready");
   }
 
   resetAutoRunBatch(workId: string): void {
@@ -795,6 +806,7 @@ export class AiManager {
       void this.drainAutoRun(workId);
     }, 0);
     this.autoRunTimers.set(workId, timer);
+    logger.debug("ai.auto_run.scheduled", { workId });
   }
 
   startAutoRunBatch(workId: string): Record<string, unknown> {
@@ -805,6 +817,11 @@ export class AiManager {
     }
     this.resetAutoRunBatch(workId);
     this.scheduleAutoRun(workId);
+    logger.info("ai.auto_run.batch_started", {
+      workId,
+      concurrency: settings.autoRunConcurrency,
+      batchLimit: settings.autoRunBatchLimit
+    });
     return {
       workId,
       autoRunEnabled: true,
@@ -816,10 +833,12 @@ export class AiManager {
   }
 
   dispose(): void {
+    logger.info("ai.manager.disposing", { scheduledWorks: this.autoRunTimers.size, activeTasks: this.taskControllers.size });
     for (const timer of this.autoRunTimers.values()) clearTimeout(timer);
     this.autoRunTimers.clear();
     this.autoRunBatches.clear();
     this.store.setAnalysisTaskQueuedHandler(null);
+    logger.info("ai.manager.disposed");
   }
 
   private getAutoRunBatch(workId: string): { claimed: number; starting: Set<string> } {
@@ -832,6 +851,7 @@ export class AiManager {
 
   private async drainAutoRun(workId: string): Promise<void> {
     try {
+      logger.debug("ai.auto_run.drain_started", { workId });
       const settings = this.store.getWorkAiSettings(workId);
       if (!settings.autoRunEnabled) return;
       const batch = this.getAutoRunBatch(workId);
@@ -856,7 +876,8 @@ export class AiManager {
             this.scheduleAutoRun(workId);
           });
       }
-    } catch {
+    } catch (error) {
+      logger.warn("ai.auto_run.drain_failed", { workId, error: aiErrorForLog(error) });
       // 数据库已关闭或作品不存在时忽略自动调度
     }
   }
@@ -967,6 +988,8 @@ export class AiManager {
     const apiKey = this.decryptKey(row);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10_000);
+    const startedAt = process.hrtime.bigint();
+    logger.info("ai.provider_test.started", { providerId });
     try {
       const endpoint = `${normalizeBaseUrl(stringValue(row, "base_url"))}/models`;
       const response = await this.outboundFetch(endpoint, {
@@ -986,6 +1009,12 @@ export class AiManager {
         timestamp,
         providerId
       );
+      logger.info("ai.provider_test.completed", {
+        providerId,
+        ok: true,
+        availableModelCount: availableModels.length,
+        durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000
+      });
       return { ok: true, availableModels, provider: this.getProvider(providerId) };
     } catch (error) {
       const message = error instanceof Error ? error.message : "连接失败";
@@ -995,6 +1024,12 @@ export class AiManager {
         now(),
         providerId
       );
+      logger.warn("ai.provider_test.completed", {
+        providerId,
+        ok: false,
+        durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000,
+        error: aiErrorForLog(error)
+      });
       return { ok: false, error: message, provider: this.getProvider(providerId) };
     } finally {
       clearTimeout(timeout);
@@ -1312,11 +1347,14 @@ export class AiManager {
     const task = this.store.getTask(taskId);
     const workId = String(task.workId);
     const batch = this.getAutoRunBatch(workId);
+    const startedAt = process.hrtime.bigint();
+    logger.info("ai.task.started", { taskId, workId, taskType: task.taskType, modelId: modelId ?? null });
     if (task.status !== "pending") throw new AppError(409, "TASK_NOT_PENDING", "只有待执行任务可以运行");
     if (!this.store.isTaskSourceCurrent(taskId)) {
       const expired = this.store.updateTask(taskId, { status: "expired" });
       batch.starting.delete(taskId);
       this.scheduleAutoRun(workId);
+      logger.warn("ai.task.expired", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000 });
       return expired;
     }
     const settings = this.store.getWorkAiSettings(workId);
@@ -1356,12 +1394,18 @@ export class AiManager {
         });
         result = { content: generated.content, callId: generated.callId };
       }
-      if (!this.taskCanCommit(taskId)) return this.store.getTask(taskId);
-      return this.store.updateTask(taskId, { status: "review", progress: 100, result });
+      if (!this.taskCanCommit(taskId)) {
+        logger.warn("ai.task.result_discarded", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000 });
+        return this.store.getTask(taskId);
+      }
+      const completed = this.store.updateTask(taskId, { status: "review", progress: 100, result });
+      logger.info("ai.task.completed", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000 });
+      return completed;
     } catch (error) {
       if (this.store.getTask(taskId).status !== "running") return this.store.getTask(taskId);
       const message = error instanceof Error ? error.message : "分析失败";
       this.store.updateTask(taskId, { status: "partial", progress: 100, failures: [{ message }] });
+      logger.error("ai.task.failed", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000, error: aiErrorForLog(error) });
       throw error;
     } finally {
       this.taskControllers.delete(taskId);
@@ -1375,6 +1419,7 @@ export class AiManager {
     this.taskControllers.get(taskId)?.abort(new Error("分析任务已取消"));
     this.taskControllers.delete(taskId);
     this.scheduleAutoRun(String(task.workId));
+    logger.warn("ai.task.cancelled", { taskId, workId: task.workId });
     return task;
   }
 
@@ -1764,6 +1809,18 @@ export class AiManager {
       timestamp,
       currentRequestActor()?.userId ?? null
     );
+    const callStartedAt = process.hrtime.bigint();
+    logger.info("ai.call.started", {
+      callId,
+      workId: input.workId,
+      taskType: input.taskType,
+      providerId: stringValue(provider, "id"),
+      modelId: stringValue(model, "id"),
+      streaming: false,
+      contextChars: context.length,
+      instructionChars: input.instruction.length,
+      toolCount: tools.length
+    });
     try {
       const apiKey = this.decryptKey(provider);
       const endpoint = `${normalizeBaseUrl(stringValue(provider, "base_url"))}/chat/completions`;
@@ -1781,6 +1838,8 @@ export class AiManager {
         let lastFailure: unknown = null;
         for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
           let retryable = true;
+          const attemptStartedAt = process.hrtime.bigint();
+          logger.info("ai.call.attempt_started", { callId, attempt, maximumAttempts, toolChoice });
           try {
             const candidate = await this.scheduleProviderRequest(provider, input.signal, async () => {
               const controller = new AbortController();
@@ -1801,6 +1860,13 @@ export class AiManager {
                 input.signal?.removeEventListener("abort", forwardAbort);
               }
             });
+            logger.info("ai.call.attempt_completed", {
+              callId,
+              attempt,
+              status: candidate.status,
+              ok: candidate.ok,
+              durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000
+            });
             if (candidate.ok) {
               try {
                 return JSON.parse(candidate.body) as CompletionPayload;
@@ -1815,6 +1881,13 @@ export class AiManager {
             }
           } catch (error) {
             lastFailure = error;
+            logger.warn("ai.call.attempt_failed", {
+              callId,
+              attempt,
+              retryable: retryable && attempt < maximumAttempts && !input.signal?.aborted,
+              durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
+              error: aiErrorForLog(error)
+            });
             if (input.signal?.aborted) throw error;
             if (!retryable || attempt >= maximumAttempts) throw error;
           }
@@ -1863,6 +1936,7 @@ export class AiManager {
         });
         for (const toolCall of toolCalls) {
           const execution = this.executeAgentTool(input.workId, toolCall);
+          logger.info("ai.tool_call.completed", { callId, toolName: execution.name, status: execution.status, round });
           executedToolCalls.push(execution);
           processSteps.push({ id: id("process"), type: "tool", round, toolCall: execution, createdAt: execution.calledAt });
           input.onToolCall?.(execution, round);
@@ -1891,10 +1965,29 @@ export class AiManager {
         now(),
         callId
       );
-      return { callId, content, outputTokens: resolveOutputTokens(payload.usage, content), provider: this.mapProvider(provider), model: this.mapModel(model), context, toolCalls: executedToolCalls, processSteps };
+      const outputTokens = resolveOutputTokens(payload.usage, content);
+      logger.info("ai.call.completed", {
+        callId,
+        workId: input.workId,
+        taskType: input.taskType,
+        streaming: false,
+        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
+        outputChars: content.length,
+        outputTokens,
+        toolCallCount: executedToolCalls.length
+      });
+      return { callId, content, outputTokens, provider: this.mapProvider(provider), model: this.mapModel(model), context, toolCalls: executedToolCalls, processSteps };
     } catch (error) {
       const message = error instanceof Error ? error.message : "AI 调用失败";
       this.store.db.run("UPDATE ai_calls SET status = 'failed', failure = ?, completed_at = ? WHERE id = ?", message, now(), callId);
+      logger.error("ai.call.failed", {
+        callId,
+        workId: input.workId,
+        taskType: input.taskType,
+        streaming: false,
+        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
+        error: aiErrorForLog(error)
+      });
       throw new AppError(502, "AI_CALL_FAILED", "AI 调用失败", { callId, failure: message });
     }
   }
@@ -1923,6 +2016,17 @@ export class AiManager {
       now(),
       currentRequestActor()?.userId ?? null
     );
+    const callStartedAt = process.hrtime.bigint();
+    logger.info("ai.call.started", {
+      callId,
+      workId: input.workId,
+      taskType: input.taskType,
+      providerId: stringValue(provider, "id"),
+      modelId: stringValue(model, "id"),
+      streaming: true,
+      contextChars: context.length,
+      instructionChars: input.instruction.length
+    });
     try {
       const apiKey = this.decryptKey(provider);
       const endpoint = `${normalizeBaseUrl(stringValue(provider, "base_url"))}/chat/completions`;
@@ -1933,6 +2037,8 @@ export class AiManager {
       const thinkingStepId = id("process");
       const thinkingCreatedAt = now();
       for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
+        const attemptStartedAt = process.hrtime.bigint();
+        logger.info("ai.call.attempt_started", { callId, attempt, maximumAttempts, streaming: true });
         try {
           const candidate = await this.scheduleProviderRequest(provider, input.signal, async () => {
             const controller = new AbortController();
@@ -1965,6 +2071,14 @@ export class AiManager {
               input.signal?.removeEventListener("abort", forwardAbort);
             }
           });
+          logger.info("ai.call.attempt_completed", {
+            callId,
+            attempt,
+            status: candidate.status,
+            ok: candidate.ok,
+            durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
+            streaming: true
+          });
           if (candidate.ok) {
             streamedResult = candidate.result;
             break;
@@ -1973,6 +2087,14 @@ export class AiManager {
           if (candidate.status !== 429 && candidate.status < 500) attempt = maximumAttempts;
         } catch (error) {
           lastFailure = error;
+          logger.warn("ai.call.attempt_failed", {
+            callId,
+            attempt,
+            retryable: !input.signal?.aborted && !emitted && attempt < maximumAttempts,
+            durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
+            streaming: true,
+            error: aiErrorForLog(error)
+          });
           if (input.signal?.aborted || emitted || attempt >= maximumAttempts) throw error;
         }
         if (attempt < maximumAttempts) await new Promise((resolve) => setTimeout(resolve, attempt * 1200));
@@ -1988,10 +2110,27 @@ export class AiManager {
         now(),
         callId
       );
+      logger.info("ai.call.completed", {
+        callId,
+        workId: input.workId,
+        taskType: input.taskType,
+        streaming: true,
+        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
+        outputChars: content.length,
+        outputTokens
+      });
       return { callId, content, outputTokens, provider: this.mapProvider(provider), model: this.mapModel(model), context, toolCalls: [], processSteps };
     } catch (error) {
       const message = error instanceof Error ? error.message : "AI 流式调用失败";
       this.store.db.run("UPDATE ai_calls SET status = 'failed', failure = ?, completed_at = ? WHERE id = ?", message, now(), callId);
+      logger.error("ai.call.failed", {
+        callId,
+        workId: input.workId,
+        taskType: input.taskType,
+        streaming: true,
+        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
+        error: aiErrorForLog(error)
+      });
       throw new AppError(502, "AI_CALL_FAILED", "AI 调用失败", { callId, failure: message });
     }
   }
@@ -3480,6 +3619,13 @@ export class AiManager {
       };
       signal?.addEventListener("abort", onAbort, { once: true });
       schedule.queue.push(entry);
+      logger.debug("ai.provider_queue.enqueued", {
+        providerId,
+        active: schedule.active,
+        queued: schedule.queue.length,
+        concurrencyLimit: schedule.concurrencyLimit,
+        rpmLimit: schedule.rpmLimit
+      });
       this.pumpProviderSchedule(providerId);
     });
   }
@@ -3503,16 +3649,19 @@ export class AiManager {
       }
       schedule.active += 1;
       schedule.starts.push(Date.now());
+      logger.debug("ai.provider_queue.dispatched", { providerId, active: schedule.active, queued: schedule.queue.length });
       void Promise.resolve()
         .then(entry.run)
         .then(entry.resolve, entry.reject)
         .finally(() => {
           schedule.active -= 1;
+          logger.debug("ai.provider_queue.finished", { providerId, active: schedule.active, queued: schedule.queue.length });
           this.pumpProviderSchedule(providerId);
         });
     }
     if (schedule.queue.length > 0 && schedule.active < schedule.concurrencyLimit && schedule.starts.length >= schedule.rpmLimit) {
       const delay = Math.max(1, (schedule.starts[0] ?? Date.now()) + 60_000 - Date.now() + 1);
+      logger.info("ai.provider_queue.rate_limited", { providerId, queued: schedule.queue.length, retryInMs: delay });
       schedule.timer = setTimeout(() => this.pumpProviderSchedule(providerId), delay);
       schedule.timer.unref?.();
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,8 @@ import { assertSafeAiEndpoint, createApiRateLimitMiddleware, createAuthenticatio
 import { ImageCaptchaService } from "./image-captcha.js";
 import { assertSafeImportedPlainText, decodeUtf8ImportedText } from "./import-security.js";
 import { InvalidRasterImageError, readRasterImageMetadata } from "./image-metadata.js";
+import { createRequestLoggingMiddleware, sanitizeRequestPath } from "./http-logging.js";
+import { accountReference, logger, sanitizeError } from "./logger.js";
 import { runWithRequestActor } from "./request-context.js";
 import {
   clearSessionCookie,
@@ -345,6 +347,13 @@ function parse<T>(schema: z.ZodType<T>, value: unknown): T {
 }
 
 export function createRuntime(options: RuntimeOptions): Runtime {
+  logger.info("runtime.initializing", {
+    databasePath: options.databasePath,
+    serveUi: options.serveUi ?? true,
+    userAuthDisabled: options.disableUserAuth === true,
+    deploymentAuthEnabled: Boolean(options.security?.auth),
+    sameOriginEnforced: options.security?.enforceSameOrigin ?? true
+  });
   const database = new Database(options.databasePath);
   const auth = new UserAuthService(database);
   const store = new Store(database);
@@ -371,6 +380,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
 
   app.disable("x-powered-by");
   if (options.security?.trustProxy !== undefined) app.set("trust proxy", options.security.trustProxy);
+  app.use(createRequestLoggingMiddleware());
   app.use(createSecurityHeadersMiddleware());
 
   app.get("/api/health", (_request, response) => {
@@ -402,6 +412,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     const result = auth.register({ username: input.username, password: input.password });
     setSessionCookie(response, result.token, request.secure);
     runWithRequestActor(result.session.user, () => store.audit(null, "user.registered", "user", result.session.user.userId, { role: result.session.user.role }));
+    logger.info("auth.registration.succeeded", { actorRef: accountReference(result.session.user.userId) });
     data(response, { user: result.session.user, csrfToken: result.session.csrfToken }, 201);
   });
   app.post("/api/auth/login", (request, response) => {
@@ -410,6 +421,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     const result = auth.login(input.username, input.password);
     setSessionCookie(response, result.token, request.secure);
     runWithRequestActor(result.session.user, () => store.audit(null, "user.logged-in", "user", result.session.user.userId));
+    logger.info("auth.login.succeeded", { actorRef: accountReference(result.session.user.userId) });
     data(response, { user: result.session.user, csrfToken: result.session.csrfToken });
   });
   app.use(createUserSessionMiddleware(auth, options.disableUserAuth));
@@ -1068,8 +1080,10 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   }
 
   app.use((_request, _response, next) => next(new AppError(404, "ROUTE_NOT_FOUND", "请求的接口不存在")));
-  app.use((error: unknown, _request: Request, response: Response, _next: NextFunction) => {
+  app.use((error: unknown, request: Request, response: Response, _next: NextFunction) => {
+    const commonFields = { method: request.method, path: sanitizeRequestPath(request.path), error: sanitizeError(error) };
     if (error instanceof ZodError) {
+      logger.warn("http.request.validation_failed", { ...commonFields, issuePaths: error.issues.map((issue) => issue.path.join(".")) });
       response.status(400).json({
         error: {
           code: "VALIDATION_ERROR",
@@ -1080,31 +1094,41 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       return;
     }
     if (error instanceof multer.MulterError) {
+      logger.warn("http.request.upload_rejected", { ...commonFields, uploadCode: error.code });
       response.status(400).json({ error: { code: "UPLOAD_ERROR", message: error.message } });
       return;
     }
     if (error instanceof SyntaxError && "status" in error && error.status === 400) {
+      logger.warn("http.request.invalid_json", commonFields);
       response.status(400).json({ error: { code: "INVALID_JSON", message: "请求体不是有效的 JSON" } });
       return;
     }
     if (error && typeof error === "object" && "type" in error && error.type === "entity.too.large") {
+      logger.warn("http.request.body_too_large", commonFields);
       response.status(413).json({ error: { code: "REQUEST_TOO_LARGE", message: "请求体超过大小限制" } });
       return;
     }
     if (error instanceof AppError) {
+      const logFields = { ...commonFields, errorCode: error.code, status: error.status };
+      if (error.status >= 500) logger.error("http.request.application_error", logFields);
+      else logger.warn("http.request.application_error", logFields);
       response.status(error.status).json({ error: { code: error.code, message: error.message, ...(error.details === undefined ? {} : { details: error.details }) } });
       return;
     }
     if (error instanceof Error && error.message.includes("UNIQUE constraint failed")) {
+      logger.warn("http.request.duplicate_record", commonFields);
       response.status(409).json({ error: { code: "DUPLICATE_RECORD", message: "记录已存在" } });
       return;
     }
-    console.error("Unhandled request error", error);
+    logger.error("http.request.unhandled_error", commonFields);
     response.status(500).json({ error: { code: "INTERNAL_ERROR", message: "服务器内部错误" } });
   });
 
+  logger.info("runtime.ready", { serveUi: options.serveUi ?? true });
   return { app, database, store, ai, auth, close: () => {
+    logger.info("runtime.closing");
     ai.dispose();
     database.close();
+    logger.info("runtime.closed");
   } };
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { logger, sanitizeError } from "./logger.js";
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
@@ -9,17 +10,27 @@ export class Database {
   readonly raw: DatabaseSync;
 
   constructor(filename: string) {
-    if (filename !== ":memory:") mkdirSync(dirname(filename), { recursive: true });
-    this.raw = new DatabaseSync(filename);
-    this.raw.exec("PRAGMA foreign_keys = ON");
-    this.raw.exec("PRAGMA busy_timeout = 5000");
-    if (filename !== ":memory:") this.raw.exec("PRAGMA journal_mode = WAL");
-    this.migrate();
-    this.recoverInterruptedOperations();
+    logger.info("database.opening", { databasePath: filename, inMemory: filename === ":memory:" });
+    try {
+      if (filename !== ":memory:") mkdirSync(dirname(filename), { recursive: true });
+      this.raw = new DatabaseSync(filename);
+      this.raw.exec("PRAGMA foreign_keys = ON");
+      this.raw.exec("PRAGMA busy_timeout = 5000");
+      if (filename !== ":memory:") this.raw.exec("PRAGMA journal_mode = WAL");
+      this.migrate();
+      this.recoverInterruptedOperations();
+      const migration = this.get<{ version: number }>("SELECT MAX(version) AS version FROM schema_migrations");
+      logger.info("database.ready", { inMemory: filename === ":memory:", schemaVersion: Number(migration?.version ?? 0) });
+    } catch (error) {
+      logger.error("database.open_failed", { databasePath: filename, error: sanitizeError(error) });
+      throw error;
+    }
   }
 
   close(): void {
+    logger.info("database.closing");
     this.raw.close();
+    logger.info("database.closed");
   }
 
   run(sql: string, ...params: SQLInputValue[]): { changes: number; lastInsertRowid: number | bigint } {
@@ -37,13 +48,20 @@ export class Database {
 
   transaction<T>(operation: () => T): T {
     if (this.raw.isTransaction) return operation();
+    const startedAt = process.hrtime.bigint();
+    logger.debug("database.transaction.started");
     this.raw.exec("BEGIN IMMEDIATE");
     try {
       const result = operation();
       this.raw.exec("COMMIT");
+      logger.debug("database.transaction.committed", { durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000 });
       return result;
     } catch (error) {
       this.raw.exec("ROLLBACK");
+      logger.warn("database.transaction.rolled_back", {
+        durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000,
+        error: sanitizeError(error)
+      });
       throw error;
     }
   }

--- a/src/http-logging.ts
+++ b/src/http-logging.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+import type { Request, RequestHandler, Response } from "express";
+import { accountReference, logger as defaultLogger, type Logger } from "./logger.js";
+import { runWithRequestContext } from "./request-context.js";
+
+function maskClientAddress(value: string | undefined): string {
+  if (!value) return "unknown";
+  const ipv4 = value.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}$/u);
+  if (ipv4) return `${ipv4[1]}.${ipv4[2]}.${ipv4[3]}.0/24`;
+  if (value.includes(":")) return `${value.split(":").slice(0, 3).join(":")}::/48`;
+  return "unknown";
+}
+
+export function sanitizeRequestPath(path: string): string {
+  const segments = path.split("/");
+  for (let index = 0; index < segments.length; index += 1) {
+    if ((segments[index] === "users" || segments[index] === "user-avatars") && segments[index + 1] && segments[index + 1] !== "directory") {
+      segments[index + 1] = "[REDACTED]";
+    }
+    if (segments[index] === "members" && segments[index + 1]) segments[index + 1] = "[REDACTED]";
+  }
+  return segments.join("/").slice(0, 2_000);
+}
+
+function routePattern(request: Request): string | undefined {
+  const route = request.route as { path?: unknown } | undefined;
+  return typeof route?.path === "string" ? route.path : undefined;
+}
+
+function responseFields(request: Request, response: Response, startedAt: bigint): Record<string, unknown> {
+  const contentLength = response.getHeader("content-length");
+  return {
+    method: request.method,
+    path: sanitizeRequestPath(request.path),
+    ...(routePattern(request) ? { route: routePattern(request) } : {}),
+    status: response.statusCode,
+    durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000,
+    ...(contentLength === undefined ? {} : { responseBytes: Number(contentLength) || String(contentLength) }),
+    ...(request.authMethod ? { authMethod: request.authMethod } : {}),
+    ...(request.authUser ? { actorRef: accountReference(request.authUser.userId) } : {})
+  };
+}
+
+export function createRequestLoggingMiddleware(log: Logger = defaultLogger): RequestHandler {
+  return (request, response, next) => {
+    const requestId = randomUUID();
+    const startedAt = process.hrtime.bigint();
+    let completed = false;
+    response.setHeader("X-Request-Id", requestId);
+    return runWithRequestContext({ requestId, actor: null }, () => {
+      log.info("http.request.started", {
+        method: request.method,
+        path: sanitizeRequestPath(request.path),
+        clientNetwork: maskClientAddress(request.ip || request.socket.remoteAddress),
+        protocol: request.protocol,
+        contentType: request.get("content-type") ?? null,
+        contentLength: request.get("content-length") ?? null,
+        userAgent: request.get("user-agent")?.slice(0, 500) ?? null
+      });
+      response.once("finish", () => {
+        completed = true;
+        const fields = responseFields(request, response, startedAt);
+        if (response.statusCode >= 500) log.error("http.request.completed", fields);
+        else if (response.statusCode >= 400) log.warn("http.request.completed", fields);
+        else log.info("http.request.completed", fields);
+      });
+      response.once("close", () => {
+        if (!completed) log.warn("http.request.aborted", responseFields(request, response, startedAt));
+      });
+      next();
+    });
+  };
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,136 @@
+import { createHash } from "node:crypto";
+import { currentRequestContext } from "./request-context.js";
+
+export type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
+export type LogFields = Record<string, unknown>;
+
+export type LogRecord = {
+  timestamp: string;
+  level: Exclude<LogLevel, "silent">;
+  service: string;
+  event: string;
+  requestId?: string;
+  actorRef?: string;
+  authentication?: "session" | "api-key";
+  [key: string]: unknown;
+};
+
+export type Logger = {
+  debug: (event: string, fields?: LogFields) => void;
+  info: (event: string, fields?: LogFields) => void;
+  warn: (event: string, fields?: LogFields) => void;
+  error: (event: string, fields?: LogFields) => void;
+};
+
+type LoggerOptions = {
+  level?: LogLevel;
+  service?: string;
+  write?: (level: Exclude<LogLevel, "silent">, record: LogRecord) => void;
+  now?: () => Date;
+};
+
+const levelPriority: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 100
+};
+
+const sensitiveField = /^(?:authorization|cookie|setcookie|password|passwordconfirmation|currentpassword|newpassword|secret|mastersecret|token|csrftoken|captchaanswer|apikey|credential|session|sessionid|username|displayname|email|account|userid|encryptedkey|keyiv|keytag)$/iu;
+const sensitiveFieldPart = /(?:password|passwd|secret|authorization|cookie|csrf|captchaanswer|apikey|accesstoken|refreshtoken|sessiontoken|encryptedkey)/iu;
+
+function scrubString(value: string): string {
+  return value
+    .replace(/\b(?:Bearer|Basic)\s+[A-Za-z0-9+/=_\-.]+/giu, (match) => `${match.split(/\s/u)[0]} [REDACTED]`)
+    .replace(/\bscrv_[A-Za-z0-9_-]+\b/gu, "scrv_[REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/gu, "sk-[REDACTED]")
+    .replace(/([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password)=)[^&\s]+/giu, "$1[REDACTED]")
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, "$1[REDACTED]@")
+    .replace(/("(?:password|secret|token|api[_-]?key|authorization)"\s*:\s*")[^"]*(")/giu, "$1[REDACTED]$2");
+}
+
+function sanitizeValue(value: unknown, key = "", depth = 0, seen = new WeakSet<object>()): unknown {
+  const normalizedKey = key.replace(/[^a-z0-9]/giu, "");
+  if (sensitiveField.test(normalizedKey) || sensitiveFieldPart.test(normalizedKey)) return "[REDACTED]";
+  if (value === null || value === undefined || typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "string") return scrubString(value).slice(0, 4_000);
+  if (value instanceof Error) return sanitizeError(value);
+  if (Buffer.isBuffer(value)) return { type: "Buffer", byteLength: value.byteLength };
+  if (depth >= 6) return "[TRUNCATED]";
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[CIRCULAR]";
+  seen.add(value);
+  if (Array.isArray(value)) return value.slice(0, 100).map((item) => sanitizeValue(item, "", depth + 1, seen));
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>).slice(0, 100).map(
+    ([entryKey, entryValue]) => [entryKey, sanitizeValue(entryValue, entryKey, depth + 1, seen)]
+  ));
+}
+
+export function sanitizeLogFields(fields: LogFields): LogFields {
+  return sanitizeValue(fields) as LogFields;
+}
+
+export function sanitizeError(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) return { message: scrubString(String(error)).slice(0, 4_000) };
+  const candidate = error as Error & { code?: unknown; status?: unknown };
+  return {
+    name: error.name,
+    message: scrubString(error.message).slice(0, 4_000),
+    ...(candidate.code === undefined ? {} : { code: sanitizeValue(candidate.code, "code") }),
+    ...(candidate.status === undefined ? {} : { status: sanitizeValue(candidate.status, "status") }),
+    ...(error.stack ? { stack: scrubString(error.stack).slice(0, 12_000) } : {})
+  };
+}
+
+export function accountReference(userId: string): string {
+  return `account:${createHash("sha256").update(userId).digest("hex").slice(0, 12)}`;
+}
+
+export function resolveLogLevel(environment: NodeJS.ProcessEnv = process.env): LogLevel {
+  const configured = environment.LOG_LEVEL?.trim().toLocaleLowerCase();
+  if (configured === "debug" || configured === "info" || configured === "warn" || configured === "error" || configured === "silent") return configured;
+  return environment.NODE_ENV === "test" ? "silent" : "info";
+}
+
+function defaultWrite(_level: Exclude<LogLevel, "silent">, record: LogRecord): void {
+  // 服务和 CLI 共用日志器，统一写入 stderr，避免污染 CLI 的机器可读 stdout。
+  console.error(JSON.stringify(record));
+}
+
+export function createLogger(options: LoggerOptions = {}): Logger {
+  const configuredLevel = options.level ?? resolveLogLevel();
+  const service = options.service ?? "scriverse";
+  const write = options.write ?? defaultWrite;
+  const now = options.now ?? (() => new Date());
+  const emit = (level: Exclude<LogLevel, "silent">, event: string, fields: LogFields = {}): void => {
+    if (levelPriority[level] < levelPriority[configuredLevel]) return;
+    const context = currentRequestContext();
+    const record: LogRecord = {
+      timestamp: now().toISOString(),
+      level,
+      service,
+      ...sanitizeLogFields(fields),
+      event,
+      ...(context?.requestId ? { requestId: context.requestId } : {}),
+      ...(context?.actor ? {
+        actorRef: accountReference(context.actor.userId),
+        ...(context.actor.authentication ? { authentication: context.actor.authentication } : {})
+      } : {})
+    };
+    try {
+      write(level, record);
+    } catch {
+      // 日志输出失败不能中断业务请求。
+    }
+  };
+  return {
+    debug: (event, fields) => emit("debug", event, fields),
+    info: (event, fields) => emit("info", event, fields),
+    warn: (event, fields) => emit("warn", event, fields),
+    error: (event, fields) => emit("error", event, fields)
+  };
+}
+
+export const logger = createLogger();

--- a/src/request-context.ts
+++ b/src/request-context.ts
@@ -8,12 +8,26 @@ export type RequestActor = {
   authentication?: "session" | "api-key";
 };
 
-const actorStorage = new AsyncLocalStorage<RequestActor | null>();
+export type RequestContext = {
+  requestId?: string;
+  actor: RequestActor | null;
+};
+
+const requestStorage = new AsyncLocalStorage<RequestContext | null>();
+
+export function runWithRequestContext<T>(context: RequestContext, operation: () => T): T {
+  return requestStorage.run(context, operation);
+}
 
 export function runWithRequestActor<T>(actor: RequestActor | null, operation: () => T): T {
-  return actorStorage.run(actor, operation);
+  const current = requestStorage.getStore();
+  return requestStorage.run({ ...(current?.requestId ? { requestId: current.requestId } : {}), actor }, operation);
 }
 
 export function currentRequestActor(): RequestActor | null {
-  return actorStorage.getStore() ?? null;
+  return requestStorage.getStore()?.actor ?? null;
+}
+
+export function currentRequestContext(): RequestContext | null {
+  return requestStorage.getStore() ?? null;
 }

--- a/src/security.ts
+++ b/src/security.ts
@@ -3,6 +3,7 @@ import { isIP } from "node:net";
 import { lookup } from "node:dns/promises";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { AppError } from "./errors.js";
+import { logger } from "./logger.js";
 
 export type BasicAuthOptions = {
   username: string;
@@ -75,14 +76,17 @@ export function createBasicAuthMiddleware(options: BasicAuthOptions): RequestHan
       && constantTimeEqual(credentials.password, options.password);
     if (valid) {
       failures.delete(key);
+      logger.debug("security.deployment_auth.succeeded");
       return next();
     }
     const rate = consumeRate(failures, key, failureLimit, failureWindowMs);
     if (!rate.allowed) {
+      logger.warn("security.request.blocked", { control: "deployment_auth_rate_limit", retryAfterSeconds: rate.retryAfter });
       response.setHeader("Retry-After", String(rate.retryAfter));
       response.status(429).json({ error: { code: "AUTH_RATE_LIMITED", message: "身份验证失败次数过多，请稍后重试" } });
       return;
     }
+    logger.warn("security.request.blocked", { control: "deployment_auth", reason: credentials ? "invalid_credentials" : "missing_credentials" });
     unauthorized(response, realm);
   };
 }
@@ -108,6 +112,7 @@ export function createSameOriginMiddleware(): RequestHandler {
   return (request, response, next) => {
     if (["GET", "HEAD", "OPTIONS"].includes(request.method)) return next();
     if (request.get("sec-fetch-site") === "cross-site") {
+      logger.warn("security.request.blocked", { control: "same_origin", reason: "cross_site_fetch" });
       response.status(403).json({ error: { code: "CROSS_ORIGIN_WRITE_BLOCKED", message: "已拒绝跨站写请求" } });
       return;
     }
@@ -118,10 +123,12 @@ export function createSameOriginMiddleware(): RequestHandler {
     try {
       expectedOrigin = new URL(`${request.protocol}://${host}`).origin;
     } catch {
+      logger.warn("security.request.blocked", { control: "same_origin", reason: "invalid_host" });
       response.status(400).json({ error: { code: "INVALID_HOST", message: "请求主机信息无效" } });
       return;
     }
     if (origin !== expectedOrigin) {
+      logger.warn("security.request.blocked", { control: "same_origin", reason: "origin_mismatch" });
       response.status(403).json({ error: { code: "CROSS_ORIGIN_WRITE_BLOCKED", message: "已拒绝跨站写请求" } });
       return;
     }
@@ -135,6 +142,7 @@ export function createApiRateLimitMiddleware(limit = 600, windowMs = 60_000): Re
     if (!request.path.startsWith("/api/") || request.path === "/api/health") return next();
     const rate = consumeRate(entries, requestKey(request), limit, windowMs);
     if (rate.allowed) return next();
+    logger.warn("security.request.blocked", { control: "api_rate_limit", retryAfterSeconds: rate.retryAfter });
     response.setHeader("Retry-After", String(rate.retryAfter));
     response.status(429).json({ error: { code: "API_RATE_LIMITED", message: "请求过于频繁，请稍后重试" } });
   };
@@ -147,6 +155,7 @@ export function createAuthenticationRateLimitMiddleware(limit = 20, windowMs = 1
     if (!authenticationWrite) return next();
     const rate = consumeRate(entries, `${requestKey(request)}:${request.path}`, limit, windowMs);
     if (rate.allowed) return next();
+    logger.warn("security.request.blocked", { control: "authentication_rate_limit", retryAfterSeconds: rate.retryAfter });
     response.setHeader("Retry-After", String(rate.retryAfter));
     response.status(429).json({ error: { code: "AUTH_RATE_LIMITED", message: "登录或注册尝试过于频繁，请稍后重试" } });
   };
@@ -185,6 +194,7 @@ export async function assertSafeAiEndpoint(value: string, allowPrivateNetwork = 
   for (const { address } of addresses) {
     const kind = unsafeIpKind(address);
     if (kind === "blocked" || (kind === "private" && !allowPrivateNetwork)) {
+      logger.warn("security.ai_endpoint.blocked", { hostname: endpoint.hostname, addressKind: kind });
       throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商地址指向受保护的本机、内网或链路本地网络");
     }
   }
@@ -206,8 +216,10 @@ export async function fetchSafeAiEndpoint(
   let currentUrl = url;
   const baseHeaders = new Headers(init.headers);
   for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    logger.debug("ai.outbound_request.validating", { hostname: new URL(currentUrl).hostname, hop });
     await validateOutboundUrl?.(currentUrl);
     const response = await fetchImpl(currentUrl, { ...init, headers: baseHeaders, redirect: "manual" });
+    logger.debug("ai.outbound_request.response", { hostname: new URL(currentUrl).hostname, hop, status: response.status });
     if (!redirectStatuses.has(response.status)) return response;
     const location = response.headers.get("location");
     if (!location) {

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { createRuntime, type Runtime } from "./app.js";
 import { loadMasterSecret } from "./credential-vault.js";
 import { resolveRuntimeSecurity, type RuntimeSecurityOptions } from "./security.js";
+import { logger, sanitizeError } from "./logger.js";
 
 export type LocalServerOptions = {
   host: string;
@@ -28,17 +29,26 @@ export type RunningLocalServer = {
 const publicPath = fileURLToPath(new URL("./public/", import.meta.url));
 
 export async function startLocalServer(options: LocalServerOptions): Promise<RunningLocalServer> {
-  const security = resolveRuntimeSecurity(options.env);
-  const runtime = createRuntime({
-    databasePath: options.databasePath,
-    masterSecret: loadMasterSecret(join(options.dataDirectory, "master.key"), options.env.AI_NOVEL_MASTER_KEY),
-    publicPath,
-    security
-  });
+  logger.info("server.starting", { host: options.host, port: options.port, dataDirectory: options.dataDirectory, databasePath: options.databasePath });
+  let security: RuntimeSecurityOptions;
+  let runtime: Runtime;
+  try {
+    security = resolveRuntimeSecurity(options.env);
+    runtime = createRuntime({
+      databasePath: options.databasePath,
+      masterSecret: loadMasterSecret(join(options.dataDirectory, "master.key"), options.env.AI_NOVEL_MASTER_KEY),
+      publicPath,
+      security
+    });
+  } catch (error) {
+    logger.error("server.initialization_failed", { host: options.host, port: options.port, error: sanitizeError(error) });
+    throw error;
+  }
 
   return await new Promise<RunningLocalServer>((resolveStart, rejectStart) => {
     const server = runtime.app.listen(options.port, options.host);
     const handleStartupError = (error: Error): void => {
+      logger.error("server.start_failed", { host: options.host, port: options.port, error: sanitizeError(error) });
       runtime.close();
       rejectStart(error);
     };
@@ -58,6 +68,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
       const close = async (): Promise<void> => {
         if (closed) return;
         closed = true;
+        logger.info("server.stopping", { host: options.host, port });
         server.closeAllConnections();
         try {
           await new Promise<void>((resolveClose, rejectClose) => {
@@ -65,6 +76,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
           });
         } finally {
           runtime.close();
+          logger.info("server.stopped", { host: options.host, port });
         }
       };
       resolveStart({
@@ -87,11 +99,11 @@ export function installServerShutdownHandlers(running: RunningLocalServer): void
   const shutdown = (signal: string): void => {
     if (shuttingDown) return;
     shuttingDown = true;
-    console.log(`Received ${signal}, shutting down`);
+    logger.info("server.shutdown_signal_received", { signal });
     void running.close().then(
       () => { process.exitCode = 0; },
       (error: unknown) => {
-        console.error(error instanceof Error ? error.message : "Failed to stop Scriverse server");
+        logger.error("server.stop_failed", { signal, error: sanitizeError(error) });
         process.exitCode = 1;
       }
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,13 @@
 import { join } from "node:path";
 import { installServerShutdownHandlers, startLocalServer } from "./server-runtime.js";
+import { logger, resolveLogLevel } from "./logger.js";
 
 const port = Number(process.env.PORT ?? 13210);
 const host = process.env.HOST ?? "127.0.0.1";
 const dataDirectory = process.env.DATA_DIR ?? join(process.cwd(), ".data");
+process.on("uncaughtExceptionMonitor", (error, origin) => {
+  logger.error("process.uncaught_exception", { origin, error });
+});
 const running = await startLocalServer({
   port,
   host,
@@ -12,5 +16,12 @@ const running = await startLocalServer({
   env: process.env
 });
 
-console.log(`Scriverse listening on ${running.url} (user authentication enabled${running.security.auth ? ", deployment gateway enabled" : ""})`);
+logger.info("server.listening", {
+  url: running.url,
+  host: running.host,
+  port: running.port,
+  logLevel: resolveLogLevel(process.env),
+  userAuthenticationEnabled: true,
+  deploymentGatewayEnabled: Boolean(running.security.auth)
+});
 installServerShutdownHandlers(running);

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { Database, PLATFORM_AI_WORK_ID, type Row } from "./database.js";
 import { AppError, notFound } from "./errors.js";
 import { currentRequestActor } from "./request-context.js";
+import { accountReference, logger } from "./logger.js";
 import { countWords, id, json, normalizeParagraphSpacing, now } from "./utils.js";
 
 type WorkInput = {
@@ -461,6 +462,14 @@ export class Store {
       now(),
       actor?.userId ?? null
     );
+    const detailKeys = detail && typeof detail === "object" && !Array.isArray(detail) ? Object.keys(detail as Record<string, unknown>) : [];
+    logger.info("domain.change.recorded", {
+      action,
+      workId,
+      entityType,
+      entityId: entityType === "user" && entityId ? accountReference(entityId) : entityId,
+      detailKeys
+    });
   }
 
   createWork(input: WorkInput): Record<string, unknown> {

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -2,6 +2,8 @@ import { createHash, randomBytes, randomUUID, scryptSync, timingSafeEqual } from
 import type { Request, RequestHandler, Response } from "express";
 import { Database, PLATFORM_AI_WORK_ID, type Row } from "./database.js";
 import { AppError, notFound } from "./errors.js";
+import { sanitizeRequestPath } from "./http-logging.js";
+import { accountReference, logger } from "./logger.js";
 import { runWithRequestActor, type RequestActor } from "./request-context.js";
 
 export type AuthUser = RequestActor & {
@@ -250,9 +252,15 @@ export class UserAuthService {
     const fallbackSalt = "invalid-login-salt";
     const calculated = passwordDigest(password, String(row?.password_salt ?? fallbackSalt));
     const valid = row && safeEqual(calculated, String(row.password_hash));
-    if (!valid) throw new AppError(401, "INVALID_CREDENTIALS", "用户名或密码不正确");
+    if (!valid) {
+      logger.warn("auth.login.failed", { reason: "invalid_credentials" });
+      throw new AppError(401, "INVALID_CREDENTIALS", "用户名或密码不正确");
+    }
     const user = mapUser(row);
-    if (user.status !== "active") throw new AppError(403, "ACCOUNT_DISABLED", "该账户已被停用");
+    if (user.status !== "active") {
+      logger.warn("auth.login.failed", { reason: "account_disabled", actorRef: accountReference(user.userId) });
+      throw new AppError(403, "ACCOUNT_DISABLED", "该账户已被停用");
+    }
     this.database.run("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?", new Date().toISOString(), new Date().toISOString(), user.userId);
     return this.createSession(user.userId);
   }
@@ -513,6 +521,7 @@ export function createUserSessionMiddleware(auth: UserAuthService, disabled = fa
     if (disabled) return runWithRequestActor(null, next);
     const apiKey = auth.authenticateApiKey(request);
     if (auth.hasApiKeyCredential(request) && !apiKey) {
+      logger.warn("auth.request.rejected", { reason: "invalid_api_key", method: request.method, path: sanitizeRequestPath(request.path) });
       response.status(401).json({ error: { code: "API_KEY_INVALID", message: "API Key 无效或已失效" } });
       return;
     }
@@ -532,18 +541,23 @@ export function createUserSessionMiddleware(auth: UserAuthService, disabled = fa
       || (request.path === "/api/auth/login" && request.method === "POST")
       || !request.path.startsWith("/api/");
     if (!session && !apiKey && !isPublic) {
+      logger.warn("auth.request.rejected", { reason: "authentication_required", method: request.method, path: sanitizeRequestPath(request.path) });
       response.status(401).json({ error: { code: "AUTH_REQUIRED", message: "请先登录" } });
       return;
     }
     if (session && !["GET", "HEAD", "OPTIONS"].includes(request.method) && request.path !== "/api/auth/login" && request.path !== "/api/auth/register") {
       const csrf = request.get("x-csrf-token") ?? "";
       if (!safeEqual(csrf, session.csrfToken)) {
+        logger.warn("auth.request.rejected", { reason: "invalid_csrf", method: request.method, path: sanitizeRequestPath(request.path), actorRef: accountReference(session.user.userId) });
         response.status(403).json({ error: { code: "CSRF_TOKEN_INVALID", message: "请求校验失败，请刷新页面后重试" } });
         return;
       }
     }
     const user = apiKey?.user ?? session?.user ?? null;
-    return runWithRequestActor(user ? { ...user, authentication: apiKey ? "api-key" : "session" } : null, next);
+    return runWithRequestActor(user ? { ...user, authentication: apiKey ? "api-key" : "session" } : null, () => {
+      if (user) logger.debug("auth.request.authenticated", { authMethod: apiKey ? "api-key" : "session" });
+      next();
+    });
   };
 }
 
@@ -569,6 +583,7 @@ export function createCliApiScopeMiddleware(disabled = false): RequestHandler {
   return (request, response, next) => {
     if (disabled || request.authMethod !== "api-key") return next();
     if (cliApiRules.some((rule) => rule.methods.includes(request.method) && rule.path.test(request.path))) return next();
+    logger.warn("auth.request.rejected", { reason: "cli_scope_denied", method: request.method, path: sanitizeRequestPath(request.path) });
     response.status(403).json({ error: { code: "CLI_SCOPE_DENIED", message: "API Key 不能访问用户管理、系统管理或未开放给 CLI 的接口" } });
   };
 }

--- a/tests/e2e/real-cli.ts
+++ b/tests/e2e/real-cli.ts
@@ -179,7 +179,7 @@ function restoreResource(type: Exclude<CliResourceType, "volume">, id: string, v
 async function startServer(): Promise<void> {
   server = spawn(tsxPath, [fixturePath], {
     cwd: process.cwd(),
-    env: { ...process.env, CLI_E2E_DATABASE_PATH: databasePath },
+    env: { ...process.env, NODE_ENV: "test", CLI_E2E_DATABASE_PATH: databasePath },
     stdio: ["pipe", "pipe", "pipe"]
   });
   server.stderr.on("data", (chunk: Buffer) => {

--- a/tests/integration/http-logging.test.ts
+++ b/tests/integration/http-logging.test.ts
@@ -1,0 +1,63 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createRequestLoggingMiddleware } from "../../src/http-logging.js";
+import { accountReference, createLogger, type LogRecord } from "../../src/logger.js";
+
+describe("HTTP 请求日志", () => {
+  it("记录请求进入和完成状态，同时隐藏账户路径、查询令牌和认证头", async () => {
+    const records: LogRecord[] = [];
+    const log = createLogger({ level: "info", write: (_level, record) => records.push(record) });
+    const app = express();
+    app.use(createRequestLoggingMiddleware(log));
+    app.get("/api/users/:userId", (incoming, response) => {
+      incoming.authMethod = "session";
+      incoming.authUser = {
+        userId: "private-authenticated-user-id",
+        username: "private-authenticated-username",
+        displayName: "private-authenticated-name",
+        role: "user",
+        status: "active",
+        createdAt: "2026-07-19T00:00:00.000Z",
+        avatarUrl: null
+      };
+      response.status(200).json({ data: { ok: true } });
+    });
+
+    const response = await request(app)
+      .get("/api/users/private-account-id?token=private-query-token")
+      .set("Authorization", "Bearer private-bearer-token")
+      .set("Cookie", "scriverse_session=private-session-token");
+
+    expect(response.headers["x-request-id"]).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(records.map((record) => record.event)).toEqual(["http.request.started", "http.request.completed"]);
+    expect(records[0]?.requestId).toBe(response.headers["x-request-id"]);
+    expect(records[1]?.requestId).toBe(response.headers["x-request-id"]);
+    expect(records[0]).toMatchObject({ method: "GET", path: "/api/users/[REDACTED]" });
+    expect(records[1]).toMatchObject({
+      method: "GET",
+      route: "/api/users/:userId",
+      status: 200,
+      authMethod: "session",
+      actorRef: accountReference("private-authenticated-user-id")
+    });
+
+    const serialized = JSON.stringify(records);
+    for (const secret of ["private-account-id", "private-query-token", "private-bearer-token", "private-session-token", "private-authenticated-user-id", "private-authenticated-username", "private-authenticated-name"]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it("隐藏作品成员路由中的账户 ID", async () => {
+    const records: LogRecord[] = [];
+    const log = createLogger({ level: "info", write: (_level, record) => records.push(record) });
+    const app = express();
+    app.use(createRequestLoggingMiddleware(log));
+    app.delete("/api/works/:workId/members/:userId", (_request, response) => response.status(204).end());
+
+    await request(app).delete("/api/works/work-1/members/private-member-id").expect(204);
+
+    expect(records[0]).toMatchObject({ path: "/api/works/work-1/members/[REDACTED]" });
+    expect(JSON.stringify(records)).not.toContain("private-member-id");
+  });
+});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { aiErrorForLog } from "../../src/ai.js";
+import { accountReference, createLogger, type LogRecord, sanitizeError } from "../../src/logger.js";
+import { runWithRequestContext } from "../../src/request-context.js";
+
+describe("结构化日志", () => {
+  it("递归脱敏凭据、账户字段和错误消息中的令牌", () => {
+    const records: LogRecord[] = [];
+    const log = createLogger({
+      level: "debug",
+      now: () => new Date("2026-07-19T00:00:00.000Z"),
+      write: (_level, record) => records.push(record)
+    });
+    const error = new Error("request failed with Bearer bearer-secret and sk-provider-secret");
+
+    log.error("security.redaction.test", {
+      username: "private-account",
+      password: "private-password",
+      csrfToken: "private-csrf",
+      apiKey: "private-api-key",
+      user_id: "private-user-id",
+      nested: { access_token: "private-access-token" },
+      message: "Authorization: Bearer bearer-secret; url=https://user:pass@example.com?token=query-secret",
+      error: sanitizeError(error)
+    });
+
+    const serialized = JSON.stringify(records[0]);
+    for (const secret of ["private-account", "private-password", "private-csrf", "private-api-key", "private-user-id", "private-access-token", "bearer-secret", "provider-secret", "query-secret", "user:pass"]) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(serialized).toContain("[REDACTED]");
+  });
+
+  it("使用请求 ID 和不可逆账户引用关联同一请求内的日志", () => {
+    const records: LogRecord[] = [];
+    const log = createLogger({ level: "info", write: (_level, record) => records.push(record) });
+
+    runWithRequestContext({
+      requestId: "request-123",
+      actor: {
+        userId: "private-user-id",
+        username: "private-username",
+        displayName: "private-display-name",
+        role: "user",
+        authentication: "session"
+      }
+    }, () => log.info("domain.test"));
+
+    expect(records[0]).toMatchObject({
+      event: "domain.test",
+      requestId: "request-123",
+      actorRef: accountReference("private-user-id"),
+      authentication: "session"
+    });
+    expect(JSON.stringify(records[0])).not.toContain("private-user-id");
+    expect(JSON.stringify(records[0])).not.toContain("private-username");
+    expect(JSON.stringify(records[0])).not.toContain("private-display-name");
+  });
+
+  it("不会把供应商错误响应正文写入日志字段", () => {
+    const fields = aiErrorForLog(new Error("HTTP 401: account private-account-id is not allowed"));
+
+    expect(fields).toEqual({ name: "Error", message: "Provider returned HTTP 401" });
+    expect(JSON.stringify(fields)).not.toContain("private-account-id");
+  });
+});


### PR DESCRIPTION
## What changed

- Added a centralized single-line JSON logger with configurable log levels and recursive sensitive-field redaction.
- Added inbound HTTP request start/completion/abort logs with server-generated request IDs, latency, status, response size, masked client networks, and redacted account paths.
- Added lifecycle and failure logs across server startup/shutdown, database transactions, authentication, security controls, domain writes, AI provider calls, retries, queues, tools, and analysis tasks.
- Added Docker `LOG_LEVEL=info` default and kept detailed transaction/queue diagnostics available through `LOG_LEVEL=debug`.
- Added unit and integration coverage for token, cookie, credential, account, provider-response, and route redaction.
- Show registration-disabled deployments as a visible, non-interactive `注册已禁用` tab while preserving the first-admin setup flow.

## Why

The Docker deployment previously emitted only a few startup/shutdown and unhandled-error messages. Requests and critical internal operations could not be correlated, making production diagnosis unreliable. When open registration is disabled, the login page should also communicate that state clearly without suggesting that registration is available.

## Impact

Docker logs now provide enough structured metadata to trace requests and failures without logging request bodies, prompts, manuscript content, model responses, passwords, cookies, authorization headers, CSRF tokens, API keys, or raw account identifiers. CLI machine-readable stdout remains unaffected because runtime logs are written to stderr. Existing users retain a normal login flow, while disabled registration is both enforced by the backend and reflected by an inaccessible UI state.

## Validation

- `npm run typecheck`
- `npm test` (219 tests passed)
- `npm run build`
- `npm run test:e2e:cli`
- Docker image build and isolated container health smoke test
- Sensitive Header, Cookie, query-token, account-route, and provider-error redaction checks
- Real browser verification for disabled-registration and first-admin setup states, with no console errors