### PR TITLE
docs(readme): improve documentation navigation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">中文</a> | <a href="README.en.md">English</a>
+  <a href="README.md">中文</a> | English
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">中文</a> | <a href="README.en.md">English</a>
+  中文 | <a href="README.en.md">English</a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ npm start
 
 ## AI 供应商配置
 
+配置前请先阅读 [AI 供应商兼容性与配置指南](docs/AI-PROVIDER-COMPATIBILITY.md)，其中列出了已验证的服务商、基础地址、模型标识符和已知差异。
+
 1. 启动项目后，点击顶部“AI 管理”进入平台级配置。
 2. 新建兼容 OpenAI Chat Completions 的供应商，填写基础地址、API 密钥、并发数、RPM 与最大输出 Token。
 3. 为模型填写其支持的上下文总量（Token），再添加模型。


### PR DESCRIPTION
## 变更内容

- 在中文 README 的 AI 供应商配置章节引用兼容性与配置指南
- 在中英文 README 的语言切换中移除当前语言的自链接

## 原因与影响

AI 配置指南此前缺少主 README 入口，读者不易发现；语言切换同时链接当前页面也会造成无意义跳转。调整后，配置指南更容易被找到，语言入口也能明确表示当前语言。

## 验证

- `npm run check`
- 类型检查通过
- 62 个测试文件、311 个测试通过
- 生产构建通过
