### PR TITLE
fix(ui): allow no-context chat without chapter

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -3379,17 +3379,19 @@ let aiContextUsageTimer = null;
 let aiContextUsageRequest = 0;
 
 function currentAiRequestScope() {
-  if (!state.work || !state.chapter) return null;
+  if (!state.work) return null;
   const taskType = $("#ai-task").value;
   const scopeType = $("#ai-scope").value;
-  const selection = $("#chapter-content").value.slice($("#chapter-content").selectionStart, $("#chapter-content").selectionEnd);
-  const volume = state.work.volumes.find((item) => item.id === state.chapter.volumeId);
+  const requiresChapter = taskType === "polish" || taskType === "continue" || scopeType !== "none";
+  if (requiresChapter && !state.chapter) return null;
+  const selection = state.chapter ? $("#chapter-content").value.slice($("#chapter-content").selectionStart, $("#chapter-content").selectionEnd) : "";
+  const volume = state.chapter ? state.work.volumes.find((item) => item.id === state.chapter.volumeId) : null;
   const includeBookSummary = scopeType === "chapter-summary";
-  const scope = taskType === "polish" ? { type: "chapter", chapterId: state.chapter.id, selection }
-    : scopeType === "none" ? { type: "none", ...(taskType === "continue" ? { chapterId: state.chapter.id } : {}) }
+  const scope = taskType === "polish" ? { type: "chapter", chapterId: state.chapter?.id, selection }
+    : scopeType === "none" ? { type: "none", ...(taskType === "continue" && state.chapter ? { chapterId: state.chapter.id } : {}) }
     : scopeType === "book" ? { type: "book" }
     : scopeType === "volume" ? { type: "volume", volumeId: volume?.id }
-    : { type: "chapter", chapterId: state.chapter.id };
+    : { type: "chapter", chapterId: state.chapter?.id };
   Object.assign(scope, buildAiReferenceScope(state.aiReferences));
   if (includeBookSummary) scope.includeBookSummary = true;
   return { taskType, scope, selection };
@@ -4923,7 +4925,7 @@ function openModelDialog(providerId, item = null) {
 }
 
 async function sendAi() {
-  if (!state.work || !state.chapter) return toast("请先选择章节", "error");
+  if (!state.work) return toast("请先选择作品", "error");
   try {
     await Promise.all([ensureAiModelsLoaded(), ensureAiConversationsLoaded()]);
   } catch (error) {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -653,6 +653,6 @@
     </dialog>
 
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
-    <script type="module" src="/app.js?v=20260723-knowledge-editor-5"></script>
+    <script type="module" src="/app.js?v=20260723-knowledge-editor-6"></script>
   </body>
 </html>

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -240,7 +240,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('id="platform-ai-button"');
     expect(page.text).toContain('rel="icon" href="/icon.svg?v=20260712"');
     expect(page.text).toContain('rel="manifest" href="/site.webmanifest"');
-    expect(page.text).toContain('/app.js?v=20260723-knowledge-editor-5');
+    expect(page.text).toContain('/app.js?v=20260723-knowledge-editor-6');
     expect(page.text).toContain('/styles.css?v=20260723-knowledge-editor-5');
     expect(application.text).toContain('/relationship-graph.js?v=20260721-release-0.3.6');
     expect(graph.text).toContain('path.setAttribute("marker-end", `url(#${arrowMarkerId})`)');

--- a/tests/system/book-summary-reference.test.ts
+++ b/tests/system/book-summary-reference.test.ts
@@ -26,11 +26,13 @@ describe("全书概要上下文引用", () => {
     expect(page.text).toContain('<option value="chapter-summary">当前章节 + 全书概要</option>');
     expect(page.text).not.toContain('<option value="selection">选中文本</option>');
     expect(page.text).not.toContain('id="ai-book-summary-reference"');
-    expect(page.text).toContain('/app.js?v=20260723-knowledge-editor-5');
+    expect(page.text).toContain('/app.js?v=20260723-knowledge-editor-6');
     expect(application.text).toContain('id="save-agent-tools"');
     expect(application.text).toContain('class="book-summary-context-percent-field"');
     expect(application.text).toContain('class="ai-agent-tools"');
     expect(application.text).toContain('const includeBookSummary = scopeType === "chapter-summary";');
+    expect(application.text).toContain('const requiresChapter = taskType === "polish" || taskType === "continue" || scopeType !== "none";');
+    expect(application.text).toContain('if (!state.work) return toast("请先选择作品", "error");');
     expect(application.text).toContain('scopeType === "none" ? { type: "none"');
     expect(application.text).toContain("if (includeBookSummary) scope.includeBookSummary = true;");
     expect(application.text).toContain('body.append("expectedVersionNo", String(state.work.versionNo));');


### PR DESCRIPTION
## Summary

- Allow chat messages to be sent when the context scope is “无上下文” and no chapter is selected.
- Keep chapter validation for续写、润色 and chapter/volume/book context scopes.
- Update the frontend asset cache version and add regression assertions.

## Root cause

The frontend required `state.chapter` before building every AI request scope, so a chat request with “无上下文” was rejected before reaching the API.

## Validation

- `npm run typecheck`
- `npm test` — 59 test files, 295 tests passed
- `npm run build`
- Isolated browser E2E verified sending from a 0-chapter work with “问答 + 无上下文” and receiving the model response.