### PR TITLE
build(release): release v0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.2";
+export const APP_VERSION = "0.5.3";


### PR DESCRIPTION
## Summary

- bump package and application version from 0.5.2 to 0.5.3
- prepare the patch release after the relationship pinyin index feature merged into develop

## Verification

- npm run check
- 81 test files, 405 tests passed
- production build passed