### PR TITLE
fix(ui): add avatar-crop type declarations

### DIFF
--- a/src/public/avatar-crop.d.ts
+++ b/src/public/avatar-crop.d.ts
@@ -1,0 +1,57 @@
+export type CropRect = {
+  x: number;
+  y: number;
+  size: number;
+};
+
+export type DisplayRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+export type CropHandle = "nw" | "ne" | "sw" | "se";
+
+export const AVATAR_CROP_OUTPUT_SIZE: number;
+export const AVATAR_CROP_MIN_SIZE: number;
+
+export function defaultCropRect(imageWidth: number, imageHeight: number): CropRect;
+export function clampCropRect(
+  rect: Partial<CropRect> | null | undefined,
+  imageWidth: number,
+  imageHeight: number,
+  minSize?: number
+): CropRect;
+export function moveCropRect(
+  rect: Partial<CropRect> | null | undefined,
+  deltaX: number,
+  deltaY: number,
+  imageWidth: number,
+  imageHeight: number
+): CropRect;
+export function resizeCropRect(
+  rect: Partial<CropRect> | null | undefined,
+  handle: CropHandle | string,
+  pointerX: number,
+  pointerY: number,
+  imageWidth: number,
+  imageHeight: number
+): CropRect;
+export function containImageRect(
+  imageWidth: number,
+  imageHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): DisplayRect;
+export function mapDisplayPointToImage(
+  point: { x: number; y: number },
+  displayRect: DisplayRect
+): { x: number; y: number };
+export function mapImageRectToDisplay(cropRect: CropRect, displayRect: DisplayRect): {
+  x: number;
+  y: number;
+  size: number;
+};
+export function cropOutputSize(cropSize: number, maxSize?: number): number;


### PR DESCRIPTION
## Summary
- Add `src/public/avatar-crop.d.ts` so `npm run typecheck` passes
- Unblocks npm publish after v0.4.8 failed on missing module types

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run tests/unit/avatar-crop.test.ts`


Made with [Cursor](https://cursor.com)