### PR TITLE
build(release): release v0.4.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4.11";
+export const APP_VERSION = "0.4.12";


### PR DESCRIPTION
## Summary

- bump package version from 0.4.11 to 0.4.12
- keep the runtime APP_VERSION aligned with package metadata

## Validation

- npm run typecheck
- npm test — 73 files, 362 tests passed
- npm run build

This version commit follows the feature and fix changes already merged into develop through PR #147.