### PR TITLE
fix(showcase): merge corrected demo link into main

### DIFF
--- a/showcase/app/demo/page.tsx
+++ b/showcase/app/demo/page.tsx
@@ -1,7 +1,0 @@
-import { redirect } from "next/navigation";
-
-const demoUrl = "https://showcase.scriverse.top/";
-
-export default function DemoPage() {
-  redirect(demoUrl);
-}

--- a/showcase/app/page.tsx
+++ b/showcase/app/page.tsx
@@ -506,7 +506,7 @@ export default function Home() {
       <header className="site-header">
         <Brand />
         <nav aria-label="主导航"><ScrollLink targetId="workspace">工作台</ScrollLink><ScrollLink targetId="abilities">能力</ScrollLink><ScrollLink targetId="relationships">关系图</ScrollLink><ScrollLink targetId="galaxy">银河图</ScrollLink></nav>
-        <a className="header-cta" href="/demo">在线体验 <span>↗</span></a>
+        <a className="header-cta" href="https://showcase.scriverse.top/">在线体验 <span>↗</span></a>
       </header>
 
       <section className="hero">
@@ -514,7 +514,7 @@ export default function Home() {
           <span className="eyebrow">LOCAL-FIRST AI WRITING STUDIO</span>
           <h1>让宏大的故事，<br />始终<span>有迹可循。</span></h1>
           <p>叙界是为长篇小说而生的本地 AI 创作工作台。正文、世界观、人物关系、时间线与每一次灵感，都在同一个叙事系统里彼此关联。</p>
-          <div className="hero-actions"><a className="primary-link" href="/demo">打开演示站 <span>↗</span></a><ScrollLink className="text-link" targetId="relationships">探索人物图谱 <span>↓</span></ScrollLink></div>
+          <div className="hero-actions"><ScrollLink className="primary-link" targetId="workspace">进入叙界世界</ScrollLink><ScrollLink className="text-link" targetId="relationships">探索人物图谱 <span>↓</span></ScrollLink></div>
         </div>
         <div className="hero-orbit" aria-hidden="true">
           <div className="orbit-ring ring-one" /><div className="orbit-ring ring-two" /><div className="orbit-ring ring-three" />

--- a/showcase/tests/rendered-html.test.mjs
+++ b/showcase/tests/rendered-html.test.mjs
@@ -3,11 +3,11 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { shouldRenderGalaxyLabel } from "../app/galaxy-visibility.js";
 
-async function render(path = "/") {
+async function render() {
   const workerUrl = new URL("../dist/server/index.js", import.meta.url);
   workerUrl.searchParams.set("test", `${process.pid}-${Date.now()}`);
   const { default: worker } = await import(workerUrl.href);
-  return worker.fetch(new Request(`http://localhost${path}`, { headers: { accept: "text/html" } }), {
+  return worker.fetch(new Request("http://localhost", { headers: { accept: "text/html" } }), {
     ASSETS: { fetch: async () => new Response("Not found", { status: 404 }) },
   }, { waitUntil() {}, passThroughOnException() {} });
 }
@@ -22,15 +22,11 @@ test("服务端渲染叙界介绍页", async () => {
   assert.match(html, /人物关系/);
   assert.match(html, /银河图/);
   assert.match(html, /AI 创作助手/);
-  assert.match(html, /href="\/demo"[^>]*>在线体验/);
-  assert.match(html, /href="\/demo"[^>]*>打开演示站/);
+  assert.match(html, /href="https:\/\/showcase\.scriverse\.top\/"[^>]*>在线体验/);
+  assert.match(html, /data-scroll-target="workspace"[^>]*>进入叙界世界/);
+  assert.doesNotMatch(html, /打开演示站/);
+  assert.doesNotMatch(html, /href="\/demo"/);
   assert.doesNotMatch(html, /codex-preview|Your site is taking shape|react-loading-skeleton/);
-});
-
-test("演示入口跳转到独立 Demo 站点", async () => {
-  const response = await render("/demo");
-  assert.ok([307, 308].includes(response.status));
-  assert.equal(response.headers.get("location"), "https://showcase.scriverse.top/");
 });
 
 test("页内导航不写入 URL 哈希锚点", async () => {


### PR DESCRIPTION
## Summary

- merge the corrected introduction-site Demo link from `develop` into `main`
- remove the internal `/demo` route
- keep the Demo entry only in the top-right header and link directly to `https://showcase.scriverse.top/`

## Release handling

- do not create a Git tag
- do not create a GitHub Release
- do not perform manual deployment or package publication
