### PR TITLE
build(release): release v0.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.10";
+export const APP_VERSION = "0.4.11";


### PR DESCRIPTION
## What changed

- Bump the package version from `0.4.10` to `0.4.11`.
- Keep `package.json`, `package-lock.json`, and the runtime application version aligned.

## Why

Prepare the next patch release after the latest fixes and features were integrated into `develop`.

## Impact

This commit contains release metadata only and does not change runtime behavior beyond reporting version `0.4.11`.

## Validation

- `npm run check`
- 71 test files and 352 tests passed
- TypeScript type checking and production build passed
