### PR TITLE
build(release): bump version to 0.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.10";
+export const APP_VERSION = "0.3.11";


### PR DESCRIPTION
## 版本

将 Scriverse 补丁版本从 `0.3.10` 提升到 `0.3.11`。

## 已包含

- TXT/DOCX 导入历史与正文恢复入口
- 无正文写权限成员隐藏导入与恢复入口
- 覆盖导入及整本恢复的跨模块写权限保护
- 旧快照兼容、非法快照拦截、历史分页和恢复后状态刷新
- 认证 API 集成测试端口复用，消除本机端口映射导致的偶发失败

## 验证

- `npm run check`
- 57 个测试文件、281 个测试全部通过
- 类型检查和生产构建通过