### PR TITLE
fix(characters): group race filter options by hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ tests/
 ### 运行与数据边界
 
 - 开发服务默认运行在 `http://127.0.0.1:13210`。
-- `npm run dev` 启动监听模式；`npm run build && npm start` 启动生产构建。
+- 本地人工查看或调试必须使用 `NODE_ENV=development APP_DEV_SKIP_AUTH=true npm run dev` 启动监听模式，直接跳过登录；禁止仅使用普通 `npm run dev` 或 `APP_ALLOW_REGISTRATION=true` 代替。若隔离开发数据库没有活跃用户，应先在该隔离数据库创建测试管理员，不得因此修改真实数据库。
+- `npm run build && npm start` 启动生产构建。
 - `.data/` 包含真实数据库和密钥，不得提交、删除、覆盖或用于破坏性测试。
 - `dist/` 是构建产物，不直接编辑。
 - 禁止读取、修改或删除工作区以外的文件，除非用户明确授权且任务确实需要。

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -35,7 +35,7 @@ import {
 import { parsePageRoute, serializePageRoute } from "/page-route.js?v=20260723-knowledge-editor-page";
 import { splitRelationshipKeywordInput, splitRelationshipKeywords, uniqueRelationshipKeywords } from "/relationship-keywords.js?v=20260720-relationship-keyword-chips";
 import { tokenizeVisibleSpaces } from "/whitespace-visualization.js?v=20260718-visible-whitespace";
-import { buildRaceForest, eligibleRaceParents, racePathLabel } from "/race-hierarchy.js?v=20260721-race-hierarchy";
+import { buildRaceForest, eligibleRaceParents, orderRaceFilterOptions, racePathLabel } from "/race-hierarchy.js?v=20260726-race-filter-order";
 import { ANALYSIS_TYPES, analysisTypeDescription } from "/analysis-types.js?v=20260721-analysis-descriptions";
 import { WORK_PERMISSION_MODULES, canReadPermissionModule, canReadUiModule, canWritePermissionModule, canWriteUiModule, emptyModulePermissions, firstReadableUiModule, normalizeModulePermissions, permissionSummary } from "/work-permissions.js?v=20260724-outline-title";
 import { MODULE_LAYOUT_STORAGE_KEY, LEGACY_SETTINGS_LAYOUT_STORAGE_KEY, normalizeModuleLayout } from "/module-layout.js?v=20260723-module-layout-toggle";
@@ -3501,7 +3501,7 @@ async function renderCharacters(page = characterListPage) {
     return `<label class="character-filter-option"><input type="checkbox" value="${esc(value)}" ${selectedIds.has(value) ? "checked" : ""}><span>${esc(label)}</span></label>`;
   }).join("");
   const filterToolbar = `<section id="character-filter-panel" class="character-filter-toolbar${characterFiltersPanelOpen ? "" : " hidden"}" aria-label="角色筛选">
-    <details class="character-filter-dropdown"><summary><span>按种族筛选</span><strong>${selectedRaceNames.length ? `已选 ${selectedRaceNames.length} 项` : "全部种族"}</strong></summary><div id="character-race-filter" class="character-filter-options">${filterOptionList(races, selectedRaceIds)}</div></details>
+    <details class="character-filter-dropdown"><summary><span>按种族筛选</span><strong>${selectedRaceNames.length ? `已选 ${selectedRaceNames.length} 项` : "全部种族"}</strong></summary><div id="character-race-filter" class="character-filter-options">${filterOptionList(orderRaceFilterOptions(races), selectedRaceIds)}</div></details>
     <details class="character-filter-dropdown"><summary><span>按组织筛选</span><strong>${selectedOrganizationNames.length ? `已选 ${selectedOrganizationNames.length} 项` : "全部组织"}</strong></summary><div id="character-organization-filter" class="character-filter-options">${filterOptionList(organizations, selectedOrganizationIds, "id")}</div></details>
     <div class="character-filter-toolbar-actions">${hasCharacterFilters ? `<span class="character-filter-result-count" aria-live="polite">筛选后剩余 ${characterPage.total} 个角色</span>` : ""}<button id="clear-character-filters" class="ghost-button" type="button" ${hasCharacterFilters ? "" : "disabled"}>重置筛选</button></div>
   </section>`;

--- a/src/public/race-hierarchy.js
+++ b/src/public/race-hierarchy.js
@@ -32,6 +32,42 @@ export function eligibleRaceParents(races, currentRaceId = null) {
   return races.filter((race) => !excluded.has(String(race?.id ?? "")));
 }
 
+export function orderRaceFilterOptions(races) {
+  const raceIds = new Set(races.map((race) => String(race?.id ?? "")).filter(Boolean));
+  const childrenByParent = new Map();
+  const roots = [];
+  for (const race of races) {
+    const id = String(race?.id ?? "");
+    const parentRaceId = race?.parentRaceId == null ? "" : String(race.parentRaceId);
+    if (!parentRaceId || parentRaceId === id || !raceIds.has(parentRaceId)) {
+      roots.push(race);
+      continue;
+    }
+    const children = childrenByParent.get(parentRaceId) ?? [];
+    children.push(race);
+    childrenByParent.set(parentRaceId, children);
+  }
+  const sortByName = (items) => items.sort((left, right) => String(left?.name ?? "").localeCompare(String(right?.name ?? ""), "zh-CN"));
+  sortByName(roots);
+  for (const children of childrenByParent.values()) sortByName(children);
+
+  const ordered = [...roots];
+  const pending = [...roots];
+  const visited = new Set(roots);
+  while (pending.length) {
+    const parent = pending.shift();
+    const children = childrenByParent.get(String(parent?.id ?? "")) ?? [];
+    for (const child of children) {
+      if (visited.has(child)) continue;
+      visited.add(child);
+      ordered.push(child);
+      pending.push(child);
+    }
+  }
+  ordered.push(...sortByName(races.filter((race) => !visited.has(race))));
+  return ordered;
+}
+
 export function buildRaceForest(races) {
   const nodes = new Map(races.map((race) => [String(race.id), { ...race, children: [] }]));
   const roots = [];

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -316,7 +316,7 @@ describe("作者完整创作流程", () => {
     expect(graph.text).toContain("assignRelationshipEdgeCurves(graph.edges)");
     expect(graph.text).toContain('statuses.push("待确认")');
     expect(graph.text).toContain('selection.endpointNames.join(selection.directed ? " → " : " ↔ ")');
-    expect(application.text).toContain('/race-hierarchy.js?v=20260721-race-hierarchy');
+    expect(application.text).toContain('/race-hierarchy.js?v=20260726-race-filter-order');
     expect(graph.text).toContain('fullscreen.className = "ghost-button relationship-galaxy-button"');
     expect(graph.text).toContain('class="relationship-galaxy-icon"');
     expect(graph.text).toContain('aria-label", "全屏银河图"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -97,6 +97,8 @@ describe("知识模块布局切换", () => {
     expect(application.text).toContain("if (!characterPage.items.length && page > 1) return renderCharacters(page - 1)");
     expect(application.text).toContain('const hasCharacterFilters = characterFilters.raceIds.length > 0 || characterFilters.organizationIds.length > 0;');
     expect(application.text).toContain('hasCharacterFilters ? apiAllPages(`/api/works/${state.work.id}/characters`)');
+    expect(application.text).toContain('filterOptionList(orderRaceFilterOptions(races), selectedRaceIds)');
+    expect(application.text).toContain('filterOptionList(organizations, selectedOrganizationIds, "id")');
     expect(application.text).toContain('await api(`/api/${route.entity === "setting" ? "settings" : route.entity === "character" ? "characters" : route.entity === "race" ? "races" : "organizations"}/${encodeURIComponent(route.entityId)}`)');
     expect(application.text).toContain('apiAllPages(`/api/works/${state.work.id}/races`)');
     expect(application.text).toContain('apiAllPages(`/api/works/${state.work.id}/organizations`)');

--- a/tests/unit/race-hierarchy.test.ts
+++ b/tests/unit/race-hierarchy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 // @ts-expect-error 浏览器端模块没有单独的类型声明，测试仅调用纯函数导出。
-import { buildRaceForest, eligibleRaceParents, raceDescendantIds, racePathLabel } from "../../src/public/race-hierarchy.js";
+import { buildRaceForest, eligibleRaceParents, orderRaceFilterOptions, raceDescendantIds, racePathLabel } from "../../src/public/race-hierarchy.js";
 
 const races = [
   { id: "human", name: "人类", parentRaceId: null, lineage: [{ id: "human", name: "人类" }] },
@@ -22,5 +22,25 @@ describe("种族层级前端逻辑", () => {
     expect(racePathLabel(races[3])).toBe("泰坦 / 原生泰坦 / 阿尔法泰坦");
     expect([...raceDescendantIds(races, "titan")]).toEqual(expect.arrayContaining(["original", "alpha"]));
     expect(eligibleRaceParents(races, "original").map((race: { id: string }) => race.id)).toEqual(["human", "titan"]);
+  });
+
+  it("筛选选项先展示全部根节点，再按父节点集中排列子节点", () => {
+    const options = [
+      { id: "titan-child-b", name: "贝塔泰坦", parentRaceId: "titan" },
+      { id: "human-child", name: "新人类", parentRaceId: "human" },
+      { id: "titan", name: "泰坦", parentRaceId: null },
+      { id: "titan-grandchild", name: "幼生泰坦", parentRaceId: "titan-child-a" },
+      { id: "human", name: "人类", parentRaceId: null },
+      { id: "titan-child-a", name: "阿尔法泰坦", parentRaceId: "titan" }
+    ];
+
+    expect(orderRaceFilterOptions(options).map((race: { id: string }) => race.id)).toEqual([
+      "human",
+      "titan",
+      "human-child",
+      "titan-child-a",
+      "titan-child-b",
+      "titan-grandchild"
+    ]);
   });
 });


### PR DESCRIPTION
## What changed

- Order the character page's race filter with all root races first.
- Keep child races with siblings that share the same parent, with stable Chinese name ordering inside each group.
- Leave the organization filter ordering unchanged.
- Document that local manual development must start with `APP_DEV_SKIP_AUTH=true` so preview sessions bypass login.

## Why

The race filter previously rendered API order directly, which separated related races and could place child races before roots. This made hierarchical race selection difficult to scan.

## Impact

Authors can now scan root races first and find sibling races together in the character filter. Organization filtering behavior is unchanged.

## Root cause

The character page passed the raw race list directly to the generic filter option renderer without applying hierarchy-aware ordering.

## Validation

- `npx vitest run tests/unit/race-hierarchy.test.ts tests/system/author-journey.test.ts tests/system/module-layout-toggle.test.ts`
- `npm run typecheck`
- `npm run build`
- SQLite integrity and foreign-key checks on the copied local development database
- Manual verification against the populated local development database