### PR TITLE
fix(release): synchronize npm 10 lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,29 @@
         "node": ">=22.5.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -3120,7 +3143,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3652,7 +3674,6 @@
       "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -3760,7 +3781,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",


### PR DESCRIPTION
## 根因

`package-lock.json` 由本机 npm 11 生成后缺少 Sharp 间接依赖的根级 lock 条目。GitHub Actions 与 Docker 使用 npm 10，执行 `npm ci` 时报告缺少 `@emnapi/runtime@1.11.2` 和 `@emnapi/core@1.11.2`，导致 npm 与 Docker 发布工作流同时失败。

## 修复

- 使用 npm `10.9.8` 重新生成 lockfile
- 补齐 npm 10 所需的 `@emnapi/core` 与 `@emnapi/runtime` 条目

## 验证

- `npx npm@10.9.8 ci`
- `npm run check`：51 个测试文件、251 项测试通过
- `npx npm@10.9.8 ci --omit=dev`
- Sharp `0.35.3` 生产依赖加载通过
- Docker `linux/arm64` build 与 runtime 阶段完整构建通过
- 双架构本地尝试仅在下载 amd64 基础镜像时因 CloudFront `unexpected EOF` 中断，未再次出现 lockfile 错误