### PR TITLE
build(release): bump version to 0.3.2

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -203,7 +203,7 @@ Expected response:
 {
   "data": {
     "status": "ok",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "protocol": "openai-chat-completions"
   }
 }

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ curl http://127.0.0.1:13210/api/health
 {
   "data": {
     "status": "ok",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "protocol": "openai-chat-completions"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/app.ts
+++ b/src/app.ts
@@ -385,7 +385,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   app.use(createSecurityHeadersMiddleware());
 
   app.get("/api/health", (_request, response) => {
-    data(response, { status: "ok", version: "0.3.1", protocol: "openai-chat-completions" });
+    data(response, { status: "ok", version: "0.3.2", protocol: "openai-chat-completions" });
   });
 
   if (options.security?.auth) app.use(createBasicAuthMiddleware(options.security.auth));


### PR DESCRIPTION
## What changed

- Bump the package version from `0.3.1` to `0.3.2`.
- Keep the lockfile, health endpoint, and Chinese/English README examples in sync.

## Why

Prepare the next patch release after the latest fixes landed on `develop`.

## Impact

The application and published package report version `0.3.2`. No data migration or configuration change is required.

## Validation

- `npm run typecheck`
- `npm test` (227 tests passed)
- `npm run build`
- Isolated production health check returned version `0.3.2`
- `git diff --check`