### PR TITLE
build(release): release v0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "MIT",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.1";
+export const APP_VERSION = "0.5.2";


### PR DESCRIPTION
## 变更

- 将应用、npm 包与锁文件版本从 `0.5.1` 提升至 `0.5.2`
- 本版本包含 #161、#162 与审查修复 #163

## 验证

- `npm run check`
- 78 个测试文件、388 项测试全部通过
- TypeScript 类型检查与生产构建通过