### PR TITLE
build(release): release v0.4.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.9";
+export const APP_VERSION = "0.4.10";


### PR DESCRIPTION
Bump Scriverse from v0.4.9 to v0.4.10 after merging the pending develop changes. Updates package metadata, lockfile metadata, and the application version constant. Validation: npm test (348 tests passed) and npm run build.