### PR TITLE
fix(onboarding): persist first-use completion per user

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -437,6 +437,13 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     clearSessionCookie(response, request.secure);
     noContent(response);
   });
+  app.post("/api/auth/onboarding/complete", (request, response) => {
+    if (!request.authUser || request.authMethod !== "session") throw new AppError(401, "SESSION_REQUIRED", "请使用网页会话完成新手引导");
+    parse(z.object({}).strict(), request.body ?? {});
+    const updated = auth.completeOnboarding(request.authUser.userId);
+    store.audit(null, "user.onboarding-completed", "user", updated.userId);
+    data(response, updated);
+  });
   app.patch("/api/auth/profile", (request, response) => {
     if (!request.authUser) throw new AppError(401, "AUTH_REQUIRED", "请先登录");
     const updated = auth.updateProfile(request.authUser.userId, parse(profileSchema, request.body).displayName);

--- a/src/database.ts
+++ b/src/database.ts
@@ -1240,6 +1240,15 @@ export class Database {
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (28, ?)", new Date().toISOString());
       });
     }
+    if (!applied.has(29)) {
+      this.transaction(() => {
+        const userColumns = new Set(this.all("PRAGMA table_info(users)").map((row) => String(row.name)));
+        if (!userColumns.has("onboarding_completed_at")) {
+          this.run("ALTER TABLE users ADD COLUMN onboarding_completed_at TEXT");
+        }
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (29, ?)", new Date().toISOString());
+      });
+    }
   }
 
   private normalizeCharacterName(value: string): string {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -136,7 +136,6 @@ function renderProfileAvatar() {
   $("#avatar-remove-button").classList.toggle("hidden", !state.user?.avatarUrl);
 }
 const platformDocumentTitle = "叙界 · 小说 AI 创作工作台";
-const onboardingStoragePrefix = "scriverse-onboarding-v2";
 const panelLayoutStorageKey = "ai-novel-panel-layout-v1";
 const panelLayoutDefaults = Object.freeze({ leftWidth: 280, aiWidth: 360, leftCollapsed: false, aiCollapsed: false });
 let restoringPageRoute = true;
@@ -180,18 +179,16 @@ const workspaceOnboardingSteps = [
   { selector: "#account-button", eyebrow: "账户", title: "管理账户并重看导览", description: "账户菜单保存个人设置入口，也可以随时重新打开这套功能导览。", placement: "bottom" }
 ];
 
-function onboardingStorageKey() {
-  return `${onboardingStoragePrefix}:${state.user?.userId ?? "anonymous"}`;
-}
-
 function hasCompletedOnboarding() {
-  try { return localStorage.getItem(onboardingStorageKey()) === "completed"; }
-  catch { return false; }
+  return state.user?.onboardingCompleted === true;
 }
 
 function persistOnboardingCompletion() {
-  try { localStorage.setItem(onboardingStorageKey(), "completed"); }
-  catch { /* 浏览器禁用存储时仅在当前页面关闭导览 */ }
+  if (!state.user || state.user.onboardingCompleted) return;
+  state.user = { ...state.user, onboardingCompleted: true };
+  api("/api/auth/onboarding/complete", { method: "POST", body: {} })
+    .then((user) => { state.user = user; })
+    .catch(() => { state.user = { ...state.user, onboardingCompleted: false }; });
 }
 
 function isOnboardingTargetVisible(target) {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -542,6 +542,6 @@
       </section>
     </dialog>
 
-    <script type="module" src="/app.js?v=20260719-ai-grep-lazy-viewer-toast"></script>
+    <script type="module" src="/app.js?v=20260719-ai-grep-lazy-viewer-toast-onboarding-db"></script>
   </body>
 </html>

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -10,6 +10,7 @@ export type AuthUser = RequestActor & {
   status: "active" | "disabled";
   createdAt: string;
   avatarUrl: string | null;
+  onboardingCompleted: boolean;
 };
 
 export type UserAvatar = {
@@ -106,7 +107,8 @@ function mapUser(row: Row): AuthUser {
     createdAt: String(row.created_at),
     avatarUrl: avatarSha256
       ? `/api/user-avatars/${encodeURIComponent(String(row.id))}?v=${encodeURIComponent(avatarSha256)}`
-      : null
+      : null,
+    onboardingCompleted: row.onboarding_completed_at !== null && row.onboarding_completed_at !== undefined
   };
 }
 
@@ -382,6 +384,18 @@ export class UserAuthService {
 
   updateProfile(userId: string, displayName: string): AuthUser {
     this.database.run("UPDATE users SET display_name = ?, updated_at = ? WHERE id = ?", displayName.trim(), new Date().toISOString(), userId);
+    return this.getUser(userId);
+  }
+
+  completeOnboarding(userId: string): AuthUser {
+    this.getUser(userId);
+    const timestamp = new Date().toISOString();
+    this.database.run(
+      "UPDATE users SET onboarding_completed_at = COALESCE(onboarding_completed_at, ?), updated_at = ? WHERE id = ?",
+      timestamp,
+      timestamp,
+      userId
+    );
     return this.getUser(userId);
   }
 

--- a/tests/integration/http-logging.test.ts
+++ b/tests/integration/http-logging.test.ts
@@ -19,7 +19,8 @@ describe("HTTP 请求日志", () => {
         role: "user",
         status: "active",
         createdAt: "2026-07-19T00:00:00.000Z",
-        avatarUrl: null
+        avatarUrl: null,
+        onboardingCompleted: false
       };
       response.status(200).json({ data: { ok: true } });
     });

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -90,6 +90,30 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
   });
 
+  it("按用户在数据库中记录新手引导完成状态", async () => {
+    const firstUser = await register(runtime, "onboarding_first");
+    const secondUser = await register(runtime, "onboarding_second");
+    expect(firstUser.user).toMatchObject({ onboardingCompleted: false });
+    expect(secondUser.user).toMatchObject({ onboardingCompleted: false });
+
+    await firstUser.agent.post("/api/auth/onboarding/complete").send({}).expect(403);
+    const completed = await firstUser.agent
+      .post("/api/auth/onboarding/complete")
+      .set("X-CSRF-Token", firstUser.csrfToken)
+      .send({})
+      .expect(200);
+    expect(completed.body.data).toMatchObject({ userId: firstUser.user.userId, onboardingCompleted: true });
+    expect(runtime.database.get(
+      "SELECT onboarding_completed_at IS NOT NULL AS completed FROM users WHERE id = ?",
+      firstUser.user.userId
+    )).toEqual({ completed: 1 });
+
+    const session = await firstUser.agent.get("/api/auth/session").expect(200);
+    expect(session.body.data.user.onboardingCompleted).toBe(true);
+    const otherSession = await secondUser.agent.get("/api/auth/session").expect(200);
+    expect(otherSession.body.data.user.onboardingCompleted).toBe(false);
+  });
+
   it("仅查看成员可读取正文和设定，但所有作品写操作都会被拒绝", async () => {
     const owner = await register(runtime, "viewer_owner");
     const viewer = await register(runtime, "readonly_guest");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -158,14 +158,13 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('id="onboarding-spotlight"');
     expect(page.text).toContain('id="onboarding-popover"');
     expect(page.text).not.toContain("data-onboarding-step");
-    expect(application.text).toContain('const onboardingStoragePrefix = "scriverse-onboarding-v2"');
     expect(application.text).toContain("const shelfOnboardingSteps = [");
     expect(application.text).toContain("const workspaceOnboardingSteps = [");
     expect(application.text).toContain("function positionOnboardingElements()");
     expect(application.text).toContain('selector: "#new-chapter-button"');
     expect(application.text).toContain('selector: ".quick-actions button[data-task=\\"continue\\"]"');
     expect(application.text).toContain("function scheduleFirstUseOnboarding()");
-    expect(application.text).toContain('localStorage.setItem(onboardingStorageKey(), "completed")');
+    expect(application.text).toContain('api("/api/auth/onboarding/complete", { method: "POST", body: {} })');
     expect(application.text).toContain('addEventListener("cancel"');
     expect(application.text).toContain('event.key === "Escape"');
     expect(styles.text).toContain(".onboarding-dialog {");

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -64,7 +64,7 @@ describe("数据库版本化迁移", () => {
       { display_name: "Mothra", kind: "alias" },
       { display_name: "拉顿", kind: "primary" }
     ]);
-    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }, { version: 4 }, { version: 5 }, { version: 6 }, { version: 7 }, { version: 8 }, { version: 9 }, { version: 10 }, { version: 11 }, { version: 12 }, { version: 13 }, { version: 14 }, { version: 15 }, { version: 16 }, { version: 17 }, { version: 18 }, { version: 19 }, { version: 20 }, { version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }, { version: 26 }, { version: 27 }, { version: 28 }]);
+    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }, { version: 4 }, { version: 5 }, { version: 6 }, { version: 7 }, { version: 8 }, { version: 9 }, { version: 10 }, { version: 11 }, { version: 12 }, { version: 13 }, { version: 14 }, { version: 15 }, { version: 16 }, { version: 17 }, { version: 18 }, { version: 19 }, { version: 20 }, { version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }, { version: 26 }, { version: 27 }, { version: 28 }, { version: 29 }]);
     expect(first.all("PRAGMA table_info(works)").some((column) => column.name === "owner_user_id")).toBe(true);
     expect(first.all("PRAGMA table_info(chapter_versions)").some((column) => column.name === "created_by_user_id")).toBe(true);
     expect(first.all("PRAGMA table_info(chapter_versions)").some((column) => column.name === "work_id")).toBe(true);
@@ -112,7 +112,7 @@ describe("数据库版本化迁移", () => {
     expect(first.all("PRAGMA table_info(user_api_keys)").map((column) => column.name)).toEqual(
       expect.arrayContaining(["user_id", "key_hash", "key_prefix", "created_at", "rotated_at", "last_used_at"])
     );
-    expect(first.all("PRAGMA table_info(users)").map((column) => column.name)).toEqual(expect.arrayContaining(["avatar_updated_at", "avatar_sha256"]));
+    expect(first.all("PRAGMA table_info(users)").map((column) => column.name)).toEqual(expect.arrayContaining(["avatar_updated_at", "avatar_sha256", "onboarding_completed_at"]));
     expect(first.all("PRAGMA table_info(user_avatars)").map((column) => column.name)).toEqual(
       expect.arrayContaining(["user_id", "mime_type", "content", "byte_length", "sha256", "width", "height", "updated_at"])
     );


### PR DESCRIPTION
## 变更内容

- 新增数据库迁移，按用户记录新手引导完成时间。
- 新增带会话与 CSRF 校验的完成接口。
- 前端自动引导改为读取并写入服务端状态，保留手动重看入口。
- 增加跨用户隔离、CSRF 和数据库迁移回归测试。

## 根因

此前完成状态仅保存在浏览器 localStorage，换设备、清理存储或浏览器禁用存储时会再次显示。

## 验证

- npm run typecheck
- npm test
- npm run build