### PR TITLE
build(release): bump version to 0.3.3

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -203,7 +203,7 @@ Expected response:
 {
   "data": {
     "status": "ok",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "protocol": "openai-chat-completions"
   }
 }

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ curl http://127.0.0.1:13210/api/health
 {
   "data": {
     "status": "ok",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "protocol": "openai-chat-completions"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.2";
+export const APP_VERSION = "0.3.3";


### PR DESCRIPTION
## What changed

- Bump the package version from `0.3.2` to `0.3.3`.
- Keep the package lock, shared application version, startup log, health endpoint, and Chinese/English README examples in sync.

## Why

Prepare the next patch release after the explicit registration opt-in fix, startup version logging, and release workflow documentation landed on `develop`.

## Impact

The application, npm package, startup log, and health endpoint report version `0.3.3`. No database migration is required.

## Validation

- `npm run typecheck`
- `npm test` (229 tests passed)
- `npm run build`
- Isolated production startup log reported `version: "0.3.3"`
- Isolated `/api/health` returned version `0.3.3`
- `git diff --check`
