### PR TITLE
docs(project): link contribution guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ tests/
 - 功能、修复和文档变更应从 `develop` 派生分支，所有协作者的 PR 必须以 `develop` 为目标分支。
 - 只有项目维护者发起的版本发布合并可以从 `develop` 进入 `main`，不得绕过 `develop` 直接提交功能或修复。
 - **所有变更必须先合入 `develop`；除项目维护者发起的 `develop` → `main` 版本发布 PR 外，禁止任何功能、修复、文档、CI、构建或维护分支直接向 `main` 发起 PR。**
-- 更完整的协作流程见 `docs/CONTRIBUTING.md`。
+- 更完整的协作流程见 [协作开发规范](docs/CONTRIBUTING.md)。
 
 ### 版本发布
 

--- a/README.en.md
+++ b/README.en.md
@@ -217,6 +217,10 @@ Expected response:
 
 Scriverse is currently an MVP. APIs and data structures may still change. Back up the `.data` directory before upgrading.
 
+## Contributing
+
+Read the [contribution guide](docs/CONTRIBUTING.md) before submitting code or documentation. Start everyday changes from the latest `develop` branch and merge them through a Pull Request targeting `develop`.
+
 ## 🌟 Special Thanks
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ curl http://127.0.0.1:13210/api/health
 
 当前为 MVP 版本，接口和数据结构仍可能调整。升级前请备份 `.data` 目录。
 
+## 参与贡献
+
+提交代码或文档前，请阅读 [协作开发规范](docs/CONTRIBUTING.md)。所有日常变更均从最新 `develop` 派生，并通过以 `develop` 为目标分支的 Pull Request 合入。
+
 ## 🌟 Special Thanks
 
 <p align="center">


### PR DESCRIPTION
## What changed

- Add a **参与贡献** section to the Chinese README.
- Add a **Contributing** section to the English README.
- Convert the existing `AGENTS.md` contribution-guide path into a clickable Markdown link.
- Point all three locations to `docs/CONTRIBUTING.md`.

## Why

The contribution guide was moved into `docs/`, but it should remain directly discoverable from the primary project entry points and agent instructions.

## Impact

Documentation only. No runtime, API, database, or deployment behavior changes.

## Validation

- Verified all three Markdown links resolve to `docs/CONTRIBUTING.md`
- `npm run check` (48 test files, 233 tests, typecheck, and production build)
- `git diff --check`
