### PR TITLE
build(release): bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.3.11",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.3.11";
+export const APP_VERSION = "0.4.0";


### PR DESCRIPTION
## 版本变更

- 将 npm 包版本从 `0.3.11` 升级到 `0.4.0`
- 同步更新 lockfile 根包版本
- 将服务端与 CLI 暴露的 `APP_VERSION` 更新为 `0.4.0`

## 发布范围

本次次版本发布包含 Vditor 编辑器、种族/组织长篇档案、知识模块布局切换、AI 对话与分析权限拆分、AI 供应商兼容、导入交互与权限增强、任务列表性能优化，以及发布前兼容性审查发现的大体量旧设定升级修复。

## 验证

- `npm run check`：61 个测试文件、307 项测试通过
- 生产构建通过
- `npm pack --dry-run --json`：包版本为 `0.4.0`，Vditor CSS、JS 与图标资源均包含在 tarball
- `git diff --check`