### PR TITLE
build(release): bump version to 0.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.9";
+export const APP_VERSION = "0.3.10";


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本从 `0.3.9` 更新为 `0.3.10`
- 同步应用运行时版本与 lockfile

## 验证

- `npm run check`
- 57 个测试文件、279 项测试全部通过
- TypeScript 类型检查与生产构建通过