### PR TITLE
fix(ai): address post-merge review findings

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -742,20 +742,22 @@ export class ContextBuilder {
 
   buildPlan(workId: string, scope: ContextScope, maximumTokens = 60_000, bookSummaryMaximumTokens?: number, query = ""): ContextBuildPlan {
     const work = this.store.getWork(workId);
-    const includeAutomaticContext = scope.type !== "none";
+    const includeAutomaticContext = scope.type !== "none" && scope.suppressAutomaticContext !== true;
     const settingsOnly = scope.type === "settings";
     const constraints: string[] = includeAutomaticContext
       ? [`作品：${String(work.title)}\n作者：${String(work.author) || "未填写"}`]
       : [];
     const contentSections: string[] = [];
     const availableSettings = this.store.listSettings(workId);
-    const contextualSettings = settingsOnly ? [] : scope.includeAllSettings ? availableSettings : availableSettings.filter((item) => item.locked);
+    const contextualSettings = !includeAutomaticContext || settingsOnly
+      ? []
+      : scope.includeAllSettings ? availableSettings : availableSettings.filter((item) => item.locked);
     const allCharacters = this.store.listCharacters(workId);
     const lockedCharacters = allCharacters.filter(
       (item) => Array.isArray(item.lockedFields) && item.lockedFields.length > 0
     );
     const organizations = this.store.listOrganizations(workId);
-    const relationshipConstraints = settingsOnly || scope.excludeRelationshipConstraints
+    const relationshipConstraints = !includeAutomaticContext || settingsOnly || scope.excludeRelationshipConstraints
       ? []
       : selectRelationshipConstraints(this.store, workId, scope.characterIds ?? []);
 
@@ -3892,7 +3894,7 @@ export class AiManager {
           : {
               type: "selection",
               selection: chunk.text,
-              ...(targeted ? { characterIds: [...selectedCharacterIds], excludeRelationshipConstraints: scope.replaceExistingRelationships === true } : {})
+              ...(targeted ? { suppressAutomaticContext: true } : {})
             },
         ...(modelId ? { modelId } : {}),
         parameters: { temperature: 0.1 },
@@ -4037,8 +4039,7 @@ export class AiManager {
           maxAttempts: 2,
           scope: {
             type: "entities",
-            characterIds: [...selectedCharacterIds],
-            excludeRelationshipConstraints: scope.replaceExistingRelationships === true
+            suppressAutomaticContext: true
           },
           ...(modelId ? { modelId } : {}),
           parameters: { temperature: 0.1 },

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4251,6 +4251,7 @@ export class AiManager {
       });
     };
     let replacedRelationshipCount = 0;
+    if (!this.taskCanCommit(taskId)) return { interrupted: true, callIds };
     this.store.db.transaction(() => {
       if (targeted && scope.replaceExistingRelationships === true) {
         const relationshipsToReplace = this.store.listRelationships(workId).filter((relationship) =>
@@ -4447,6 +4448,7 @@ export class AiManager {
         recordRelationshipOutcome("created", relationship);
         existing.push(relationship);
       }
+      if (taskId && settingsOnly) this.store.refreshTaskSourceVersions(taskId);
     });
     const characterNameById = new Map(characters.map((character) => [String(character.id), String(character.name)]));
     const relationshipResults = [...relationshipOutcomes.values()].map(({ action, relationship }) => {

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1710,7 +1710,7 @@ export class AiManager {
     const rows = this.store.db.all(
       `SELECT call.id, call.task_type, call.provider_id, call.model_id, call.status, call.failure,
         call.input_chars, call.output_chars, call.created_at, call.completed_at, trace.call_id AS trace_call_id,
-        trace.initial_messages_json, trace.rounds_json,
+        trace.source_refs_json,
         CASE WHEN trace.call_id IS NULL THEN 0 ELSE json_array_length(trace.initial_messages_json) END AS initial_message_count,
         CASE WHEN trace.call_id IS NULL THEN 0 ELSE json_array_length(trace.rounds_json) END AS round_count,
         CASE WHEN trace.call_id IS NULL THEN 0 ELSE length(trace.initial_messages_json) + length(trace.rounds_json) END AS trace_chars,
@@ -1728,10 +1728,7 @@ export class AiManager {
       const hasTrace = row.trace_call_id !== null && row.trace_call_id !== undefined;
       const failure = row.failure === null ? null : stringValue(row, "failure");
       const sourceRefs = hasTrace
-        ? taskTraceSourceRefs(
-            json<unknown[]>(stringValue(row, "initial_messages_json"), []),
-            json<unknown[]>(stringValue(row, "rounds_json"), [])
-          )
+        ? json<Array<{ type: "chapter" | "setting"; title: string }>>(stringValue(row, "source_refs_json"), [])
         : [];
       return {
         id: stringValue(row, "id"),
@@ -2331,11 +2328,12 @@ export class AiManager {
       );
       if (input.taskId) {
         this.store.db.run(
-          `INSERT INTO ai_call_traces (call_id, task_id, initial_messages_json, rounds_json, created_at, updated_at)
-           VALUES (?, ?, ?, '[]', ?, ?)`,
+          `INSERT INTO ai_call_traces (call_id, task_id, initial_messages_json, rounds_json, source_refs_json, created_at, updated_at)
+           VALUES (?, ?, ?, '[]', ?, ?, ?)`,
           callId,
           input.taskId,
           JSON.stringify(messages),
+          JSON.stringify(taskTraceSourceRefs(messages, [])),
           timestamp,
           timestamp
         );
@@ -2344,8 +2342,9 @@ export class AiManager {
     const saveTrace = (): void => {
       if (!input.taskId) return;
       this.store.db.run(
-        "UPDATE ai_call_traces SET rounds_json = ?, updated_at = ? WHERE call_id = ?",
+        "UPDATE ai_call_traces SET rounds_json = ?, source_refs_json = ?, updated_at = ? WHERE call_id = ?",
         JSON.stringify(traceRounds),
+        JSON.stringify(taskTraceSourceRefs(messages, traceRounds)),
         now(),
         callId
       );

--- a/src/app.ts
+++ b/src/app.ts
@@ -518,6 +518,25 @@ function redactOrganizationMembers(record: Record<string, unknown>, permissions:
   return permissions.characters === "none" ? { ...record, memberIds: [], members: [] } : record;
 }
 
+const taskResultPermissionModules: Partial<Record<string, keyof WorkModulePermissions>> = {
+  "chapter-analysis": "prose",
+  "character-extraction": "characters",
+  "character-summary": "characters",
+  "character-identity-audit": "reviews",
+  "timeline-analysis": "timeline",
+  "relationship-analysis": "relationships",
+  "worldview-analysis": "settings",
+  "setting-extraction": "settings",
+  "consistency-check": "reviews",
+  "book-analysis": "prose",
+  structure: "outlines",
+  "report-update": "prose"
+};
+
+function requiredTaskResultModule(taskType: unknown): keyof WorkModulePermissions | undefined {
+  return taskResultPermissionModules[String(taskType)];
+}
+
 function redactTaskCharacterNames(record: Record<string, unknown>, permissions: WorkModulePermissions): Record<string, unknown> {
   const { scopeSummaryWithoutCharacterNames, ...result } = record;
   const proseRestricted = permissions.prose === "none";
@@ -571,20 +590,7 @@ function redactTaskCharacterNames(record: Record<string, unknown>, permissions: 
   const resultSummary = recordValue(result.resultSummary);
   const characterSensitiveTask = ["character-extraction", "character-summary", "character-identity-audit", "relationship-analysis"]
     .includes(String(result.taskType));
-  const requiredResultModule = {
-    "chapter-analysis": "prose",
-    "character-extraction": "characters",
-    "character-summary": "characters",
-    "character-identity-audit": "reviews",
-    "timeline-analysis": "timeline",
-    "relationship-analysis": "relationships",
-    "worldview-analysis": "settings",
-    "setting-extraction": "settings",
-    "consistency-check": "reviews",
-    "book-analysis": "prose",
-    structure: "outlines",
-    "report-update": "prose"
-  }[String(result.taskType)] as keyof WorkModulePermissions | undefined;
+  const requiredResultModule = requiredTaskResultModule(result.taskType);
   const resultRestricted = requiredResultModule !== undefined && permissions[requiredResultModule] === "none";
   if (resultSummary && (resultRestricted || (characterRestricted && characterSensitiveTask))) {
     result.resultSummary = {
@@ -1535,9 +1541,14 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   ));
   app.get("/api/tasks/:taskId/result", (request, response) => {
     const task = store.getTaskResultPayload(request.params.taskId);
+    const permissions = requestPermissions(request);
+    const requiredModule = requiredTaskResultModule(task.taskType);
+    if (requiredModule && permissions[requiredModule] === "none") {
+      throw new AppError(403, "WORK_MODULE_READ_DENIED", "你没有读取该分析结果对应资料模块的权限");
+    }
     const redacted = redactTaskCharacterNames(
       task,
-      requestPermissions(request)
+      permissions
     );
     data(response, { taskId: task.id, result: redacted.result });
   });

--- a/src/database.ts
+++ b/src/database.ts
@@ -464,6 +464,7 @@ export class Database {
         task_id TEXT NOT NULL REFERENCES analysis_tasks(id) ON DELETE CASCADE,
         initial_messages_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(initial_messages_json) AND json_type(initial_messages_json) = 'array'),
         rounds_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(rounds_json) AND json_type(rounds_json) = 'array'),
+        source_refs_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(source_refs_json) AND json_type(source_refs_json) = 'array'),
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
@@ -1662,6 +1663,7 @@ export class Database {
           task_id TEXT NOT NULL REFERENCES analysis_tasks(id) ON DELETE CASCADE,
           initial_messages_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(initial_messages_json) AND json_type(initial_messages_json) = 'array'),
           rounds_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(rounds_json) AND json_type(rounds_json) = 'array'),
+          source_refs_json TEXT NOT NULL DEFAULT '[]' CHECK(json_valid(source_refs_json) AND json_type(source_refs_json) = 'array'),
           created_at TEXT NOT NULL,
           updated_at TEXT NOT NULL
         )`);
@@ -1685,6 +1687,22 @@ export class Database {
             CHECK(json_valid(page_sizes_json) AND json_type(page_sizes_json) = 'object')`);
         }
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (42, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    if (!applied.has(43)) {
+      this.transaction(() => {
+        const columns = new Set(this.all("PRAGMA table_info(ai_call_traces)").map((row) => String(row.name)));
+        if (!columns.has("source_refs_json")) {
+          this.run(`ALTER TABLE ai_call_traces ADD COLUMN source_refs_json TEXT NOT NULL DEFAULT '[]'
+            CHECK(json_valid(source_refs_json) AND json_type(source_refs_json) = 'array')`);
+        }
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (43, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -64,4 +64,5 @@ export type ContextScope = {
   additionalPrompt?: string;
   replaceExistingRelationships?: boolean;
   excludeRelationshipConstraints?: boolean;
+  suppressAutomaticContext?: boolean;
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -5275,6 +5275,41 @@ export class Store {
     return createHash("sha256").update(content).digest("hex");
   }
 
+  private relationshipSettingsSourceVersions(workId: string): Record<string, number | string> {
+    const versions: Record<string, number | string> = {};
+    const work = this.getWork(workId);
+    versions[`work:${workId}`] = Number(work.versionNo);
+    for (const setting of this.listSettings(workId)) versions[`setting:${String(setting.id)}`] = Number(setting.versionNo);
+    const characters = this.listCharacters(workId, true);
+    for (const character of characters) {
+      versions[`character:${String(character.id)}`] = Number(character.versionNo);
+      for (const section of this.listCharacterProfileSections(String(character.id))) {
+        versions[`character-section:${String(section.id)}`] = Number(section.versionNo);
+      }
+    }
+    for (const race of this.listRaces(workId)) versions[`race:${String(race.id)}`] = Number(race.versionNo);
+    for (const organization of this.listOrganizations(workId)) {
+      versions[`organization:${String(organization.id)}`] = Number(organization.versionNo);
+    }
+    for (const track of this.listTimelineTracks(workId)) versions[`timeline-track:${String(track.id)}`] = Number(track.versionNo);
+    for (const event of this.listTimelineEvents(workId)) versions[`timeline-event:${String(event.id)}`] = Number(event.versionNo);
+    for (const relationship of this.listRelationships(workId)) {
+      versions[`relationship:${String(relationship.id)}`] = Number(relationship.versionNo);
+    }
+    for (const outline of this.listChapterOutlines(workId)) {
+      const chapterId = String(outline.chapterId);
+      versions[`chapter-meta:${chapterId}`] = Number(this.getChapter(chapterId).versionNo);
+      versions[`chapter-outline:${chapterId}`] = this.currentEntityVersionNo("chapter-outline", chapterId);
+    }
+    for (const foreshadow of this.listForeshadows(workId)) {
+      versions[`foreshadow:${String(foreshadow.id)}`] = Number(foreshadow.versionNo);
+    }
+    for (const review of this.listReviewItems(workId)) {
+      versions[`review:${String(review.id)}`] = String(review.updatedAt);
+    }
+    return versions;
+  }
+
   private mapContinuationGuard(row: Row): Record<string, unknown> {
     return {
       id: requiredString(row, "id"),
@@ -5295,7 +5330,7 @@ export class Store {
     const taskId = id("task");
     const timestamp = now();
     const scope = { ...(input.scope ?? { type: "book" }) };
-    const sourceVersions: Record<string, number> = {};
+    const sourceVersions: Record<string, number | string> = {};
     const targetCharacters: Array<{ id: string; name: string }> = [];
     if (Array.isArray(scope.characterIds)) {
       for (const characterId of scope.characterIds) {
@@ -5321,9 +5356,7 @@ export class Store {
         sourceVersions[String(chapter.id)] = Number(chapter.versionNo);
       }
     } else if (scope.type === "settings") {
-      for (const setting of this.listSettings(workId)) {
-        sourceVersions[`setting:${String(setting.id)}`] = Number(setting.versionNo);
-      }
+      Object.assign(sourceVersions, this.relationshipSettingsSourceVersions(workId));
     }
     this.db.run(
       `INSERT INTO analysis_tasks (id, work_id, task_type, scope_json, status, source_versions_json, created_at, updated_at, created_by_user_id)
@@ -5428,10 +5461,9 @@ export class Store {
   isTaskSourceCurrent(taskId: string): boolean {
     const task = this.getTask(taskId);
     const scope = task.scope as Record<string, unknown>;
-    const expected = task.sourceVersions as Record<string, number>;
+    const expected = task.sourceVersions as Record<string, number | string>;
     if (scope.type === "settings") {
-      const current = Object.fromEntries(this.listSettings(String(task.workId))
-        .map((setting) => [`setting:${String(setting.id)}`, Number(setting.versionNo)]));
+      const current = this.relationshipSettingsSourceVersions(String(task.workId));
       const expectedIds = Object.keys(expected).sort();
       const currentIds = Object.keys(current).sort();
       return expectedIds.length === currentIds.length
@@ -5458,6 +5490,18 @@ export class Store {
     const currentIds = Object.keys(current).sort();
     return expectedIds.length === currentIds.length
       && expectedIds.every((chapterId, index) => chapterId === currentIds[index] && expected[chapterId] === current[chapterId]);
+  }
+
+  refreshTaskSourceVersions(taskId: string): void {
+    const task = this.getTask(taskId);
+    const scope = task.scope as Record<string, unknown>;
+    if (scope.type !== "settings") return;
+    this.db.run(
+      "UPDATE analysis_tasks SET source_versions_json = ?, updated_at = ? WHERE id = ?",
+      JSON.stringify(this.relationshipSettingsSourceVersions(String(task.workId))),
+      now(),
+      taskId
+    );
   }
 
   cancelTask(taskId: string): Record<string, unknown> {

--- a/tests/integration/analysis-task-trace.test.ts
+++ b/tests/integration/analysis-task-trace.test.ts
@@ -212,11 +212,15 @@ describe("AI 分析全流程追踪", () => {
         timestamp
       );
       runtime.database.run(
-        `INSERT INTO ai_call_traces (call_id, task_id, initial_messages_json, rounds_json, created_at, updated_at)
-         VALUES (?, ?, ?, '[]', ?, ?)`,
+        `INSERT INTO ai_call_traces (call_id, task_id, initial_messages_json, rounds_json, source_refs_json, created_at, updated_at)
+         VALUES (?, ?, ?, '[]', ?, ?, ?)`,
         callId,
         task.body.data.id,
         JSON.stringify(initialMessages),
+        JSON.stringify(index === 0 ? [
+          { type: "chapter", title: "第一章" },
+          { type: "setting", title: "旧港盟约" }
+        ] : []),
         timestamp,
         timestamp
       );

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -1031,7 +1031,12 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
       scope: { type: "settings" }
     }).expect(201);
     expect(task.body.data.scopeSummary).toBe("仅设定集");
-    expect(task.body.data.sourceVersions).toEqual({ [`setting:${settingId}`]: 1 });
+    expect(task.body.data.sourceVersions).toMatchObject({
+      [`work:${workId}`]: 1,
+      [`setting:${settingId}`]: 1,
+      [`character:${linId}`]: 1,
+      [`character:${shenId}`]: 1
+    });
     const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
     expect(result.body.data.result).toMatchObject({
       candidateCount: 1,
@@ -1047,6 +1052,30 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
       subtype: "朋友",
       evidence: [{ settingId, settingTitle: "北港旧友", quote: "林舟与沈星自幼相识，是彼此最信任的朋友。" }]
     });
+  });
+
+  it("仅设定集任务在其他设定数据变化后过期", async () => {
+    runtime = createTestRuntime();
+    const work = await request(runtime.app).post("/api/works").send({ title: "设定新鲜度" }).expect(201);
+    const workId = String(work.body.data.id);
+    const organization = await request(runtime.app).post(`/api/works/${workId}/organizations`).send({
+      name: "守望会",
+      description: "负责旧港航线。"
+    }).expect(201);
+    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
+      taskType: "relationship-analysis",
+      scope: { type: "settings" }
+    }).expect(201);
+    expect(task.body.data.sourceVersions).toMatchObject({
+      [`work:${workId}`]: 1,
+      [`organization:${String(organization.body.data.id)}`]: 1
+    });
+
+    await request(runtime.app).patch(`/api/organizations/${organization.body.data.id}`).send({
+      description: "改为负责深空航线。"
+    }).expect(200);
+    const expired = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({}).expect(200);
+    expect(expired.body.data.status).toBe("expired");
   });
 
   it("选择角色后先收集跨章节证据再进行全局关系归纳", async () => {

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -1176,12 +1176,22 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     await request(runtime.app).post(`/api/works/${workId}/settings`).send({
       title: "无关天文规则",
       category: "世界规则",
-      content: "双月每隔百年重合一次，不含目标人物。"
+      content: "双月每隔百年重合一次，不含目标人物。",
+      locked: true
+    }).expect(201);
+    await request(runtime.app).post(`/api/works/${workId}/characters`).send({
+      name: "旁观者",
+      attributes: { identity: "绝密旁观者自动注入标记" },
+      lockedFields: ["identity"]
     }).expect(201);
     await request(runtime.app).post(`/api/works/${workId}/organizations`).send({
       name: "守望会",
       description: "负责旧港航线。",
       memberIds: [target.body.data.id]
+    }).expect(201);
+    await request(runtime.app).post(`/api/works/${workId}/organizations`).send({
+      name: "星图局",
+      description: "无关组织自动注入标记。"
     }).expect(201);
     const modelId = await configureAi(runtime, workId);
     const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
@@ -1199,6 +1209,8 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     expect(sent).not.toContain("另一章也没有目标人物，不应发送。");
     expect(sent).toContain("阿宁与顾川在旧港订立了长期守望盟约。");
     expect(sent).not.toContain("双月每隔百年重合一次，不含目标人物。");
+    expect(sent).not.toContain("绝密旁观者自动注入标记");
+    expect(sent).not.toContain("无关组织自动注入标记");
     expect(sent).toContain('title="组织设定：守望会"');
   });
 

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -1083,21 +1083,22 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(protectedReadableTaskDetail.body.data.resultSummary.restricted).toBe(true);
     expect(protectedReadableTaskDetail.body.data.resultSummary.sections).toEqual([]);
     expect(JSON.stringify(protectedReadableTaskDetail.body.data)).not.toContain("TOP_SECRET_CHARACTER");
-    const protectedFullTaskResult = await analysisOnly.agent.get(`/api/tasks/${targetedTask.body.data.id}/result`).expect(200);
-    expect(protectedFullTaskResult.body.data.result.relationshipResults[0].fromCharacterName).toBeUndefined();
-    expect(protectedFullTaskResult.body.data.result.relationshipResults[0].toCharacterName).toBeUndefined();
-    expect(protectedFullTaskResult.body.data.result.analysisTarget.characterNames).toBeUndefined();
-    expect(JSON.stringify(protectedFullTaskResult.body.data)).not.toContain("TOP_SECRET_CHARACTER");
+    const protectedFullTaskResult = await analysisOnly.agent.get(`/api/tasks/${targetedTask.body.data.id}/result`).expect(403);
+    expect(protectedFullTaskResult.body.error.code).toBe("WORK_MODULE_READ_DENIED");
     const protectedTimelineDetail = await analysisOnly.agent.get(`/api/tasks/${timelineTask.body.data.id}/detail`).expect(200);
     expect(protectedTimelineDetail.body.data.resultSummary.restricted).toBe(true);
     expect(protectedTimelineDetail.body.data.resultSummary.sections).toEqual([]);
     expect(JSON.stringify(protectedTimelineDetail.body.data)).not.toContain("TOP_SECRET_TIMELINE");
+    const protectedTimelineResult = await analysisOnly.agent.get(`/api/tasks/${timelineTask.body.data.id}/result`).expect(403);
+    expect(protectedTimelineResult.body.error.code).toBe("WORK_MODULE_READ_DENIED");
     const protectedSelectionDetail = await analysisOnly.agent.get(`/api/tasks/${secretSelectionTask.body.data.id}/detail`).expect(200);
     expect(protectedSelectionDetail.body.data.scopeSummary).toBe("选定内容（正文读取权限受限）");
     expect(protectedSelectionDetail.body.data.scope.selection).toBeUndefined();
     expect(protectedSelectionDetail.body.data.scopeDetails).toEqual([{ type: "selection", restricted: true }]);
     expect(protectedSelectionDetail.body.data.resultSummary.restricted).toBe(true);
     expect(JSON.stringify(protectedSelectionDetail.body.data)).not.toContain("TOP_SECRET_SELECTION_PROSE");
+    const protectedSelectionResult = await analysisOnly.agent.get(`/api/tasks/${secretSelectionTask.body.data.id}/result`).expect(403);
+    expect(protectedSelectionResult.body.error.code).toBe("WORK_MODULE_READ_DENIED");
     const protectedTaskCancellation = await analysisOnly.agent.post(`/api/tasks/${targetedTask.body.data.id}/cancel`)
       .set("X-CSRF-Token", analysisOnly.csrfToken)
       .send({})

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -74,7 +74,7 @@ describe("数据库版本化迁移", () => {
       { display_name: "Mothra", kind: "alias" },
       { display_name: "拉顿", kind: "primary" }
     ]);
-    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }, { version: 4 }, { version: 5 }, { version: 6 }, { version: 7 }, { version: 8 }, { version: 9 }, { version: 10 }, { version: 11 }, { version: 12 }, { version: 13 }, { version: 14 }, { version: 15 }, { version: 16 }, { version: 17 }, { version: 18 }, { version: 19 }, { version: 20 }, { version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }, { version: 26 }, { version: 27 }, { version: 28 }, { version: 29 }, { version: 30 }, { version: 31 }, { version: 32 }, { version: 33 }, { version: 34 }, { version: 35 }, { version: 36 }, { version: 37 }, { version: 38 }, { version: 39 }, { version: 40 }, { version: 41 }, { version: 42 }]);
+    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual([{ version: 1 }, { version: 2 }, { version: 3 }, { version: 4 }, { version: 5 }, { version: 6 }, { version: 7 }, { version: 8 }, { version: 9 }, { version: 10 }, { version: 11 }, { version: 12 }, { version: 13 }, { version: 14 }, { version: 15 }, { version: 16 }, { version: 17 }, { version: 18 }, { version: 19 }, { version: 20 }, { version: 21 }, { version: 22 }, { version: 23 }, { version: 24 }, { version: 25 }, { version: 26 }, { version: 27 }, { version: 28 }, { version: 29 }, { version: 30 }, { version: 31 }, { version: 32 }, { version: 33 }, { version: 34 }, { version: 35 }, { version: 36 }, { version: 37 }, { version: 38 }, { version: 39 }, { version: 40 }, { version: 41 }, { version: 42 }, { version: 43 }]);
     expect(first.all("PRAGMA table_info(characters)").map((column) => column.name)).toEqual(expect.arrayContaining(["code", "merged_into_character_id", "merged_at"]));
     expect(first.all("PRAGMA table_info(characters)").some((column) => column.name === "visibility")).toBe(false);
     expect(first.get("SELECT code FROM characters WHERE id = 'character-a'")).toEqual({ code: "" });
@@ -104,7 +104,7 @@ describe("数据库版本化迁移", () => {
     expect(first.all("PRAGMA index_list(analysis_tasks)").some((index) => index.name === "idx_tasks_work_created")).toBe(true);
     expect(first.all("PRAGMA table_info(ai_calls)").some((column) => column.name === "task_id")).toBe(true);
     expect(first.all("PRAGMA table_info(ai_call_traces)").map((column) => column.name)).toEqual(
-      expect.arrayContaining(["call_id", "task_id", "initial_messages_json", "rounds_json", "created_at", "updated_at"])
+      expect.arrayContaining(["call_id", "task_id", "initial_messages_json", "rounds_json", "source_refs_json", "created_at", "updated_at"])
     );
     expect(first.all("PRAGMA index_list(ai_calls)").some((index) => index.name === "idx_calls_task")).toBe(true);
     expect(first.all("PRAGMA index_list(ai_call_traces)").some((index) => index.name === "idx_ai_call_traces_task")).toBe(true);
@@ -266,6 +266,30 @@ describe("数据库版本化迁移", () => {
     );
     expect(migrated.all("PRAGMA index_list(ai_calls)").some((index) => index.name === "idx_calls_task")).toBe(true);
     expect(migrated.all("PRAGMA index_list(ai_call_traces)").some((index) => index.name === "idx_ai_call_traces_task")).toBe(true);
+    migrated.close();
+  });
+
+  it("为历史任务追踪补充轻量来源标题字段", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-trace-source-refs-"));
+    roots.push(root);
+    const filename = join(root, "trace-source-refs.db");
+    const current = new Database(filename);
+    current.close();
+
+    const legacy = new DatabaseSync(filename);
+    legacy.exec(`
+      ALTER TABLE ai_call_traces DROP COLUMN source_refs_json;
+      DELETE FROM schema_migrations WHERE version = 43;
+    `);
+    legacy.close();
+
+    const migrated = new Database(filename);
+    expect(migrated.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 43")?.count).toBe(1);
+    const sourceRefsColumn = migrated.all("PRAGMA table_info(ai_call_traces)")
+      .find((column) => column.name === "source_refs_json");
+    expect(sourceRefsColumn).toMatchObject({ notnull: 1, dflt_value: "'[]'" });
+    expect(migrated.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
     migrated.close();
   });
 });


### PR DESCRIPTION
## What changed

- suppress generic locked settings, character fields, organizations, and relationship constraints from targeted relationship chunks after keyword filtering
- require the task-specific content module permission before returning a full analysis result
- persist trace source title summaries so the task summary endpoint no longer reads or parses complete prompts and rounds
- track every data source consumed by settings-only relationship analysis and expire queued tasks when any source changes

## Why

An independent post-merge review found two permission/context correctness blockers and two performance/freshness gaps before the planned patch release.

## Validation

- `npm run typecheck`: passed
- `npm test`: 78 files, 388 tests passed
- `npm run build`: passed
- targeted permission, relationship-analysis, trace, and migration tests passed
- migration 43 verifies `integrity_check` and `foreign_key_check`
