### PR TITLE
build(release): bump version to 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.2";
+export const APP_VERSION = "0.4.3";


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本从 `0.4.2` 更新为 `0.4.3`
- 同步应用运行时版本常量和 lockfile 根包版本

## 发布影响

这是补丁版本发布提交，不包含额外功能或数据库迁移。合入 `develop` 后将通过 `develop → main` 发布 PR 发布。

## 验证

- `npm run check`
- 66 个测试文件、325 项测试通过
- TypeScript 类型检查和生产构建通过