### PR TITLE
fix(ai): gate duplicate characters before persistence

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -94,6 +94,47 @@ type GenerateResult = {
   processSteps: AiProcessStep[];
 };
 
+type CharacterExtractionEvidence = {
+  chapterId: string;
+  chapterTitle: string;
+  quote: string;
+};
+
+type CharacterExtractionGroup = {
+  name: string;
+  aliases: Set<string>;
+  species: string;
+  identity: string;
+  firstChapterId: string | null;
+  firstEvidence: CharacterExtractionEvidence;
+  references: Set<string>;
+};
+
+type CharacterVerificationSubject = {
+  key: string;
+  kind: "candidate" | "existing";
+  characterId?: string;
+  name: string;
+  aliases: string[];
+  species: string;
+  identity: string;
+  firstChapterId: string | null;
+  evidence: CharacterExtractionEvidence | null;
+};
+
+type CharacterVerificationPair = {
+  key: string;
+  left: CharacterVerificationSubject;
+  right: CharacterVerificationSubject;
+};
+
+type CharacterVerificationDecision = {
+  pairKey: string;
+  verdict: "same" | "separate" | "uncertain";
+  confidence: number;
+  reason: string;
+};
+
 const allowedParameters = new Set(["temperature", "top_p", "max_tokens", "presence_penalty", "frequency_penalty", "seed"]);
 const DEFAULT_MAX_TOKENS = 32_000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
@@ -395,6 +436,25 @@ const unsafeGlobalAliases = new Set([
   "怪兽之王", "怪兽女王", "君王", "女王", "吾王", "博士", "陈博士", "玲博士", "老师", "舰长", "上尉", "司令", "族长",
   "父亲", "母亲", "爸爸", "妈妈", "哥哥", "姐姐", "大哥", "妹妹", "先生", "小姐", "陛下", "尔森"
 ]);
+
+const characterTitleSuffixPattern = /^(?<base>.+?)(?:博士|教授|老师|舰长|上尉|司令|族长|将军|队长|船长|院士|主任)$/u;
+
+function normalizeCharacterReference(value: string): string {
+  return value.normalize("NFKC").trim().replace(/\s+/gu, " ").toLocaleLowerCase("zh-CN");
+}
+
+export function stripCharacterTitleSuffix(value: string): string | null {
+  const normalized = normalizeCharacterReference(value);
+  const base = normalized.match(characterTitleSuffixPattern)?.groups?.base?.trim();
+  return base && base !== normalized ? base : null;
+}
+
+export function areCharacterTitleVariants(left: string, right: string): boolean {
+  const normalizedLeft = normalizeCharacterReference(left);
+  const normalizedRight = normalizeCharacterReference(right);
+  return stripCharacterTitleSuffix(normalizedLeft) === normalizedRight
+    || stripCharacterTitleSuffix(normalizedRight) === normalizedLeft;
+}
 
 export function isSafeGlobalAlias(value: string): boolean {
   const normalized = value.normalize("NFKC").trim().replace(/\s+/gu, " ").toLocaleLowerCase("zh-CN");
@@ -2828,6 +2888,54 @@ export class AiManager {
     };
   }
 
+  private async verifyCharacterTitlePairs(
+    workId: string,
+    pairs: CharacterVerificationPair[],
+    modelId?: string,
+    taskId?: string
+  ): Promise<{ decisions: Map<string, CharacterVerificationDecision>; callId: string }> {
+    const generated = await this.generateTaggedJson({
+      workId,
+      taskType: "book-analysis",
+      signal: this.taskSignal(taskId),
+      scope: { type: "none" },
+      ...(modelId ? { modelId } : {}),
+      parameters: { temperature: 0.1 },
+      instruction: [
+        "对下面列出的角色候选对进行第二次身份确认。只有确认是同一人或确认是不同人，服务端才会允许这组候选继续写入数据库。",
+        "请结合候选的主名、别名、身份、种族、首次章节和原文证据判断。不能仅因为名字相似就判定 same；职称后缀相同也不是充分证据。",
+        "如果信息不足、身份冲突未解决或无法确认，必须返回 uncertain。",
+        "输出 JSON 数组，每项字段：pairKey、verdict（same/separate/uncertain）、confidence（0到1）、reason。必须逐项覆盖输入中的所有 pairKey，不得创造 pairKey。",
+        `候选对：${JSON.stringify(pairs.map((pair) => ({
+          pairKey: pair.key,
+          left: pair.left,
+          right: pair.right
+        })))}`
+      ].join("\n"),
+      extraSystemPrompt: "你是角色身份二次确认器。你的输出只用于服务端写入门禁；证据不足时宁可 uncertain，不得为了减少角色数量而强行合并。"
+    });
+    const extracted = extractJson<unknown>(generated.content);
+    if (!Array.isArray(extracted)) throw new AppError(502, "AI_INVALID_JSON", "角色身份二次确认结果必须是数组");
+    const allowedPairKeys = new Set(pairs.map((pair) => pair.key));
+    const decisions = new Map<string, CharacterVerificationDecision>();
+    for (const item of extracted) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const candidate = item as Record<string, unknown>;
+      const pairKey = typeof candidate.pairKey === "string" ? candidate.pairKey : "";
+      if (!allowedPairKeys.has(pairKey) || decisions.has(pairKey)) continue;
+      const verdict = candidate.verdict === "same" || candidate.verdict === "separate" || candidate.verdict === "uncertain"
+        ? candidate.verdict
+        : "uncertain";
+      decisions.set(pairKey, {
+        pairKey,
+        verdict,
+        confidence: clamp(typeof candidate.confidence === "number" ? candidate.confidence : 0, 0, 1),
+        reason: typeof candidate.reason === "string" && candidate.reason.trim() ? candidate.reason.trim() : "AI 未提供充分确认理由"
+      });
+    }
+    return { decisions, callId: generated.callId };
+  }
+
   private async runCharacterExtraction(workId: string, scope: ContextScope, modelId?: string, taskId?: string): Promise<Record<string, unknown>> {
     const chapters = this.getScopeChapters(workId, scope);
     if (chapters.length === 0) throw new AppError(409, "CHAPTERS_REQUIRED", "人物抽取范围内没有章节");
@@ -2847,7 +2955,7 @@ export class AiManager {
         instruction: [
           "抽取本批原文中有名字且对跨章节剧情有意义的人物或具有人格的生物。输出 JSON 数组。",
           "每项字段：canonicalName、aliases（仅无歧义昵称或拼写变体）、species（仅原文明确说明时填写）、identity、firstEvidence（chapterId、chapterTitle、quote）。",
-          "规则：合并明显拼写变体；不能把怪兽之王、怪兽女王、君王、女王、吾王、博士、舰长、上尉、司令、族长、老师、父亲、母亲、哥哥、姐姐等称号作为全局别名；不能把单字母简称作为别名；梦境或作品内虚构角色需在 identity 标明；不得创造人物；quote 必须是原文连续引文且不超过 80 字。",
+          "规则：合并明显拼写变体；不能把怪兽之王、怪兽女王、君王、女王、吾王、博士、舰长、上尉、司令、族长、老师、父亲、母亲、哥哥、姐姐等单独称号作为全局别名；带具体人名的‘X博士’、‘X教授’等形式不能仅因职称后缀拆成两个角色，保留无职称姓名作为 canonicalName，并将带职称形式作为待确认的候选称呼；不能把单字母简称作为别名；梦境或作品内虚构角色需在 identity 标明；不得创造人物；quote 必须是原文连续引文且不超过 80 字。",
           "没有合格人物时输出 []，不得使用 Markdown 代码块。"
         ].join("\n"),
         extraSystemPrompt: [
@@ -2897,7 +3005,7 @@ export class AiManager {
     if (!this.taskCanCommit(taskId)) return { interrupted: true, callIds };
 
     const byChapterId = new Map(chapters.map((chapter) => [String(chapter.id), chapter]));
-    const groups: Array<{ name: string; aliases: Set<string>; species: string; identity: string; firstChapterId: string | null; references: Set<string> }> = [];
+    const groups: CharacterExtractionGroup[] = [];
     for (const candidate of rawCandidates) {
       if (typeof candidate.canonicalName !== "string" || !candidate.canonicalName.trim()) continue;
       const name = candidate.canonicalName.normalize("NFKC").trim();
@@ -2920,6 +3028,11 @@ export class AiManager {
         species: typeof candidate.species === "string" ? candidate.species.trim() : "",
         identity: typeof candidate.identity === "string" ? candidate.identity : "",
         firstChapterId: chapterId,
+        firstEvidence: {
+          chapterId,
+          chapterTitle: typeof evidence?.chapterTitle === "string" ? evidence.chapterTitle : "",
+          quote
+        },
         references: new Set<string>()
       };
       if (!matches.length) groups.push(group);
@@ -2938,25 +3051,190 @@ export class AiManager {
       }
     }
 
-    const characterIds: string[] = [];
+    const existingCharacters = this.store.listCharacters(workId);
+    const existingIdByGroupIndex = new Map<number, string>();
+    const candidateSubjects: CharacterVerificationSubject[] = groups.map((group, index) => ({
+      key: `candidate:${index}`,
+      kind: "candidate",
+      name: group.name,
+      aliases: [...group.aliases],
+      species: group.species,
+      identity: group.identity,
+      firstChapterId: group.firstChapterId,
+      evidence: group.firstEvidence
+    }));
+    for (const [index, group] of groups.entries()) {
+      const existingId = [group.name, ...group.aliases]
+        .map((value) => this.store.resolveCharacterReference(workId, value))
+        .find((value): value is string => Boolean(value));
+      if (existingId) existingIdByGroupIndex.set(index, existingId);
+    }
+    const existingSubjects: CharacterVerificationSubject[] = existingCharacters.map((character) => ({
+      key: `existing:${String(character.id)}`,
+      kind: "existing",
+      characterId: String(character.id),
+      name: String(character.name),
+      aliases: (character.aliases as string[]).slice(),
+      species: String(character.species ?? ""),
+      identity: String((character.attributes as Record<string, unknown>).identity ?? ""),
+      firstChapterId: (character.firstChapterId as string | null) ?? null,
+      evidence: null
+    }));
+    const subjectNames = (subject: CharacterVerificationSubject): string[] => [subject.name, ...subject.aliases];
+    const hasTitleVariant = (left: CharacterVerificationSubject, right: CharacterVerificationSubject): boolean =>
+      subjectNames(left).some((leftName) => subjectNames(right).some((rightName) => areCharacterTitleVariants(leftName, rightName)));
+    const verificationPairs = new Map<string, CharacterVerificationPair>();
+    const addVerificationPair = (left: CharacterVerificationSubject, right: CharacterVerificationSubject): void => {
+      if (left.key === right.key || !hasTitleVariant(left, right)) return;
+      if (left.kind === "existing" && right.kind === "existing") return;
+      const ordered = [left, right].sort((first, second) => first.key.localeCompare(second.key));
+      const pairKey = `${ordered[0]?.key}|${ordered[1]?.key}`;
+      if (!verificationPairs.has(pairKey)) verificationPairs.set(pairKey, { key: pairKey, left: ordered[0]!, right: ordered[1]! });
+    };
+    for (let leftIndex = 0; leftIndex < candidateSubjects.length; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < candidateSubjects.length; rightIndex += 1) {
+        if (existingIdByGroupIndex.get(leftIndex) && existingIdByGroupIndex.get(leftIndex) === existingIdByGroupIndex.get(rightIndex)) continue;
+        addVerificationPair(candidateSubjects[leftIndex]!, candidateSubjects[rightIndex]!);
+      }
+      const existingId = existingIdByGroupIndex.get(leftIndex);
+      for (const existing of existingSubjects) {
+        if (existing.characterId === existingId) continue;
+        addVerificationPair(candidateSubjects[leftIndex]!, existing);
+      }
+    }
+
     const skipped: Array<{ name: string; reason: string }> = [];
-    for (const group of groups) {
+    let verificationCallId: string | null = null;
+    let confirmedSameCount = 0;
+    let confirmedSeparateCount = 0;
+    let unresolvedCount = 0;
+    const blockedGroups = new Set<number>();
+    const blockedReasons = new Map<number, string>();
+    const forcedExistingIds = new Map<number, string>();
+    const parent = groups.map((_, index) => index);
+    const findRoot = (index: number): number => {
+      let root = index;
+      while (parent[root] !== root) root = parent[root]!;
+      while (parent[index] !== index) {
+        const next = parent[index]!;
+        parent[index] = root;
+        index = next;
+      }
+      return root;
+    };
+    const unionGroups = (left: number, right: number): void => {
+      const leftRoot = findRoot(left);
+      const rightRoot = findRoot(right);
+      if (leftRoot !== rightRoot) parent[rightRoot] = leftRoot;
+    };
+    const candidateIndexByKey = new Map(candidateSubjects.map((subject, index) => [subject.key, index]));
+    const verificationResults = verificationPairs.size > 0
+      ? await this.verifyCharacterTitlePairs(workId, [...verificationPairs.values()], modelId, taskId)
+      : { decisions: new Map<string, CharacterVerificationDecision>(), callId: null };
+    verificationCallId = verificationResults.callId;
+    for (const pair of verificationPairs.values()) {
+      const decision = verificationResults.decisions.get(pair.key);
+      const leftIndex = candidateIndexByKey.get(pair.left.key);
+      const rightIndex = candidateIndexByKey.get(pair.right.key);
+      const candidateIndexes = [leftIndex, rightIndex].filter((value): value is number => value !== undefined);
+      const confirmed = decision && decision.confidence >= 0.8 && (decision.verdict === "same" || decision.verdict === "separate");
+      if (!confirmed) {
+        unresolvedCount += 1;
+        for (const candidateIndex of candidateIndexes) {
+          blockedGroups.add(candidateIndex);
+          blockedReasons.set(candidateIndex, `角色身份二次确认未通过：${decision?.reason ?? "AI 未返回确认结果"}`);
+        }
+        continue;
+      }
+      if (decision.verdict === "same") {
+        confirmedSameCount += 1;
+        if (leftIndex !== undefined && rightIndex !== undefined) {
+          unionGroups(leftIndex, rightIndex);
+        } else if (leftIndex !== undefined || rightIndex !== undefined) {
+          const candidateIndex = leftIndex ?? rightIndex!;
+          const existingSubject = pair.left.kind === "existing" ? pair.left : pair.right;
+          const existingId = String(existingSubject.characterId);
+          const root = findRoot(candidateIndex);
+          const previous = forcedExistingIds.get(root);
+          if (previous && previous !== existingId) {
+            blockedGroups.add(root);
+            blockedReasons.set(root, "角色身份二次确认指向了多个已有角色");
+          } else {
+            forcedExistingIds.set(root, existingId);
+          }
+        }
+      } else {
+        confirmedSeparateCount += 1;
+      }
+    }
+
+    const mergedGroups = new Map<number, CharacterExtractionGroup>();
+    for (const [index, group] of groups.entries()) {
+      const root = findRoot(index);
+      const target = mergedGroups.get(root);
+      if (!target) {
+        mergedGroups.set(root, group);
+        continue;
+      }
+      const titleFreeTarget = stripCharacterTitleSuffix(target.name);
+      if (titleFreeTarget === this.normalizeReference(group.name)) target.name = group.name;
+      for (const alias of [group.name, ...group.aliases]) {
+        if (this.normalizeReference(alias) !== this.normalizeReference(target.name) && this.isSafeGlobalAlias(alias)) target.aliases.add(alias);
+      }
+      for (const reference of group.references) target.references.add(reference);
+      if (!target.identity && group.identity) target.identity = group.identity;
+      if (!target.species && group.species) target.species = group.species;
+      if (!target.firstChapterId && group.firstChapterId) target.firstChapterId = group.firstChapterId;
+    }
+    const existingIdByRoot = new Map<number, string>();
+    for (const [index, existingId] of existingIdByGroupIndex) {
+      const root = findRoot(index);
+      const previous = existingIdByRoot.get(root);
+      if (previous && previous !== existingId) {
+        blockedGroups.add(root);
+        blockedReasons.set(root, "同一候选组匹配到多个已有角色");
+      } else {
+        existingIdByRoot.set(root, existingId);
+      }
+    }
+    for (const [index, existingId] of forcedExistingIds) {
+      const root = findRoot(index);
+      const previous = existingIdByRoot.get(root);
+      if (previous && previous !== existingId) {
+        blockedGroups.add(root);
+        blockedReasons.set(root, "角色身份二次确认指向了多个已有角色");
+      } else {
+        existingIdByRoot.set(root, existingId);
+      }
+    }
+    for (const index of [...blockedGroups]) {
+      const root = findRoot(index);
+      blockedGroups.add(root);
+      if (!blockedReasons.has(root) && blockedReasons.has(index)) blockedReasons.set(root, blockedReasons.get(index)!);
+    }
+
+    const characterIds: string[] = [];
+    for (const [root, group] of mergedGroups) {
+      if (blockedGroups.has(root)) {
+        skipped.push({ name: group.name, reason: blockedReasons.get(root) ?? "角色身份二次确认未通过" });
+        continue;
+      }
       const aliases = [...group.aliases].filter((alias) => this.isSafeGlobalAlias(alias));
       const extractedRaceId = group.species ? this.store.resolveRaceReference(workId, group.species) : null;
-      const existingId = [group.name, ...aliases]
+      const existingId = existingIdByRoot.get(root) ?? [group.name, ...aliases]
         .map((value) => this.store.resolveCharacterReference(workId, value))
         .find((value): value is string => Boolean(value));
       try {
         if (existingId) {
           const existing = this.store.getCharacter(existingId);
-          const mergedAliases = [...new Set([...(existing.aliases as string[]), ...aliases])]
+          const mergedAliases = [...new Set([...(existing.aliases as string[]), group.name, ...aliases])]
             .filter((alias) => this.isSafeGlobalAlias(alias) && this.normalizeReference(alias) !== this.normalizeReference(String(existing.name)));
           const updated = this.store.updateCharacter(existingId, {
             aliases: mergedAliases,
             raceId: (existing.raceId as string | null) ?? extractedRaceId,
             attributes: { ...(existing.attributes as Record<string, unknown>), ...(group.identity ? { identity: group.identity } : {}) },
             firstChapterId: existing.firstChapterId as string | null ?? group.firstChapterId
-          });
+          }, "ai", taskId ?? null, "全书角色抽取及身份二次确认");
           characterIds.push(String(updated.id));
         } else {
           const created = this.store.createCharacter(workId, {
@@ -2974,14 +3252,21 @@ export class AiManager {
     }
     return {
       characterIds: [...new Set(characterIds)],
-      candidateCount: groups.length,
+      candidateCount: mergedGroups.size,
       savedCount: new Set(characterIds).size,
       skipped,
       batchCount: chunks.length,
       coveredChapterCount: chapters.length,
       fallbackSegmentCount,
       policyOmittedSegmentCount,
-      callIds
+      callIds,
+      verification: {
+        pairCount: verificationPairs.size,
+        confirmedSameCount,
+        confirmedSeparateCount,
+        unresolvedCount,
+        callId: verificationCallId
+      }
     };
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1221,7 +1221,10 @@ export function createRuntime(options: RuntimeOptions): Runtime {
 
   app.get("/api/works/:workId/tasks", (request, response) => {
     const pagination = parsePagination(request.query);
-    data(response, pagination ? store.listTasksPage(request.params.workId, pagination) : store.listTasks(request.params.workId));
+    const summary = request.query.view === "summary";
+    data(response, pagination
+      ? (summary ? store.listTaskSummariesPage(request.params.workId, pagination) : store.listTasksPage(request.params.workId, pagination))
+      : store.listTasks(request.params.workId));
   });
   app.post("/api/works/:workId/tasks", (request, response) => {
     const input = parse(z.object({ taskType: z.enum(["structure", "chapter-analysis", "character-extraction", "character-summary", "character-identity-audit", "timeline-analysis", "relationship-analysis", "worldview-analysis", "setting-extraction", "consistency-check", "report-update", "book-analysis"]), scope: jsonObject.optional() }), request.body);

--- a/src/database.ts
+++ b/src/database.ts
@@ -1527,6 +1527,12 @@ export class Database {
       const foreignKeys = this.all("PRAGMA foreign_key_check");
       if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
     }
+    if (!applied.has(36)) {
+      this.transaction(() => {
+        this.run("CREATE INDEX IF NOT EXISTS idx_tasks_work_created ON analysis_tasks(work_id, created_at DESC, id DESC)");
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (36, ?)", new Date().toISOString());
+      });
+    }
   }
 
   private normalizeCharacterName(value: string): string {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -3019,7 +3019,7 @@ async function renderReviews() {
 
 async function renderTasks() {
   const [tasks, settings] = await Promise.all([
-    apiPage(`/api/works/${state.work.id}/tasks`).then((result) => result.items),
+    apiPage(`/api/works/${state.work.id}/tasks?view=summary`).then((result) => result.items),
     canReadModule("ai-settings")
       ? api(`/api/works/${state.work.id}/ai-settings`)
       : Promise.resolve({ autoRunEnabled: false, autoRunConcurrency: 2, autoRunBatchLimit: 20 })
@@ -3090,9 +3090,13 @@ async function renderTasks() {
     }
   });
 
-  const taskById = new Map(tasks.map((item) => [item.id, item]));
   $("#module-content").querySelectorAll("[data-task-detail]").forEach((button) => button.addEventListener("click", () => {
-    openTaskDetailDialog(taskById.get(button.dataset.taskDetail));
+    if (button.disabled) return;
+    button.disabled = true;
+    api(`/api/tasks/${encodeURIComponent(button.dataset.taskDetail)}`)
+      .then((task) => openTaskDetailDialog(task))
+      .catch((error) => toast(error.message, "error"))
+      .finally(() => { button.disabled = false; });
   }));
   $("#module-content").querySelectorAll("[data-run-task]").forEach((button) => button.addEventListener("click", async () => {
     const workId = state.work.id;

--- a/src/store.ts
+++ b/src/store.ts
@@ -5112,14 +5112,39 @@ export class Store {
 
   listTasks(workId: string): Record<string, unknown>[] {
     this.getWork(workId);
-    return this.db.all("SELECT * FROM analysis_tasks WHERE work_id = ? ORDER BY created_at DESC", workId).map((row) => this.mapTask(row));
+    return this.db.all("SELECT * FROM analysis_tasks WHERE work_id = ? ORDER BY created_at DESC, id DESC", workId).map((row) => this.mapTask(row));
   }
 
   listTasksPage(workId: string, pagination: Pagination): PaginatedResult<Record<string, unknown>> {
     this.getWork(workId);
     const page = paginationSql(pagination);
-    const rows = this.db.all(`SELECT * FROM analysis_tasks WHERE work_id = ? ORDER BY created_at DESC${page.sql}`, workId, ...page.params);
+    const rows = this.db.all(`SELECT * FROM analysis_tasks WHERE work_id = ? ORDER BY created_at DESC, id DESC${page.sql}`, workId, ...page.params);
     return paginated(rows.map((row) => this.mapTask(row)), pagination);
+  }
+
+  listTaskSummariesPage(workId: string, pagination: Pagination): PaginatedResult<Record<string, unknown>> {
+    this.getWork(workId);
+    const page = paginationSql(pagination);
+    const rows = this.db.all(
+      `SELECT id, work_id, task_type, scope_json, status, progress, created_at, updated_at
+       FROM analysis_tasks WHERE work_id = ? ORDER BY created_at DESC, id DESC${page.sql}`,
+      workId,
+      ...page.params
+    );
+    const chapterSummaries = new Map(this.db.all(
+      `SELECT chapter.id, chapter.title, volume.title AS volume_title
+       FROM chapters chapter JOIN volumes volume ON volume.id = chapter.volume_id
+       WHERE chapter.work_id = ?`,
+      workId
+    ).map((row) => [
+      requiredString(row, "id"),
+      `${requiredString(row, "volume_title")} · ${requiredString(row, "title")}`
+    ] as const));
+    const volumeTitles = new Map(this.db.all(
+      "SELECT id, title FROM volumes WHERE work_id = ?",
+      workId
+    ).map((row) => [requiredString(row, "id"), requiredString(row, "title")] as const));
+    return paginated(rows.map((row) => this.mapTaskSummary(row, chapterSummaries, volumeTitles)), pagination);
   }
 
   getTask(taskId: string): Record<string, unknown> {
@@ -5232,6 +5257,31 @@ export class Store {
       createdAt: requiredString(row, "created_at"),
       updatedAt: requiredString(row, "updated_at")
     };
+  }
+
+  private mapTaskSummary(row: Row, chapterSummaries: Map<string, string>, volumeTitles: Map<string, string>): Record<string, unknown> {
+    const scope = json<Record<string, unknown>>(requiredString(row, "scope_json"), {});
+    return {
+      id: requiredString(row, "id"),
+      workId: requiredString(row, "work_id"),
+      taskType: requiredString(row, "task_type"),
+      scope,
+      scopeSummary: this.taskScopeSummaryFromMaps(scope, chapterSummaries, volumeTitles),
+      status: requiredString(row, "status"),
+      progress: numberValue(row, "progress"),
+      createdAt: requiredString(row, "created_at"),
+      updatedAt: requiredString(row, "updated_at")
+    };
+  }
+
+  private taskScopeSummaryFromMaps(scope: Record<string, unknown>, chapterSummaries: Map<string, string>, volumeTitles: Map<string, string>): string {
+    if (typeof scope.chapterId === "string") return chapterSummaries.get(scope.chapterId) ?? "章节已删除";
+    if (scope.type === "volume" && typeof scope.volumeId === "string") {
+      const title = volumeTitles.get(scope.volumeId);
+      return title ? `分卷 · ${title}` : "分卷已删除";
+    }
+    if (scope.type === "book" || Object.keys(scope).length === 0) return "全书";
+    return "未指定范围";
   }
 
   private taskScopeSummary(workId: string, scope: Record<string, unknown>): string {

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -468,6 +468,113 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     expect((byName.get("沈星") as { aliases: string[] }).aliases).toEqual(["沈博士"]);
   });
 
+  it("角色职称变体在落库前经 AI 确认同一人后合并", async () => {
+    let verificationCalls = 0;
+    fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { messages: Array<{ content?: string }> };
+      const prompt = body.messages[1]?.content ?? "";
+      const chapters = [...prompt.matchAll(/<CHAPTER id="([^"]+)" title="([^"]+)"[^>]*>/gu)];
+      if (prompt.includes("第二次身份确认")) {
+        verificationCalls += 1;
+        expect(prompt).toContain("candidate:0|candidate:1");
+        return new Response(JSON.stringify({ choices: [{ message: { content: `<json>${JSON.stringify([{
+          pairKey: "candidate:0|candidate:1",
+          verdict: "same",
+          confidence: 0.96,
+          reason: "正文中的马克博士是马克的职称称呼，身份和行动连续。"
+        }])}</json>` } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      const chapter = chapters[0];
+      return new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify([
+        { canonicalName: "马克", aliases: [], identity: "帝王组织研究员", firstEvidence: { chapterId: chapter?.[1], chapterTitle: chapter?.[2], quote: "马克在实验室" } },
+        { canonicalName: "马克博士", aliases: [], identity: "帝王组织研究员", firstEvidence: { chapterId: chapter?.[1], chapterTitle: chapter?.[2], quote: "马克博士说" } }
+      ]) } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    runtime = createTestRuntime(fetchMock);
+    const { workId, chapters } = await seedWork(runtime);
+    await request(runtime.app).patch(`/api/chapters/${chapters[0].id}`).send({
+      content: "马克在实验室记录数据。马克博士说：实验已经完成。"
+    }).expect(200);
+    const modelId = await configureAi(runtime, workId);
+    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({ taskType: "character-extraction", scope: { type: "book" } }).expect(201);
+    const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
+    expect(result.body.data.result).toMatchObject({
+      savedCount: 1,
+      candidateCount: 1,
+      verification: { pairCount: 1, confirmedSameCount: 1, confirmedSeparateCount: 0, unresolvedCount: 0 }
+    });
+    expect(verificationCalls).toBe(1);
+    const characters = await request(runtime.app).get(`/api/works/${workId}/characters`).expect(200);
+    expect(characters.body.data).toHaveLength(1);
+    expect(characters.body.data[0]).toMatchObject({ name: "马克", aliases: ["马克博士"] });
+  });
+
+  it("角色职称变体未通过二次确认时不落库", async () => {
+    fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { messages: Array<{ content?: string }> };
+      const prompt = body.messages[1]?.content ?? "";
+      if (prompt.includes("第二次身份确认")) {
+        return new Response(JSON.stringify({ choices: [{ message: { content: `<json>${JSON.stringify([{
+          pairKey: "candidate:0|candidate:1",
+          verdict: "uncertain",
+          confidence: 0.55,
+          reason: "原文不足以确认两种称呼是否属于同一人。"
+        }])}</json>` } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      const chapter = [...prompt.matchAll(/<CHAPTER id="([^"]+)" title="([^"]+)"[^>]*>/gu)][0];
+      return new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify([
+        { canonicalName: "马克", aliases: [], identity: "研究员", firstEvidence: { chapterId: chapter?.[1], chapterTitle: chapter?.[2], quote: "马克在实验室" } },
+        { canonicalName: "马克博士", aliases: [], identity: "研究员", firstEvidence: { chapterId: chapter?.[1], chapterTitle: chapter?.[2], quote: "马克博士说" } }
+      ]) } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    runtime = createTestRuntime(fetchMock);
+    const { workId, chapters } = await seedWork(runtime);
+    await request(runtime.app).patch(`/api/chapters/${chapters[0].id}`).send({
+      content: "马克在实验室记录数据。马克博士说：实验已经完成。"
+    }).expect(200);
+    const modelId = await configureAi(runtime, workId);
+    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({ taskType: "character-extraction", scope: { type: "book" } }).expect(201);
+    const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
+    expect(result.body.data.result).toMatchObject({
+      savedCount: 0,
+      verification: { pairCount: 1, confirmedSameCount: 0, confirmedSeparateCount: 0, unresolvedCount: 1 }
+    });
+    expect(result.body.data.result.skipped[0].reason).toContain("二次确认未通过");
+    const characters = await request(runtime.app).get(`/api/works/${workId}/characters`).expect(200);
+    expect(characters.body.data).toEqual([]);
+  });
+
+  it("角色职称变体命中已有角色时经确认后只更新原档案", async () => {
+    fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { messages: Array<{ content?: string }> };
+      const prompt = body.messages[1]?.content ?? "";
+      if (prompt.includes("第二次身份确认")) {
+        const pairKey = prompt.match(/"pairKey":"([^"]+)"/u)?.[1] ?? "";
+        return new Response(JSON.stringify({ choices: [{ message: { content: `<json>${JSON.stringify([{
+          pairKey,
+          verdict: "same",
+          confidence: 0.94,
+          reason: "带职称的称呼与已有角色的身份和原文证据一致。"
+        }])}</json>` } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      const chapter = [...prompt.matchAll(/<CHAPTER id="([^"]+)" title="([^"]+)"[^>]*>/gu)][0];
+      return new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify([
+        { canonicalName: "马克博士", aliases: [], identity: "帝王组织研究员", firstEvidence: { chapterId: chapter?.[1], chapterTitle: chapter?.[2], quote: "马克博士说" } }
+      ]) } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    runtime = createTestRuntime(fetchMock);
+    const { workId, chapters } = await seedWork(runtime);
+    const existing = await request(runtime.app).post(`/api/works/${workId}/characters`).send({ name: "马克" }).expect(201);
+    await request(runtime.app).patch(`/api/chapters/${chapters[0].id}`).send({ content: "马克博士说：实验已经完成。" }).expect(200);
+    const modelId = await configureAi(runtime, workId);
+    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({ taskType: "character-extraction", scope: { type: "book" } }).expect(201);
+    const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
+    expect(result.body.data.result).toMatchObject({ savedCount: 1, verification: { pairCount: 1, confirmedSameCount: 1 } });
+    const characters = await request(runtime.app).get(`/api/works/${workId}/characters`).expect(200);
+    expect(characters.body.data).toHaveLength(1);
+    expect(characters.body.data[0]).toMatchObject({ id: existing.body.data.id, name: "马克", aliases: ["马克博士"] });
+  });
+
   it("取消运行中的分批任务后不会被后台结果改回完成状态", async () => {
     let requestStarted = false;
     fetchMock = vi.fn<typeof fetch>((_input, init) => new Promise<Response>((_resolve, reject) => {

--- a/tests/integration/task-auto-run.test.ts
+++ b/tests/integration/task-auto-run.test.ts
@@ -126,6 +126,20 @@ describe("分析任务自动运行", () => {
       scopeSummary: expect.stringContaining("第一卷"),
       scopeDetails: expect.any(Array)
     }));
+
+    const summaries = await request(runtime.app).get(`/api/works/${workId}/tasks?view=summary&page=1&limit=5`).expect(200);
+    expect(summaries.body.data.items).toHaveLength(5);
+    expect(summaries.body.data.items[0]).toEqual(expect.objectContaining({
+      id: expect.stringMatching(/^task_/u),
+      scopeSummary: expect.stringContaining("第一卷")
+    }));
+    expect(summaries.body.data.items[0]).not.toHaveProperty("result");
+    expect(summaries.body.data.items[0]).not.toHaveProperty("scopeDetails");
+    const detail = await request(runtime.app).get(`/api/tasks/${summaries.body.data.items[0].id}`).expect(200);
+    expect(detail.body.data).toEqual(expect.objectContaining({
+      result: expect.anything(),
+      scopeDetails: expect.any(Array)
+    }));
   });
 
   it("开启自动运行后遵守并发与单次上限", async () => {

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -68,7 +68,7 @@ describe("数据库版本化迁移", () => {
       { display_name: "Mothra", kind: "alias" },
       { display_name: "拉顿", kind: "primary" }
     ]);
-    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }, { version: 4 }, { version: 5 }, { version: 6 }, { version: 7 }, { version: 8 }, { version: 9 }, { version: 10 }, { version: 11 }, { version: 12 }, { version: 13 }, { version: 14 }, { version: 15 }, { version: 16 }, { version: 17 }, { version: 18 }, { version: 19 }, { version: 20 }, { version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }, { version: 26 }, { version: 27 }, { version: 28 }, { version: 29 }, { version: 30 }, { version: 31 }, { version: 32 }, { version: 33 }, { version: 34 }, { version: 35 }]);
+    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }, { version: 4 }, { version: 5 }, { version: 6 }, { version: 7 }, { version: 8 }, { version: 9 }, { version: 10 }, { version: 11 }, { version: 12 }, { version: 13 }, { version: 14 }, { version: 15 }, { version: 16 }, { version: 17 }, { version: 18 }, { version: 19 }, { version: 20 }, { version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }, { version: 26 }, { version: 27 }, { version: 28 }, { version: 29 }, { version: 30 }, { version: 31 }, { version: 32 }, { version: 33 }, { version: 34 }, { version: 35 }, { version: 36 }]);
     expect(first.all("PRAGMA table_info(characters)").map((column) => column.name)).toEqual(expect.arrayContaining(["merged_into_character_id", "merged_at"]));
     expect(first.get("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'character_merges'")?.name).toBe("character_merges");
     expect(first.all("PRAGMA table_info(works)").some((column) => column.name === "owner_user_id")).toBe(true);
@@ -91,6 +91,7 @@ describe("数据库版本化迁移", () => {
     expect(first.all("SELECT name, description FROM races")).toEqual([{ name: "泰坦族", description: "由旧人物种族字段迁移生成" }]);
     expect(first.get("SELECT parent_race_id FROM races WHERE id = 'race_migration_1'")?.parent_race_id).toBeNull();
     expect(first.all("PRAGMA index_list(races)").some((index) => index.name === "idx_races_parent")).toBe(true);
+    expect(first.all("PRAGMA index_list(analysis_tasks)").some((index) => index.name === "idx_tasks_work_created")).toBe(true);
     expect(first.get("SELECT race_id FROM characters WHERE id = 'character-a'")?.race_id).toBe("race_migration_1");
     expect(first.get("SELECT race_id FROM characters WHERE id = 'character-b'")?.race_id).toBeNull();
     expect(first.all("SELECT character_id, version_no, source, change_note FROM character_versions ORDER BY character_id")).toEqual([


### PR DESCRIPTION
## 变更内容

- 优化 AI 分析任务列表，仅加载轻量摘要，详情按需加载，并移除任务范围摘要的 N+1 查询。
- 为角色抽取增加职称变体检测，识别 `X / X博士`、`X / X教授` 等疑似重复组合。
- 疑似组合在落库前统一调用 AI 二次确认：确认同一人则合并，确认不同人则分别写入，无法确认则跳过写入。
- 新增任务分页索引，并将性能索引迁移顺延到版本 36，兼容 develop 的现有迁移 34/35。

## 修复原因

角色抽取按章节分批执行，原本只按完全相同的名字或别名合并，导致 `X` 和 `X博士` 可能被落成两个角色档案。任务列表也会加载完整分析结果，造成 AI 分析页面性能问题。

## 验证

- `npm run check`
- 58 个测试文件、287 个测试通过
- 类型检查和生产构建通过
