### PR TITLE
fix(works): omit chapter content from import responses

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -861,7 +861,7 @@ export class Store {
       return {
         fileVersionId: restorePointId,
         restoredFrom: fileVersionId,
-        tree: this.getWorkTree(workId)
+        tree: this.getWorkDirectory(workId)
       };
     });
   }
@@ -870,7 +870,7 @@ export class Store {
     this.getWork(workId);
     let result: Record<string, unknown> = {};
     this.db.transaction(() => { result = this.importNovelInTransaction(workId, fileName, fileType, parsed); });
-    return result;
+    return { ...result, tree: this.getWorkDirectory(workId) };
   }
 
   createImportedWork(input: WorkInput, fileName: string, fileType: string, parsed: ParsedNovel): Record<string, unknown> {
@@ -928,8 +928,7 @@ export class Store {
       fileVersionId,
       warnings: parsed.warnings,
       wordCount: parsed.wordCount,
-      paragraphCount: parsed.paragraphCount,
-      tree: this.getWorkTree(workId)
+      paragraphCount: parsed.paragraphCount
     };
   }
 

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -242,6 +242,8 @@ describe("书架、别名、大纲伏笔和一致性守卫 API", () => {
       .expect(201);
     const workId = imported.body.data.work.id;
     expect(imported.body.data.work).toMatchObject({ title: "导入书名", chapterCount: 1 });
+    expect(imported.body.data).not.toHaveProperty("tree");
+    expect(JSON.stringify(imported.body)).not.toContain("故事开始。");
 
     const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01]);
     const uploaded = await request(runtime.app).put(`/api/works/${workId}/cover`).attach("file", png, "cover.png").expect(200);

--- a/tests/integration/work-chapter-api.test.ts
+++ b/tests/integration/work-chapter-api.test.ts
@@ -21,6 +21,8 @@ describe("作品、导入和章节版本 API", () => {
     expect(imported.body.data.tree.volumes).toHaveLength(2);
     const chapter = imported.body.data.tree.volumes[0].chapters[0];
     expect(chapter.versionNo).toBe(1);
+    expect(chapter).not.toHaveProperty("content");
+    expect(JSON.stringify(imported.body)).not.toContain("林舟收到信号。");
 
     const saved = await request(runtime.app)
       .patch(`/api/chapters/${chapter.id}`)
@@ -54,6 +56,7 @@ describe("作品、导入和章节版本 API", () => {
       .expect(201);
     expect(imported.body.data.tree.volumes).toHaveLength(1);
     expect(imported.body.data.tree.volumes[0]).toMatchObject({ title: "正文", source: "default" });
+    expect(imported.body.data.tree.volumes[0].chapters[0]).not.toHaveProperty("content");
     expect(imported.body.data.warnings[0]).toContain("默认卷");
 
     await request(runtime.app)
@@ -180,7 +183,12 @@ describe("作品、导入和章节版本 API", () => {
       .expect(201);
 
     expect(imported.body.data.tree.volumes[0]).toMatchObject({ title: "第一卷 星港", source: "explicit" });
-    expect(imported.body.data.tree.volumes[0].chapters[0]).toMatchObject({ title: "第一章 抵达", content: "林舟抵达星港。" });
+    const chapter = imported.body.data.tree.volumes[0].chapters[0];
+    expect(chapter).toMatchObject({ title: "第一章 抵达" });
+    expect(chapter).not.toHaveProperty("content");
+    expect(JSON.stringify(imported.body)).not.toContain("林舟抵达星港。");
+    const loadedChapter = await request(runtime.app).get(`/api/chapters/${chapter.id}`).expect(200);
+    expect(loadedChapter.body.data.content).toBe("林舟抵达星港。");
   });
 
   it("正确解码 multipart 中文文件名并应用含前传提示", async () => {
@@ -299,7 +307,11 @@ describe("作品、导入和章节版本 API", () => {
       .post(`/api/works/${workId}/file-versions/${v2VersionId}/restore`)
       .expect(200);
     expect(restored.body.data.restoredFrom).toBe(v2VersionId);
-    expect(restored.body.data.tree.volumes[0].chapters[0].content).toBe("初版正文。");
+    const restoredChapter = restored.body.data.tree.volumes[0].chapters[0];
+    expect(restoredChapter).not.toHaveProperty("content");
+    expect(JSON.stringify(restored.body)).not.toContain("初版正文。");
+    const restoredChapterDetails = await request(runtime.app).get(`/api/chapters/${restoredChapter.id}`).expect(200);
+    expect(restoredChapterDetails.body.data.content).toBe("初版正文。");
 
     const fileVersionsAfter = await request(runtime.app).get(`/api/works/${workId}/file-versions`).expect(200);
     expect(fileVersionsAfter.body.data[0].fileType).toBe("snapshot");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -424,7 +424,9 @@ describe("作者完整创作流程", () => {
     const imported = await request(runtime.app).post(`/api/works/${workId}/import`)
       .attach("file", Buffer.from("第一卷 启航\n第一章 北港\n飞船停在北港。林舟检查跃迁引擎。林舟想起沈星的警告。\n第二章 旧信\n沈星仍保存着林舟的旧信。"), "星际纪元.txt")
       .expect(201);
-    const chapterId = imported.body.data.tree.volumes[0].chapters[0].id;
+    expect(JSON.stringify(imported.body)).not.toContain("飞船停在北港。");
+    const directory = await request(runtime.app).get(`/api/works/${workId}`).expect(200);
+    const chapterId = directory.body.data.volumes[0].chapters[0].id;
 
     await request(runtime.app).post(`/api/works/${workId}/settings`).send({
       title: "跃迁冷却规则",


### PR DESCRIPTION
## 变更内容

- 现有作品导入完成后返回不含章节 `content` 的目录树
- 新建并导入作品时不再返回前端未使用的完整 `tree`
- 文件版本恢复后返回不含正文的目录树
- 增加回归测试，验证导入和恢复响应不包含小说正文，同时章节详情接口仍可正常读取正文

## 根因

导入和文件版本恢复完成后调用了 `getWorkTree()` 组装响应，导致服务端将全部章节正文再次序列化并发送给浏览器。前端刷新目录只需要章节元数据，新建导入流程甚至只使用作品 ID。

## 影响

避免在导入和恢复完成后重复下载整本小说，降低响应体积、序列化开销和浏览器内存占用，不改变章节按需读取行为。

## 验证

- `npm run typecheck`
- `npx vitest run tests/integration/work-chapter-api.test.ts tests/integration/feature-suite-api.test.ts`
- `npx vitest run tests/system/author-journey.test.ts`
- `npm test`：47 个测试文件、229 个测试通过
- `npm run build`
