### PR TITLE
fix(ui): ordered list numbering and character state labels

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -29,8 +29,9 @@ import {
   searchResultTypeLabel,
   settingStatusLabel,
   taskScopeLabel,
-  timelineStatusLabel
-} from "/display-labels.js?v=20260725-unified-permissions";
+  timelineStatusLabel,
+  characterStateFieldLabel
+} from "/display-labels.js?v=20260725-state-field-zh";
 import { parsePageRoute, serializePageRoute } from "/page-route.js?v=20260723-knowledge-editor-page";
 import { splitRelationshipKeywordInput, splitRelationshipKeywords, uniqueRelationshipKeywords } from "/relationship-keywords.js?v=20260720-relationship-keyword-chips";
 import { tokenizeVisibleSpaces } from "/whitespace-visualization.js?v=20260718-visible-whitespace";
@@ -3403,14 +3404,14 @@ async function renderCharacters(page = characterListPage) {
     ${item.aliases.length ? `<div class="character-aliases"><b>别名</b>${item.aliases.map((alias) => `<span class="pill">${esc(alias)}</span>`).join("")}</div>` : ""}
     ${item.code ? `<div class="character-code"><b>编号</b><span class="pill">${esc(item.code)}</span></div>` : ""}
     ${item.species ? `<div class="character-species"><b>种族</b><span class="pill">${esc(racePathLabel(item.race) || item.species)}</span></div>` : ""}
-    ${details.length ? `<dl class="character-detail-list">${details.slice(0, 4).map((detail) => `<div><dt>${esc(detail.label)}</dt><dd>${esc(detail.value)}</dd></div>`).join("")}</dl>` : ""}
+    ${details.length ? `<dl class="character-detail-list">${details.slice(0, 4).map((detail) => `<div><dt>${esc(characterStateFieldLabel(detail.label))}</dt><dd>${esc(detail.value)}</dd></div>`).join("")}</dl>` : ""}
     <div class="organization-links"><b>所属组织</b>${(item.organizations ?? []).length ? item.organizations.map((organization) => `<span class="pill organization-pill">${esc(organization.name)}</span>`).join("") : '<span class="organization-empty">未加入组织</span>'}</div>
-    ${item.profile?.summary ? `<p class="character-summary">${esc(item.profile.summary)}</p>` : `<p>${esc(Object.entries(item.currentState).map(([key, value]) => `${key}：${value}`).join("\n") || "尚未记录当前状态")}</p>`}
+    ${item.profile?.summary ? `<p class="character-summary">${esc(item.profile.summary)}</p>` : `<p>${esc(Object.entries(item.currentState).map(([key, value]) => `${characterStateFieldLabel(key)}：${value}`).join("\n") || "尚未记录当前状态")}</p>`}
     ${item.profileSectionCount ? `<small class="character-section-count">${item.profileSectionCount} 个设定章节</small>` : ""}
     </article>`;
   }).join("")}</div>`;
   const characterRows = () => `<div class="module-row-list">${state.characters.map((item) => {
-    const preview = moduleRowPreview(item.profile?.summary || item.attributes?.identity || Object.entries(item.currentState).map(([key, value]) => `${key}：${value}`).join(" ") || "尚未记录当前状态");
+    const preview = moduleRowPreview(item.profile?.summary || item.attributes?.identity || Object.entries(item.currentState).map(([key, value]) => `${characterStateFieldLabel(key)}：${value}`).join(" ") || "尚未记录当前状态");
     const meta = [
       item.code ? `编号 ${item.code}` : "",
       item.species ? (racePathLabel(item.race) || item.species) : "",

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -1,6 +1,6 @@
 import { buildRelationshipGraph, createGalaxyRenderer, renderRelationshipMindMap } from "/relationship-graph.js?v=20260725-galaxy-ripple";
 import { collapseExcessBlankLines, formatDateTime, normalizeParagraphSpacing } from "/text-formatting.js?v=20260713-saved-at-seconds";
-import { renderMarkdown } from "/markdown.js?v=20260722-inline-code";
+import { renderMarkdown } from "/markdown.js?v=20260725-ordered-list";
 import { buildAiReferenceScope, findAiMention, listAiMentionOptions } from "/ai-mentions.js?v=20260716-chapter-references";
 import { shouldShowAiQuickActions } from "/ai-conversation.js?v=20260713-quick-actions";
 import { calculateLineNumberRowHeight, calculateLineNumberRowTop, calculateLineNumberTextOffset, calculateLineNumberTop } from "/line-number-layout.js?v=20260713-row-box-alignment";

--- a/src/public/display-labels.js
+++ b/src/public/display-labels.js
@@ -75,3 +75,11 @@ export function occurrenceRoleLabel(value) {
 export function searchResultTypeLabel(value) {
   return enumLabel({ chapter: "章节", setting: "设定", character: "角色", race: "种族", organization: "组织" }, value, "其他资料");
 }
+
+export function characterStateFieldLabel(value) {
+  const normalized = String(value ?? "").trim();
+  return enumLabel({
+    location: "位置",
+    condition: "状况"
+  }, normalized, normalized || "未命名字段");
+}

--- a/src/public/markdown.js
+++ b/src/public/markdown.js
@@ -199,6 +199,22 @@ export function renderMarkdown(value) {
     }
     flushQuote();
     if (!line.trim()) {
+      // CommonMark 松散列表：同类型列表项之间的空行不结束列表，
+      // 否则每个条目会各自生成 <ol>/<ul>，有序序号会全部显示为 1。
+      if (list) {
+        let nextIndex = lineIndex + 1;
+        while (nextIndex < lines.length && !lines[nextIndex].trim()) nextIndex += 1;
+        if (nextIndex < lines.length) {
+          const nextListItem = lines[nextIndex].match(/^(\s*)([-+*]|\d+\.)\s+(.+)$/u);
+          if (nextListItem) {
+            const nextTag = /\d+\./u.test(nextListItem[2]) ? "ol" : "ul";
+            if (nextTag === list.tag) {
+              flushParagraph();
+              continue;
+            }
+          }
+        }
+      }
       flushBlocks();
       continue;
     }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -380,7 +380,7 @@ describe("作者完整创作流程", () => {
     expect(markdown.text).toContain("renderMarkdownTable");
     expect(vditorCss.text).toContain("Vditor v3.11.2");
     expect(vditorScript.text).toContain("Vditor");
-    expect(application.text).toContain('/markdown.js?v=20260722-inline-code');
+    expect(application.text).toContain('/markdown.js?v=20260725-ordered-list');
     expect(application.text).toContain('new window.Vditor');
     expect(application.text).toContain('createVditorUploadHandler');
     expect(page.text).toContain('id="character-section-editor-view"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -60,7 +60,7 @@ describe("知识模块布局切换", () => {
     expect(application.text).toContain('bindRecordPreview("[data-open-review]"');
     expect(page.text).toContain('id="dialog-meta" class="dialog-header-meta hidden"');
     expect(application.text).toContain('hideCancel: true');
-    expect(application.text).toContain('/display-labels.js?v=20260725-unified-permissions');
+    expect(application.text).toContain('/display-labels.js?v=20260725-state-field-zh');
     expect(application.text).toContain('settingStatusLabel(item.status)');
     expect(application.text).not.toContain('characterVisibilityLabel(item.visibility)');
     expect(application.text).toContain('timelineStatusLabel(item.status)');

--- a/tests/unit/display-labels.test.ts
+++ b/tests/unit/display-labels.test.ts
@@ -12,7 +12,8 @@ import {
   reviewStatusLabel,
   settingStatusLabel,
   taskScopeLabel,
-  timelineStatusLabel
+  timelineStatusLabel,
+  characterStateFieldLabel
 } from "../../src/public/display-labels.js";
 
 describe("前端枚举中文标签", () => {
@@ -33,6 +34,13 @@ describe("前端枚举中文标签", () => {
     expect(providerStatusLabel("enabled")).toBe("已启用");
     expect(providerConnectionLabel("success")).toBe("连接正常");
     expect(chapterVersionSourceLabel("ai-suggestion")).toBe("AI 建议");
+  });
+
+  it("将角色当前状态常用英文字段显示为中文", () => {
+    expect(characterStateFieldLabel("location")).toBe("位置");
+    expect(characterStateFieldLabel("condition")).toBe("状况");
+    expect(characterStateFieldLabel("自定义字段")).toBe("自定义字段");
+    expect(characterStateFieldLabel("energy")).toBe("energy");
   });
 
   it("保留中文自定义值并隐藏未知英文枚举", () => {

--- a/tests/unit/markdown.test.ts
+++ b/tests/unit/markdown.test.ts
@@ -36,6 +36,28 @@ describe("侧边栏 Markdown 渲染", () => {
     expect(html).not.toContain("<blockquote></blockquote>");
   });
 
+  it("跨空行的有序与无序列表合并为单个列表", () => {
+    const ordered = renderMarkdown("1. **相遇**：初见。\n\n2. **承诺**：约定。\n\n3. **幻灭**：失望。");
+    expect(ordered.match(/<ol>/gu)).toHaveLength(1);
+    expect(ordered.match(/<\/ol>/gu)).toHaveLength(1);
+    expect(ordered).toContain("<li class=\"markdown-depth-0\"><strong>相遇</strong>：初见。</li>");
+    expect(ordered).toContain("<li class=\"markdown-depth-0\"><strong>承诺</strong>：约定。</li>");
+    expect(ordered).toContain("<li class=\"markdown-depth-0\"><strong>幻灭</strong>：失望。</li>");
+
+    const unordered = renderMarkdown("- 甲\n\n- 乙\n\n- 丙");
+    expect(unordered.match(/<ul>/gu)).toHaveLength(1);
+    expect(unordered).toContain("<li class=\"markdown-depth-0\">甲</li>");
+    expect(unordered).toContain("<li class=\"markdown-depth-0\">乙</li>");
+    expect(unordered).toContain("<li class=\"markdown-depth-0\">丙</li>");
+  });
+
+  it("空行后若不再是同类型列表则结束当前列表", () => {
+    const html = renderMarkdown("1. 第一项\n\n不是列表\n\n- 无序项");
+    expect(html).toContain("</ol><p>不是列表</p><ul>");
+    expect(html.match(/<ol>/gu)).toHaveLength(1);
+    expect(html.match(/<ul>/gu)).toHaveLength(1);
+  });
+
   it("渲染带对齐方式的表格并保留单元格内的管道符", () => {
     const html = renderMarkdown("| 章节 | 标题 | 内容摘要 |\n| :--- | :---: | ---: |\n| 第一百六十三章 | **护盾实验** | `能量 | 护盾` |\n| 第一百六十四章 | 海洋星舰 | 哥斯拉\\|机械哥斯拉 | ");
 


### PR DESCRIPTION
## Summary
- 修复 Markdown 有序列表在条目间有空行时被拆成多个 `<ol>`、序号全部显示为 `1.` 的问题
- 角色卡片/列表将常用当前状态字段（如 `location`）显示为中文（位置）

## Test plan
- [ ] `npx vitest run tests/unit/markdown.test.ts tests/unit/display-labels.test.ts`
- [ ] `npx vitest run tests/system/author-journey.test.ts tests/system/module-layout-toggle.test.ts`
- [ ] AI 回复中带空行的有序列表应显示为 1/2/3/4
- [ ] 角色卡片 `currentState.location` 应显示为「位置」而非 `location`


Made with [Cursor](https://cursor.com)