### PR TITLE
fix(docker): complete arm64 dependency lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,29 @@
         "node": ">=22.5.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",

--- a/tests/unit/docker-package-manifests.test.ts
+++ b/tests/unit/docker-package-manifests.test.ts
@@ -12,6 +12,16 @@ afterEach(() => {
 });
 
 describe("Docker 依赖清单规范化", () => {
+  it("保留 Linux ARM64 干净安装所需的跨平台可选依赖", () => {
+    const lock = JSON.parse(readFileSync(new URL("../../package-lock.json", import.meta.url), "utf8")) as {
+      packages: Record<string, { version?: string; dependencies?: Record<string, string> }>;
+    };
+
+    expect(lock.packages["node_modules/@img/sharp-wasm32"]?.dependencies).toHaveProperty("@emnapi/runtime");
+    expect(lock.packages["node_modules/@emnapi/runtime"]?.version).toBe("1.11.2");
+    expect(lock.packages["node_modules/@emnapi/core"]?.version).toBe("1.11.2");
+  });
+
   it("只移除会随发版变化的根包版本并固定文件时间", () => {
     const directory = mkdtempSync(join(tmpdir(), "scriverse-docker-manifests-"));
     temporaryDirectories.push(directory);


### PR DESCRIPTION
## 变更内容

- 补全 Linux ARM64 干净安装所需的 `@emnapi/core` 与 `@emnapi/runtime` lockfile 条目
- 增加跨平台可选依赖回归断言，防止后续在 macOS 更新 lockfile 时再次遗漏

## 根因

macOS 上生成的 lockfile 保留了 Sharp 的跨平台包，但缺少其中 WASM 路径在 Linux ARM64 上解析的根级 Emscripten N-API 依赖。本地 macOS `npm ci` 和常规测试不会安装该平台路径，因此只有真实双架构 Docker 构建能复现。

## 影响

修复前，0.4.0 的 Docker 发布工作流会在 `linux/arm64` 的 `npm ci` 阶段失败；修复后 amd64 与 arm64 的开发依赖、生产依赖和 TypeScript 构建均完成。

## 验证

- 首次双架构构建真实复现 `Missing: @emnapi/runtime@1.11.2` 与 `@emnapi/core@1.11.2`
- 修复后 `docker buildx build --platform linux/amd64,linux/arm64 --output=type=cacheonly .` 通过
- `npx vitest run tests/unit/docker-package-manifests.test.ts --maxWorkers=1`：3 项通过
- `npm run check`：61 个测试文件、308 项测试通过，生产构建通过
- `git diff --check`
