### PR TITLE
build(vercel): skip unrelated site deployments

### DIFF
--- a/demo/vercel.json
+++ b/demo/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "cleanUrls": true,

--- a/showcase/vercel.json
+++ b/showcase/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./",
   "buildCommand": "npm run build:static",
   "outputDirectory": "dist/client",
   "cleanUrls": true


### PR DESCRIPTION
## 变更

- 为 Demo Vercel 项目增加 Ignored Build Step，只在 `demo/` 发生变化时继续构建
- 为 Showcase Vercel 项目增加 Ignored Build Step，只在 `showcase/` 发生变化时继续构建

## 原因

仓库中的后端、测试或文档变动无需重新部署两个静态站点。由各项目的 `vercel.json` 固化差异检查规则，避免执行无关构建。

## 影响

配置合并后由 Vercel Git 部署自动读取，无需在控制台重复设置 Ignored Build Step。前提是两个 Vercel 项目的 Root Directory 继续分别保持为 `demo` 和 `showcase`。

## 验证

- `demo`: `npm run check`
- `showcase`: `npm test`
- `showcase`: `npm run build:static`
- 两份 `vercel.json` JSON 解析检查
- `git diff --check`
