### PR TITLE
build(release): release v0.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.6";
+export const APP_VERSION = "0.4.7";


### PR DESCRIPTION
## Summary
- Bump patch version from `0.4.6` to `0.4.7`
- Includes mobile workspace unification from #114

## Test plan
- [x] Version fields updated in `package.json`, `package-lock.json`, and `src/version.ts`
- [ ] Merge to develop, then promote to main and publish GitHub Release `v0.4.7`


Made with [Cursor](https://cursor.com)