### PR TITLE
build(release): bump version to 0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.5";
+export const APP_VERSION = "0.3.6";


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本从 `0.3.5` 提升到 `0.3.6`
- 同步应用运行时版本与 lockfile 根包版本

## 发布范围

本补丁版本包含已合入 `develop` 的 PR #32、#33、#34，以及三项并行功能的迁移号、静态资源缓存和共享 API 集成修正。

## 验证

- `npm run check`：51 个测试文件、251 项测试通过
- `npm pack --dry-run --json`：`@musnows/scriverse@0.3.6` 打包预检通过
- 隔离数据库真实 E2E 通过
- 健康检查通过
- SQLite `integrity_check` 与外键检查通过
- 内置浏览器加载、静态资源与控制台检查通过