### PR TITLE
build(release): bump version to 0.3.1

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -203,7 +203,7 @@ Expected response:
 {
   "data": {
     "status": "ok",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "protocol": "openai-chat-completions"
   }
 }

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ curl http://127.0.0.1:13210/api/health
 {
   "data": {
     "status": "ok",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "protocol": "openai-chat-completions"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/app.ts
+++ b/src/app.ts
@@ -385,7 +385,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   app.use(createSecurityHeadersMiddleware());
 
   app.get("/api/health", (_request, response) => {
-    data(response, { status: "ok", version: "0.3.0", protocol: "openai-chat-completions" });
+    data(response, { status: "ok", version: "0.3.1", protocol: "openai-chat-completions" });
   });
 
   if (options.security?.auth) app.use(createBasicAuthMiddleware(options.security.auth));


### PR DESCRIPTION
## What changed

- bump the package version from `0.3.0` to `0.3.1`
- update the root lockfile package metadata
- report `0.3.1` from the health endpoint
- update the Chinese and English health response examples

## Why

Prepare the next patch release after the latest features and fixes were integrated into `develop`.

## Validation

- `npm run check`
- 45 test files passed, 225 tests passed
- TypeScript typecheck passed
- production build passed