### PR TITLE
perf(demo): cache homepage covers until content changes

### DIFF
--- a/demo/mock-api.js
+++ b/demo/mock-api.js
@@ -1,7 +1,7 @@
 import { analysisTasks, works as sourceWorks } from "./data.js";
 import { buildBrowserAiMessages, createBrowserAiStore, normalizeProviderBaseUrl, publicProvider, requestBrowserAi, testBrowserAiProvider } from "./browser-ai.js";
 import { DEMO_CREDENTIALS as demoCredentials, isValidDemoLogin } from "./demo-auth.js";
-import { DEMO_VERSION } from "./demo-version.js";
+import { DEMO_COVER_VERSIONS, DEMO_VERSION } from "./demo-version.js";
 
 const now = "2026-07-25T10:00:00.000Z";
 const nativeFetch = window.fetch.bind(window);
@@ -252,7 +252,7 @@ function buildWork(source) {
     description: source.synopsis,
     accessRole: "owner",
     modulePermissions: null,
-    coverUrl: `/demo-covers/${id}.webp`,
+    coverUrl: `/demo-covers/${id}.webp?v=${encodeURIComponent(DEMO_COVER_VERSIONS[id] ?? "0")}`,
     chapterCount: chapters.length,
     wordCount: wordTotal,
     versionNo: 1,

--- a/demo/scripts/build.mjs
+++ b/demo/scripts/build.mjs
@@ -1,5 +1,5 @@
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { demoAssetVersion, readMainVersion, versionModuleSource, versionedDemoAdapterSource } from "./version.mjs";
+import { demoAssetVersion, readDemoCoverVersions, readMainVersion, versionModuleSource, versionedDemoAdapterSource } from "./version.mjs";
 
 const demoSource = new URL("../", import.meta.url);
 const publicSource = new URL("../../src/public/", import.meta.url);
@@ -13,11 +13,12 @@ await cp(new URL("demo-auth.js", demoSource), new URL("demo-auth.js", output));
 await cp(new URL("browser-ai.js", demoSource), new URL("browser-ai.js", output));
 await cp(new URL("demo-covers/", demoSource), new URL("demo-covers/", output), { recursive: true });
 const mainVersion = await readMainVersion();
+const coverVersions = await readDemoCoverVersions();
 const adapter = await readFile(new URL("mock-api.js", demoSource), "utf8");
 const browserAi = await readFile(new URL("browser-ai.js", demoSource), "utf8");
 const adapterVersion = demoAssetVersion(`${adapter}\n${browserAi}`, mainVersion);
 await writeFile(new URL("mock-api.js", output), versionedDemoAdapterSource(adapter, mainVersion));
-await writeFile(new URL("demo-version.js", output), versionModuleSource(mainVersion));
+await writeFile(new URL("demo-version.js", output), versionModuleSource(mainVersion, coverVersions));
 
 const vditorSource = new URL("../node_modules/vditor/dist/", import.meta.url);
 await cp(vditorSource, new URL("vendor/vditor/dist/", output), { recursive: true });

--- a/demo/scripts/serve.mjs
+++ b/demo/scripts/serve.mjs
@@ -1,14 +1,16 @@
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
 import { extname, normalize, resolve } from "node:path";
-import { demoAssetVersion, readMainVersion, versionModuleSource, versionedDemoAdapterSource } from "./version.mjs";
+import { demoAssetVersion, demoCoverCacheControl, readDemoCoverVersions, readMainVersion, versionModuleSource, versionedDemoAdapterSource } from "./version.mjs";
 
 const port = Number(process.env.PORT ?? 45678);
 const demoRoot = new URL("../", import.meta.url).pathname;
 const publicRoot = new URL("../../src/public/", import.meta.url).pathname;
 const vditorRoot = new URL("../node_modules/vditor/dist/", import.meta.url).pathname;
 const mainVersion = await readMainVersion();
-const versionModule = versionModuleSource(mainVersion);
+const coverVersions = await readDemoCoverVersions();
+const versionModule = versionModuleSource(mainVersion, coverVersions);
 const adapterSource = await readFile(new URL("../mock-api.js", import.meta.url), "utf8");
 const browserAiSource = await readFile(new URL("../browser-ai.js", import.meta.url), "utf8");
 const adapterVersion = demoAssetVersion(`${adapterSource}\n${browserAiSource}`, mainVersion);
@@ -29,7 +31,8 @@ createServer(async (request, response) => {
     response.end(versionModule);
     return;
   }
-  const isDemoAsset = relativePath === "data.js" || relativePath === "demo-auth.js" || relativePath === "browser-ai.js" || relativePath === "mock-api.js" || relativePath.startsWith("demo-covers/");
+  const isDemoCover = relativePath.startsWith("demo-covers/");
+  const isDemoAsset = relativePath === "data.js" || relativePath === "demo-auth.js" || relativePath === "browser-ai.js" || relativePath === "mock-api.js" || isDemoCover;
   const isVditorAsset = relativePath.startsWith("vendor/vditor/dist/");
   const root = isDemoAsset ? demoRoot : isVditorAsset ? vditorRoot : publicRoot;
   const rootRelativePath = isVditorAsset ? relativePath.replace(/^vendor\/vditor\/dist\//, "") : relativePath;
@@ -52,7 +55,19 @@ createServer(async (request, response) => {
         (appScript) => `<script type="module" src="/mock-api.js?v=${encodeURIComponent(adapterVersion)}"></script>\n    ${appScript}`
       ));
     }
-    response.writeHead(200, { "cache-control": "no-store", "content-type": contentTypes[extname(target)] ?? "application/octet-stream" });
+    const headers = {
+      "cache-control": isDemoCover ? demoCoverCacheControl() : "no-store",
+      "content-type": contentTypes[extname(target)] ?? "application/octet-stream"
+    };
+    if (isDemoCover) {
+      headers.etag = `"${createHash("sha256").update(body).digest("hex")}"`;
+      if (request.headers["if-none-match"] === headers.etag) {
+        response.writeHead(304, headers);
+        response.end();
+        return;
+      }
+    }
+    response.writeHead(200, headers);
     response.end(body);
   } catch {
     response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });

--- a/demo/scripts/version.mjs
+++ b/demo/scripts/version.mjs
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 
 const mainPackageUrl = new URL("../../package.json", import.meta.url);
+const demoCoversUrl = new URL("../demo-covers/", import.meta.url);
 
 export async function readMainVersion() {
   const packageJson = JSON.parse(await readFile(mainPackageUrl, "utf8"));
@@ -10,8 +11,20 @@ export async function readMainVersion() {
   return version;
 }
 
-export function versionModuleSource(version) {
-  return `export const DEMO_VERSION = ${JSON.stringify(version)};\n`;
+export async function readDemoCoverVersions() {
+  const entries = await readdir(demoCoversUrl);
+  const versions = {};
+  for (const entry of entries.sort()) {
+    if (!entry.endsWith(".webp")) continue;
+    const id = entry.slice(0, -".webp".length);
+    const bytes = await readFile(new URL(entry, demoCoversUrl));
+    versions[id] = createHash("sha256").update(bytes).digest("hex").slice(0, 8);
+  }
+  return versions;
+}
+
+export function versionModuleSource(version, coverVersions = {}) {
+  return `export const DEMO_VERSION = ${JSON.stringify(version)};\nexport const DEMO_COVER_VERSIONS = ${JSON.stringify(coverVersions)};\n`;
 }
 
 export function versionedDemoAdapterSource(source, version) {
@@ -24,4 +37,8 @@ export function versionedDemoAdapterSource(source, version) {
 export function demoAssetVersion(source, version) {
   const digest = createHash("sha256").update(source).digest("hex").slice(0, 8);
   return `${version}-${digest}`;
+}
+
+export function demoCoverCacheControl() {
+  return "public, max-age=31536000, immutable";
 }

--- a/demo/tests/demo.test.mjs
+++ b/demo/tests/demo.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import { BROWSER_AI_STORAGE_KEY, buildBrowserAiMessages, createBrowserAiStore, publicProvider, requestBrowserAi } from "../browser-ai.js";
 import { works } from "../data.js";
 import { DEMO_CREDENTIALS, isValidDemoLogin } from "../demo-auth.js";
-import { demoAssetVersion, readMainVersion, versionModuleSource, versionedDemoAdapterSource } from "../scripts/version.mjs";
+import { demoAssetVersion, demoCoverCacheControl, readDemoCoverVersions, readMainVersion, versionModuleSource, versionedDemoAdapterSource } from "../scripts/version.mjs";
 
 test("预制两本不同类型的作品", () => {
   assert.equal(works.length, 2);
@@ -99,11 +99,23 @@ test("浏览器直接调用 OpenAI 兼容模型并携带作品上下文", async 
 
 test("两本预制作品都设置了项目内封面", async () => {
   const adapter = await readFile(new URL("../mock-api.js", import.meta.url), "utf8");
-  assert.match(adapter, /\/demo-covers\/\$\{id\}\.webp/);
+  const server = await readFile(new URL("../scripts/serve.mjs", import.meta.url), "utf8");
+  const vercel = JSON.parse(await readFile(new URL("../vercel.json", import.meta.url), "utf8"));
+  const coverVersions = await readDemoCoverVersions();
+  assert.match(adapter, /DEMO_COVER_VERSIONS/);
+  assert.match(adapter, /\/demo-covers\/\$\{id\}\.webp\?v=\$\{encodeURIComponent\(DEMO_COVER_VERSIONS\[id\] \?\? "0"\)\}/);
+  assert.match(server, /demoCoverCacheControl/);
+  assert.match(server, /isDemoCover/);
+  assert.equal(demoCoverCacheControl(), "public, max-age=31536000, immutable");
+  assert.equal(vercel.headers?.[0]?.source, "/demo-covers/(.*)");
+  assert.equal(vercel.headers?.[0]?.headers?.[0]?.value, "public, max-age=31536000, immutable");
+  assert.deepEqual(Object.keys(coverVersions).sort(), ["city-blank", "silent-tide"]);
   for (const filename of ["silent-tide.webp", "city-blank.webp"]) {
     const cover = await stat(new URL(`../demo-covers/${filename}`, import.meta.url));
     assert.ok(cover.size > 50_000, `${filename} 不是有效的完整封面`);
     assert.ok(cover.size <= 200_000, `${filename} 超过 200 KB`);
+    const id = filename.slice(0, -".webp".length);
+    assert.match(coverVersions[id], /^[a-f0-9]{8}$/u);
   }
   for (const filename of ["silent-tide.png", "city-blank.png"]) {
     const original = await stat(new URL(`../cover-originals/${filename}`, import.meta.url));
@@ -128,7 +140,8 @@ test("Demo 版本直接继承主项目版本", async () => {
   const adapter = await readFile(new URL("../mock-api.js", import.meta.url), "utf8");
   assert.equal(await readMainVersion(), mainPackage.version);
   assert.equal(Object.hasOwn(demoPackage, "version"), false);
-  assert.equal(versionModuleSource(mainPackage.version), `export const DEMO_VERSION = ${JSON.stringify(mainPackage.version)};\n`);
+  assert.equal(versionModuleSource(mainPackage.version), `export const DEMO_VERSION = ${JSON.stringify(mainPackage.version)};\nexport const DEMO_COVER_VERSIONS = {};\n`);
+  assert.equal(versionModuleSource(mainPackage.version, { "silent-tide": "abcd1234" }), `export const DEMO_VERSION = ${JSON.stringify(mainPackage.version)};\nexport const DEMO_COVER_VERSIONS = ${JSON.stringify({ "silent-tide": "abcd1234" })};\n`);
   assert.match(demoAssetVersion(adapter, mainPackage.version), new RegExp(`^${mainPackage.version.replaceAll(".", "\\.")}-[a-f0-9]{8}$`));
   assert.match(versionedDemoAdapterSource(adapter, mainPackage.version), new RegExp(`demo-version\\.js\\?v=${mainPackage.version.replaceAll(".", "\\.")}`));
   assert.match(adapter, /version: DEMO_VERSION/);

--- a/demo/vercel.json
+++ b/demo/vercel.json
@@ -4,5 +4,16 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "cleanUrls": true,
-  "trailingSlash": false
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/demo-covers/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- 演示站书架封面改为按内容哈希版本化 URL，避免每次访问都重新下载
- 本地开发服务器与 Vercel 均对 `/demo-covers/*` 使用长期 `immutable` 缓存，并支持 ETag 304
- 补充对应 demo 测试断言

## Test plan
- [x] `cd demo && npm test`
- [x] `cd demo && npm run build`
- [x] 本地 `serve.mjs` 验证封面返回 `Cache-Control: public, max-age=31536000, immutable`
- [x] 带匹配 `If-None-Match` 时返回 `304 Not Modified`
- [ ] 部署后确认 `showcase.scriverse.top/demo-covers/*.webp` 响应头已更新


Made with [Cursor](https://cursor.com)