### PR TITLE
fix(logging): lower normal request logs to debug

### DIFF
--- a/src/http-logging.ts
+++ b/src/http-logging.ts
@@ -48,7 +48,7 @@ export function createRequestLoggingMiddleware(log: Logger = defaultLogger): Req
     let completed = false;
     response.setHeader("X-Request-Id", requestId);
     return runWithRequestContext({ requestId, actor: null }, () => {
-      log.info("http.request.started", {
+      log.debug("http.request.started", {
         method: request.method,
         path: sanitizeRequestPath(request.path),
         clientNetwork: maskClientAddress(request.ip || request.socket.remoteAddress),
@@ -62,7 +62,7 @@ export function createRequestLoggingMiddleware(log: Logger = defaultLogger): Req
         const fields = responseFields(request, response, startedAt);
         if (response.statusCode >= 500) log.error("http.request.completed", fields);
         else if (response.statusCode >= 400) log.warn("http.request.completed", fields);
-        else log.info("http.request.completed", fields);
+        else log.debug("http.request.completed", fields);
       });
       response.once("close", () => {
         if (!completed) log.warn("http.request.aborted", responseFields(request, response, startedAt));

--- a/tests/integration/http-logging.test.ts
+++ b/tests/integration/http-logging.test.ts
@@ -7,7 +7,7 @@ import { accountReference, createLogger, type LogRecord } from "../../src/logger
 describe("HTTP 请求日志", () => {
   it("记录请求进入和完成状态，同时隐藏账户路径、查询令牌和认证头", async () => {
     const records: LogRecord[] = [];
-    const log = createLogger({ level: "info", write: (_level, record) => records.push(record) });
+    const log = createLogger({ level: "debug", write: (_level, record) => records.push(record) });
     const app = express();
     app.use(createRequestLoggingMiddleware(log));
     app.get("/api/users/:userId", (incoming, response) => {
@@ -51,7 +51,7 @@ describe("HTTP 请求日志", () => {
 
   it("隐藏作品成员路由中的账户 ID", async () => {
     const records: LogRecord[] = [];
-    const log = createLogger({ level: "info", write: (_level, record) => records.push(record) });
+    const log = createLogger({ level: "debug", write: (_level, record) => records.push(record) });
     const app = express();
     app.use(createRequestLoggingMiddleware(log));
     app.delete("/api/works/:workId/members/:userId", (_request, response) => response.status(204).end());
@@ -60,5 +60,17 @@ describe("HTTP 请求日志", () => {
 
     expect(records[0]).toMatchObject({ path: "/api/works/work-1/members/[REDACTED]" });
     expect(JSON.stringify(records)).not.toContain("private-member-id");
+  });
+
+  it("默认 info 级别不记录正常请求生命周期", async () => {
+    const records: LogRecord[] = [];
+    const log = createLogger({ level: "info", write: (_level, record) => records.push(record) });
+    const app = express();
+    app.use(createRequestLoggingMiddleware(log));
+    app.get("/api/health", (_request, response) => response.status(200).json({ data: { ok: true } }));
+
+    await request(app).get("/api/health").expect(200);
+
+    expect(records).toEqual([]);
   });
 });


### PR DESCRIPTION
## 变更内容

将正常 HTTP 请求生命周期日志（开始和成功完成）调整为 `debug` 级别，保持默认 `info` 日志的输出简洁。4xx/5xx 和中断请求仍保留原有的 `warn`/`error` 级别。

## 验证

- `npm run typecheck`
- `npm test`
- `npm run build`

## 根因

健康检查等高频正常请求此前使用 `info` 级别，导致默认日志持续输出请求明细。
