### PR TITLE
build(release): bump version to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.0";
+export const APP_VERSION = "0.4.1";


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本从 0.4.0 更新为 0.4.1
- 同步 package-lock.json 根包版本
- 同步运行时 APP_VERSION

## 发布目的

为 develop 当前已完成并验证的功能、修复和协作者权限改进准备补丁版本发布。

## 验证

- npm run check：63 个测试文件、313 个测试通过
- TypeScript 类型检查和生产构建通过
- npm pack --dry-run 通过，包版本为 0.4.1
- SQLite integrity_check 和 foreign_key_check 通过