### PR TITLE
perf(docker): reuse dependency layers across releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
-FROM node:22-bookworm-slim AS build
+# syntax=docker/dockerfile:1
+
+# 基础镜像按多架构索引固定，升级 Node 时需同步更新摘要。
+ARG NODE_IMAGE=node:22-bookworm-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3
+
+FROM ${NODE_IMAGE} AS dependency-manifests
+
+WORKDIR /manifests
+
+COPY scripts/normalize-docker-package-manifests.mjs ./normalize-package-manifests.mjs
+COPY package.json package-lock.json ./
+RUN node ./normalize-package-manifests.mjs package.json package-lock.json
+
+FROM ${NODE_IMAGE} AS build
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci
+COPY --from=dependency-manifests /manifests/package.json /manifests/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
 
 COPY tsconfig.json tsconfig.build.json ./
 COPY scripts ./scripts
 COPY src ./src
 RUN npm run build
 
-FROM node:22-bookworm-slim AS runtime
+FROM ${NODE_IMAGE} AS runtime
 
 ENV NODE_ENV=production \
     LOG_LEVEL=info \
@@ -20,13 +33,15 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && npm cache clean --force
-
-COPY --from=build /app/dist ./dist
-COPY --chown=node:node src/public ./src/public
-
 RUN mkdir -p /app/.data && chown node:node /app/.data
+
+COPY --from=dependency-manifests /manifests/package.json /manifests/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci --omit=dev
+
+COPY --chown=node:node src/public ./src/public
+COPY --from=build /app/dist ./dist
+
+COPY package.json package-lock.json ./
 
 USER node
 

--- a/scripts/normalize-docker-package-manifests.mjs
+++ b/scripts/normalize-docker-package-manifests.mjs
@@ -1,0 +1,21 @@
+import { readFileSync, utimesSync, writeFileSync } from "node:fs";
+
+const manifestPaths = process.argv.slice(2);
+
+if (manifestPaths.length === 0) {
+  console.error("Package manifest paths are required");
+  process.exitCode = 1;
+} else {
+  for (const manifestPath of manifestPaths) {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    delete manifest.version;
+
+    const rootPackage = manifest.packages?.[""];
+    if (rootPackage && typeof rootPackage === "object" && !Array.isArray(rootPackage)) {
+      delete rootPackage.version;
+    }
+
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    utimesSync(manifestPath, new Date(0), new Date(0));
+  }
+}

--- a/tests/unit/docker-package-manifests.test.ts
+++ b/tests/unit/docker-package-manifests.test.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Docker 依赖清单规范化", () => {
+  it("只移除会随发版变化的根包版本并固定文件时间", () => {
+    const directory = mkdtempSync(join(tmpdir(), "scriverse-docker-manifests-"));
+    temporaryDirectories.push(directory);
+    const packagePath = join(directory, "package.json");
+    const lockPath = join(directory, "package-lock.json");
+    writeFileSync(packagePath, JSON.stringify({
+      name: "@musnows/scriverse",
+      version: "0.3.11",
+      type: "module",
+      dependencies: { express: "^5.1.0" }
+    }));
+    writeFileSync(lockPath, JSON.stringify({
+      name: "@musnows/scriverse",
+      version: "0.3.11",
+      packages: {
+        "": { name: "@musnows/scriverse", version: "0.3.11", dependencies: { express: "^5.1.0" } },
+        "node_modules/express": { version: "5.1.0" }
+      }
+    }));
+
+    execFileSync(process.execPath, [
+      fileURLToPath(new URL("../../scripts/normalize-docker-package-manifests.mjs", import.meta.url)),
+      packagePath,
+      lockPath
+    ]);
+
+    expect(JSON.parse(readFileSync(packagePath, "utf8"))).toEqual({
+      name: "@musnows/scriverse",
+      type: "module",
+      dependencies: { express: "^5.1.0" }
+    });
+    expect(JSON.parse(readFileSync(lockPath, "utf8"))).toEqual({
+      name: "@musnows/scriverse",
+      packages: {
+        "": { name: "@musnows/scriverse", dependencies: { express: "^5.1.0" } },
+        "node_modules/express": { version: "5.1.0" }
+      }
+    });
+    expect(statSync(packagePath).mtimeMs).toBe(0);
+    expect(statSync(lockPath).mtimeMs).toBe(0);
+  });
+
+  it("在依赖层之后才复制含版本号的真实清单", () => {
+    const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+    const runtimeStage = dockerfile.slice(dockerfile.indexOf("AS runtime"));
+    const normalizedManifestCopy = runtimeStage.indexOf("COPY --from=dependency-manifests");
+    const productionInstall = runtimeStage.indexOf("npm ci --omit=dev");
+    const publicCopy = runtimeStage.indexOf("COPY --chown=node:node src/public");
+    const buildCopy = runtimeStage.indexOf("COPY --from=build /app/dist");
+    const versionedManifestCopy = runtimeStage.lastIndexOf("COPY package.json package-lock.json");
+
+    expect(normalizedManifestCopy).toBeGreaterThan(-1);
+    expect(productionInstall).toBeGreaterThan(normalizedManifestCopy);
+    expect(publicCopy).toBeGreaterThan(productionInstall);
+    expect(buildCopy).toBeGreaterThan(publicCopy);
+    expect(versionedManifestCopy).toBeGreaterThan(buildCopy);
+  });
+});


### PR DESCRIPTION
## 变更内容

- 规范化 Docker 构建使用的包清单，移除只随发版变化的根包版本号
- 将真实 `package.json` 和 `package-lock.json` 移到运行时镜像末层
- 调整 `.data`、前端资源和编译产物的层顺序
- 为 npm 安装增加 BuildKit 缓存挂载
- 固定 Node 多架构基础镜像摘要
- 增加依赖清单规范化和 Dockerfile 层顺序回归测试

## 原因与影响

此前每次补丁发版都会修改包版本号，导致生产 `npm ci` 层缓存失效，客户端需要重新下载约 25 MiB 的压缩依赖层。本次修改让普通 Release 在依赖不变时继续复用生产依赖层。

本地 Docker 模拟 `0.3.11` 升级到 `0.3.12` 后，12 个文件系统层中有 10 个复用；约 75 MB（未压缩）的生产依赖层 digest 保持一致，仅编译产物和末尾版本元数据层变化。

## 验证

- `npm run typecheck`
- `npm test`：58 个测试文件、283 项测试通过
- `npm run build`
- 本地 Docker 实际构建并逐层比较 digest
- 更新版本镜像 `/api/health` 返回正确版本
- 生产依赖变化镜像健康检查通过