### PR TITLE
build(release): bump version to 0.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.3";
+export const APP_VERSION = "0.4.4";


### PR DESCRIPTION
## 变更

将项目补丁版本从 0.4.3 升至 0.4.4，同步更新 package manifest、lockfile 和运行时版本常量。

## 验证

- npm run typecheck
- npm run test:system -- --run tests/system/product-footer.test.ts
- npm run build