### PR TITLE
feat(showcase): restore github icon in header

### DIFF
--- a/showcase/app/globals.css
+++ b/showcase/app/globals.css
@@ -34,9 +34,13 @@ a { color: inherit; text-decoration: none; }
 .site-header nav .scroll-link { position: relative; }
 .site-header nav .scroll-link::after { position: absolute; right: 0; bottom: -8px; left: 0; height: 1px; transform: scaleX(0); background: var(--accent); content: ""; transition: transform .2s ease; }
 .site-header nav .scroll-link:hover::after, .site-header nav .scroll-link:focus-visible::after { transform: scaleX(1); }
-.header-cta { justify-self: end; padding: 10px 14px; border: 1px solid var(--line); border-radius: 4px; background: rgba(255,255,255,.35); font-size: 11px; }
+.header-actions { justify-self: end; display: inline-flex; align-items: center; gap: 10px; }
+.header-cta { padding: 10px 14px; border: 1px solid var(--line); border-radius: 4px; background: rgba(255,255,255,.35); font-size: 11px; }
 .header-cta:hover { border-color: var(--accent); color: var(--accent-dark); }
 .header-cta span { margin-left: 10px; }
+.header-github { display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid var(--line); border-radius: 4px; background: rgba(255,255,255,.35); color: var(--ink); }
+.header-github:hover, .header-github:focus-visible { border-color: var(--accent); color: var(--accent-dark); }
+.header-github svg { width: 18px; height: 18px; display: block; }
 
 .hero { position: relative; display: grid; grid-template-columns: 1.05fr .95fr; min-height: calc(100vh - 72px); align-items: center; gap: 6vw; overflow: hidden; padding: 9vh clamp(24px, 8vw, 132px); background: radial-gradient(circle at 78% 42%, rgba(139,61,44,.08), transparent 27%), linear-gradient(90deg, transparent 49.9%, rgba(217,210,197,.48) 50%, transparent 50.1%); }
 .hero::before { position: absolute; inset: 0; opacity: .22; background-image: linear-gradient(rgba(37,35,31,.12) 1px, transparent 1px), linear-gradient(90deg, rgba(37,35,31,.12) 1px, transparent 1px); background-size: 64px 64px; mask-image: linear-gradient(to bottom, transparent, #000 20%, #000 75%, transparent); content: ""; pointer-events: none; }
@@ -134,7 +138,7 @@ a { color: inherit; text-decoration: none; }
 }
 
 @media (max-width: 760px) {
-  .site-header { height: 62px; padding: 0 18px; }.header-cta { padding: 8px 10px; }.header-cta > span { display: none; }
+  .site-header { height: 62px; padding: 0 18px; }.header-cta { padding: 8px 10px; }.header-cta > span { display: none; }.header-github { width: 34px; height: 34px; }.header-github svg { width: 16px; height: 16px; }
   .hero { min-height: auto; padding: 100px 24px 80px; background: radial-gradient(circle at 50% 70%, rgba(139,61,44,.09), transparent 30%); }.hero h1 { font-size: clamp(49px, 15vw, 70px); }.hero-copy > p { font-size: 14px; }.hero-actions { align-items: flex-start; flex-direction: column; gap: 20px; }.hero-orbit { width: 104vw; margin-left: -12vw; }.orbit-note { right: 5%; }.orbit-node { min-width: 50px; height: 50px; }
   .principles { grid-template-columns: 1fr; }.principles article { justify-content: flex-start; padding: 0 24px; }.principles article + article { border-top: 1px solid var(--line); border-left: 0; }
   .section, .graph-section { padding: 88px 22px; }.split-heading, .graph-heading { grid-template-columns: 1fr; gap: 28px; }.section-heading h2, .galaxy-heading h2 { font-size: 42px; }

--- a/showcase/app/page.tsx
+++ b/showcase/app/page.tsx
@@ -96,6 +96,17 @@ function Brand() {
   );
 }
 
+function GitHubIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 16 16">
+      <path
+        fill="currentColor"
+        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8"
+      />
+    </svg>
+  );
+}
+
 function RelationshipGraph() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const hostRef = useRef<HTMLDivElement>(null);
@@ -506,7 +517,18 @@ export default function Home() {
       <header className="site-header">
         <Brand />
         <nav aria-label="主导航"><ScrollLink targetId="workspace">工作台</ScrollLink><ScrollLink targetId="abilities">能力</ScrollLink><ScrollLink targetId="relationships">关系图</ScrollLink><ScrollLink targetId="galaxy">银河图</ScrollLink></nav>
-        <a className="header-cta" href="https://showcase.scriverse.top/">在线体验 <span>↗</span></a>
+        <div className="header-actions">
+          <a className="header-cta" href="https://showcase.scriverse.top/">在线体验 <span>↗</span></a>
+          <a
+            aria-label="在 GitHub 查看源代码"
+            className="header-github"
+            href="https://github.com/musnows/Scriverse"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <GitHubIcon />
+          </a>
+        </div>
       </header>
 
       <section className="hero">

--- a/showcase/tests/rendered-html.test.mjs
+++ b/showcase/tests/rendered-html.test.mjs
@@ -23,6 +23,9 @@ test("服务端渲染叙界介绍页", async () => {
   assert.match(html, /银河图/);
   assert.match(html, /AI 创作助手/);
   assert.match(html, /href="https:\/\/showcase\.scriverse\.top\/"[^>]*>在线体验/);
+  assert.match(html, /href="https:\/\/github\.com\/musnows\/Scriverse"/);
+  assert.match(html, /aria-label="在 GitHub 查看源代码"/);
+  assert.match(html, /class="[^"]*header-github[^"]*"/);
   assert.match(html, /data-scroll-target="workspace"[^>]*>进入叙界世界/);
   assert.doesNotMatch(html, /打开演示站/);
   assert.doesNotMatch(html, /href="\/demo"/);


### PR DESCRIPTION
## Summary
- 在 showcase 站点右上角加回指向 GitHub 仓库的图标按钮
- 保留「在线体验」入口，图标使用 GitHub Mark SVG（非文字）
- 补充 SSR HTML 回归断言

## Test plan
- [x] `cd showcase && npm test`
- [ ] 打开 showcase 首页，确认右上角有 GitHub 图标并可跳转仓库


Made with [Cursor](https://cursor.com)