### PR TITLE
build(release): bump version to 0.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.8";
+export const APP_VERSION = "0.3.9";


### PR DESCRIPTION
## Summary

- bump the package version from 0.3.8 to 0.3.9
- keep package metadata, lockfile metadata, and the runtime version constant aligned

## Validation

- `npm run check`
- 56 test files and 272 tests passed
- TypeScript typecheck passed
- production build passed
- release version consistency check passed