### PR TITLE
build(release): release v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.0";
+export const APP_VERSION = "0.5.1";


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本从 `0.5.0` 提升到 `0.5.1`
- 同步应用运行时版本常量与锁文件

## 发布范围

包含已合入 `develop` 的任务进度环与任务追踪懒加载改动。

## 验证

- `npm run typecheck`
- `npm test`：77 个测试文件、379 项测试通过
- `npm run build`