### PR TITLE
build(release): release v0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.4";
+export const APP_VERSION = "0.5.5";


### PR DESCRIPTION
## 版本

将 Scriverse 从 `0.5.4` 升级到 `0.5.5`，为 `develop` 合入 `main` 的补丁版本发布做准备。

## 变更范围

- `package.json`
- `package-lock.json`
- `src/version.ts`

## 影响

应用版本、npm 包版本与锁文件根版本保持一致，不改变运行时业务行为。

## 验证

- `npm run check`
- 类型检查通过
- 90 个测试文件、441 项测试通过
- 生产构建通过
