### PR TITLE
build(release): bump version to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.1";
+export const APP_VERSION = "0.4.2";


### PR DESCRIPTION
## Release preparation

Bump Scriverse from `0.4.1` to `0.4.2` after all UI fixes landed in `develop`.

Updated version sources:

- `package.json`
- `package-lock.json`
- `src/version.ts`

## Validation

- `npm run check`
- 64 test files / 320 tests passed
- production build passed
- local health endpoint reports `0.4.2`
- SQLite integrity and foreign-key checks passed
