### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.5";
+export const APP_VERSION = "0.5.6";


### PR DESCRIPTION
## 变更

- 将 Scriverse 版本从 `0.5.5` 更新到 `0.5.6`
- 同步根包、锁文件与运行时版本常量
- demo 继续自动继承主项目版本

## 验证

- `npm run check`
- `npm --prefix demo run check`
- 90 个测试文件、446 项主项目测试通过
- 12 项 demo 测试通过