### PR TITLE
fix(ui): load full chapter directory

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2735,7 +2735,7 @@ function resetWorkScopedUiCaches() {
 async function selectWork(workId, preferredChapterId = null) {
   const discarding = state.work?.id !== workId && state.dirty;
   if (discarding && !(await confirmDiscardChanges())) return false;
-  const nextWork = await api(`/api/works/${workId}?page=1&limit=100`);
+  const nextWork = await api(`/api/works/${workId}`);
   if (state.work?.id !== nextWork.id) resetWorkScopedUiCaches();
   if (discarding) setSaveState("就绪");
   $("#app").classList.remove("shelf-mode");

--- a/src/store.ts
+++ b/src/store.ts
@@ -1185,9 +1185,9 @@ export class Store {
       workId,
       ...page.params
     );
-    const chapters = chapterRows.map((row) => this.mapChapterDirectoryEntry(row));
+    const pageResult = paginated(chapterRows.map((row) => this.mapChapterDirectoryEntry(row)), pagination);
     const chaptersByVolume = new Map<string, Record<string, unknown>[]>();
-    for (const chapter of chapters) {
+    for (const chapter of pageResult.items) {
       const volumeId = String(chapter.volumeId);
       const list = chaptersByVolume.get(volumeId) ?? [];
       list.push(chapter);
@@ -1197,7 +1197,7 @@ export class Store {
       ...this.mapVolume(row),
       chapters: chaptersByVolume.get(requiredString(row, "id")) ?? []
     }));
-    return { ...work, volumes, directoryPage: paginated(chapters, pagination) };
+    return { ...work, volumes, directoryPage: pageResult };
   }
 
   listFileVersions(workId: string): Record<string, unknown>[] {

--- a/tests/integration/work-chapter-api.test.ts
+++ b/tests/integration/work-chapter-api.test.ts
@@ -212,6 +212,23 @@ describe("作品、导入和章节版本 API", () => {
     expect(loadedChapter.body.data.content).toBe("这段正文只能通过章节接口返回。");
   });
 
+  it("分页作品目录不会把下一页探测记录计入分卷", async () => {
+    const work = await request(runtime.app).post("/api/works").send({ title: "分页目录作品" }).expect(201);
+    const text = Array.from({ length: 101 }, (_, index) => `第${index + 1}章 章节${index + 1}\n正文${index + 1}`).join("\n");
+    await request(runtime.app)
+      .post(`/api/works/${work.body.data.id}/import`)
+      .attach("file", Buffer.from(text), "分页目录.txt")
+      .expect(201);
+
+    const firstPage = await request(runtime.app).get(`/api/works/${work.body.data.id}?page=1&limit=100`).expect(200);
+    expect(firstPage.body.data.directoryPage).toMatchObject({ hasMore: true, nextPage: 2 });
+    expect(firstPage.body.data.volumes[0].chapters).toHaveLength(100);
+
+    const secondPage = await request(runtime.app).get(`/api/works/${work.body.data.id}?page=2&limit=100`).expect(200);
+    expect(secondPage.body.data.directoryPage).toMatchObject({ hasMore: false, nextPage: null });
+    expect(secondPage.body.data.volumes[0].chapters).toHaveLength(1);
+  });
+
   it("从 DOCX 正文中提取并解析卷章", async () => {
     const zip = new JSZip();
     zip.file("[Content_Types].xml", `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
## 变更

- 正文编辑器进入作品时直接请求全量章节目录。
- 修正分页目录接口，不再把下一页探测记录计入分卷。
- 增加 101 章节分页回归测试。

## 根因

分页查询使用 `limit + 1` 判断是否存在下一页，但返回分卷数据时使用了未裁剪的查询结果，导致前端把 100 条正文和 1 条探测记录显示为 101 条。

## 验证

- `npm run typecheck`
- `npm test -- --run tests/integration/work-chapter-api.test.ts`
- `npm run build`

目标分支：`develop`。