### PR TITLE
build(release): bump version to 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.6";
+export const APP_VERSION = "0.3.7";


### PR DESCRIPTION
## What changed

- Bump the npm package version from `0.3.6` to `0.3.7`.
- Synchronize the package lockfile and runtime health version.

## Validation

- `npm run typecheck`
- `npm test` (52 files, 253 tests)
- `npm run build`
- `git diff --check`

This prepares the patch release before the final `develop → main` release PR.