### PR TITLE
build(release): release v0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.3";
+export const APP_VERSION = "0.5.4";


### PR DESCRIPTION
## 版本

将 Scriverse 从 `0.5.3` 升级到 `0.5.4`。

## 变更范围

- `package.json`
- `package-lock.json`
- `src/version.ts`

## 验证

- `npm run check`
- 类型检查通过
- 83 个测试文件、412 项测试通过
- 生产构建通过
