### PR TITLE
release: promote v0.4.9 to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/public/avatar-crop.d.ts
+++ b/src/public/avatar-crop.d.ts
@@ -1,0 +1,57 @@
+export type CropRect = {
+  x: number;
+  y: number;
+  size: number;
+};
+
+export type DisplayRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+export type CropHandle = "nw" | "ne" | "sw" | "se";
+
+export const AVATAR_CROP_OUTPUT_SIZE: number;
+export const AVATAR_CROP_MIN_SIZE: number;
+
+export function defaultCropRect(imageWidth: number, imageHeight: number): CropRect;
+export function clampCropRect(
+  rect: Partial<CropRect> | null | undefined,
+  imageWidth: number,
+  imageHeight: number,
+  minSize?: number
+): CropRect;
+export function moveCropRect(
+  rect: Partial<CropRect> | null | undefined,
+  deltaX: number,
+  deltaY: number,
+  imageWidth: number,
+  imageHeight: number
+): CropRect;
+export function resizeCropRect(
+  rect: Partial<CropRect> | null | undefined,
+  handle: CropHandle | string,
+  pointerX: number,
+  pointerY: number,
+  imageWidth: number,
+  imageHeight: number
+): CropRect;
+export function containImageRect(
+  imageWidth: number,
+  imageHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+): DisplayRect;
+export function mapDisplayPointToImage(
+  point: { x: number; y: number },
+  displayRect: DisplayRect
+): { x: number; y: number };
+export function mapImageRectToDisplay(cropRect: CropRect, displayRect: DisplayRect): {
+  x: number;
+  y: number;
+  size: number;
+};
+export function cropOutputSize(cropSize: number, maxSize?: number): number;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.8";
+export const APP_VERSION = "0.4.9";


### PR DESCRIPTION
## Summary
- Promote `v0.4.9` from develop to main
- Fix missing `avatar-crop.d.ts` so npm publish typecheck passes (#127)
- Patch version bump to `0.4.9` (#128)

## Test plan
- [x] `npm run typecheck` on develop tip
- [ ] Tag `v0.4.9` and create GitHub Release after merge
- [ ] Confirm npm / Docker publish workflows succeed


Made with [Cursor](https://cursor.com)