### PR TITLE
build(release): release v0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",


### PR DESCRIPTION
发布补丁版本 v0.4.6。

- 将 package.json 与 package-lock.json 版本从 0.4.5 更新为 0.4.6
- 已通过 npm run typecheck