### PR TITLE
build(release): bump version to 0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.3";
+export const APP_VERSION = "0.3.4";


### PR DESCRIPTION
## 发布说明

将版本号从 0.3.3 升级为 0.3.4（SemVer 补丁版本），为 `develop` → `main` 的小版本发布做准备。

本次发布包含的主要内容：

- `perf(auth)`：验证码图片改为按需加载，登录页默认不再自动请求验证码接口（PR #29）。

## 变更范围

- `package.json` / `package-lock.json` / `src/version.ts` 版本号同步更新。

## 验证

- `tests/unit/version.test.ts` 版本一致性断言通过。