### PR TITLE
fix(knowledge): preserve large legacy settings

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -44,6 +44,7 @@ const jsonObject = z.record(z.string(), z.unknown());
 const chapterTypeSchema = z.enum(["正文", "设定", "作者的话", "其他"]);
 const versionedEntityTypeSchema = z.enum(versionedEntityTypes);
 const maximumImportedTextLength = 20_000_000;
+const maximumKnowledgeSectionsLength = 4_000_000;
 
 const captchaFields = {
   captchaId: z.string().trim().min(1).max(200),
@@ -231,7 +232,9 @@ const knowledgeSectionSchema = z.object({
 
 const knowledgeSectionsSchema = knowledgeSectionSchema.array().max(200).superRefine((sections, context) => {
   const totalLength = sections.reduce((total, section) => total + (section.contentMarkdown?.length ?? 0) + (section.summary?.length ?? 0), 0);
-  if (totalLength > 200_000) context.addIssue({ code: z.ZodIssueCode.custom, message: "Markdown 章节总长度不能超过 200000 个字符" });
+  if (totalLength > maximumKnowledgeSectionsLength) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Markdown 章节总长度不能超过 4000000 个字符" });
+  }
 });
 
 const organizationSchema = z.object({

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -201,6 +201,39 @@ describe("书架、别名、大纲伏笔和一致性守卫 API", () => {
     ]);
   });
 
+  it("允许旧版大体量种族和组织设定升级后继续保存", async () => {
+    const { workId } = await seedWork(runtime);
+    const legacySettings = Array.from({ length: 11 }, (_, index) => `## 旧设定 ${index + 1}\n\n${"旧".repeat(19_900)}`);
+    const legacyLength = legacySettings.reduce((total, item) => total + item.length, 0);
+    expect(legacyLength).toBeGreaterThan(200_000);
+
+    const race = await request(runtime.app).post(`/api/works/${workId}/races`).send({
+      name: "旧版大体量种族",
+      settings: legacySettings
+    }).expect(201);
+    const organization = await request(runtime.app).post(`/api/works/${workId}/organizations`).send({
+      name: "旧版大体量组织",
+      settings: legacySettings
+    }).expect(201);
+
+    const loadedRace = await request(runtime.app).get(`/api/races/${race.body.data.id}`).expect(200);
+    const updatedRace = await request(runtime.app).patch(`/api/races/${race.body.data.id}`).send({
+      name: "升级后的大体量种族",
+      settingsSections: loadedRace.body.data.settingsSections
+    }).expect(200);
+    expect(updatedRace.body.data.settings).toEqual(legacySettings);
+
+    const loadedOrganization = await request(runtime.app).get(`/api/organizations/${organization.body.data.id}`).expect(200);
+    const updatedOrganization = await request(runtime.app).patch(`/api/organizations/${organization.body.data.id}`).send({
+      name: "升级后的大体量组织",
+      settingsSections: loadedOrganization.body.data.settingsSections.map((section: Record<string, unknown>, index: number) => (
+        index === 0 ? { ...section, summary: "升级后补充摘要" } : section
+      ))
+    }).expect(200);
+    expect(updatedOrganization.body.data.settings).toEqual(legacySettings);
+    expect(updatedOrganization.body.data.settingsSections[0].summary).toBe("升级后补充摘要");
+  });
+
   it("先维护种族主数据，再由人物引用并与组织保持独立", async () => {
     const { workId } = await seedWork(runtime);
     const organization = await request(runtime.app).post(`/api/works/${workId}/organizations`).send({ name: "帝王组织" }).expect(201);


### PR DESCRIPTION
## 变更内容

- 将种族/组织 Markdown 章节总容量从 200,000 字符调整为 4,000,000 字符，与旧版 `settings` 合法容量保持一致
- 保留单章节、章节数量与输入结构限制，不截断任何旧数据
- 增加超过 200,000 字符的旧版种族和组织设定往返保存回归测试

## 根因

0.3.11 允许最多 200 条、每条 20,000 字符的种族/组织设定。迁移 36 会完整转换这些数据，但新 `settingsSections` 接口把所有章节合计限制为 200,000 字符。旧版合法的大档案因此升级后可读但无法保存。

## 用户影响

修复后，旧版合法上限内的大体量种族和组织档案可在 0.4.0 升级后继续修改名称、成员、章节和摘要，不需要删除既有资料。

## 验证

- `npx vitest run tests/integration/feature-suite-api.test.ts --maxWorkers=1`：34 项通过
- `npm run typecheck`
- `npm run check`：61 个测试文件、307 项测试通过，生产构建通过
- `git diff --check`
