### PR TITLE
fix(database): index paragraph search cleanup

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -2209,6 +2209,19 @@ export class Database {
       const foreignKeys = this.all("PRAGMA foreign_key_check");
       if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
     }
+    if (!applied.has(52)) {
+      this.transaction(() => {
+        this.run(`CREATE INDEX IF NOT EXISTS idx_chapter_paragraph_short_terms_paragraph
+          ON chapter_paragraph_short_terms(paragraph_id)`);
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (52, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
   }
 
   private normalizeCharacterName(value: string): string {

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -74,7 +74,7 @@ describe("数据库版本化迁移", () => {
       { display_name: "Mothra", kind: "alias" },
       { display_name: "拉顿", kind: "primary" }
     ]);
-    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual(Array.from({ length: 51 }, (_, index) => ({ version: index + 1 })));
+    expect(first.all("SELECT version FROM schema_migrations ORDER BY version")).toEqual(Array.from({ length: 52 }, (_, index) => ({ version: index + 1 })));
     expect(first.all("PRAGMA table_info(characters)").map((column) => column.name)).toEqual(expect.arrayContaining(["code", "merged_into_character_id", "merged_at"]));
     expect(first.all("PRAGMA table_info(characters)").some((column) => column.name === "visibility")).toBe(false);
     expect(first.get("SELECT code FROM characters WHERE id = 'character-a'")).toEqual({ code: "" });
@@ -148,6 +148,12 @@ describe("数据库版本化迁移", () => {
     });
     expect(first.all("PRAGMA table_info(platform_ui_settings)").some((column) => column.name === "page_sizes_json")).toBe(true);
     expect(first.get("SELECT chapter_id, content FROM chapter_paragraph_search WHERE chapter_id = 'chapter-old'")).toEqual({ chapter_id: "chapter-old", content: "旧正文" });
+    expect(first.all("PRAGMA index_list(chapter_paragraph_short_terms)").some(
+      (index) => index.name === "idx_chapter_paragraph_short_terms_paragraph"
+    )).toBe(true);
+    expect(first.all("EXPLAIN QUERY PLAN DELETE FROM chapter_paragraph_short_terms WHERE paragraph_id = 1").some(
+      (step) => String(step.detail).includes("idx_chapter_paragraph_short_terms_paragraph")
+    )).toBe(true);
     expect(first.get(`SELECT paragraph.rowid AS id FROM chapter_paragraph_search_fts paragraph
       WHERE chapter_paragraph_search_fts MATCH '"旧正文"'`)).toEqual({ id: 1 });
     expect(first.all("PRAGMA table_info(work_ai_settings)").map((column) => column.name)).toEqual(


### PR DESCRIPTION
## 变更内容

- 新增 schema 52 数据库迁移，为 `chapter_paragraph_short_terms(paragraph_id)` 建立索引
- 增加迁移测试和 SQLite 查询计划断言

## 根因

删除章节会级联清理正文段落对应的短词索引。短词表原有主键为 `(term, paragraph_id)`，无法支持按 `paragraph_id` 查找，导致每删除一个段落都全表扫描短词索引；数据量较大时会造成严重 CPU、I/O 和 WAL 写入压力，最终可能出现请求超时或进程被资源限制终止。

## 影响

- 已有数据库升级时自动补建索引
- 新建数据库自动执行同一迁移
- 章节删除的短词索引清理从全表扫描改为索引查找

## 验证

- `npm run typecheck`
- `npm test`
- `npm run build`
- 章节删除集成测试：23 项通过
- 隔离服务健康检查通过
- `PRAGMA integrity_check` 返回 `ok`
- `PRAGMA foreign_key_check` 无异常
- 查询计划命中 `idx_chapter_paragraph_short_terms_paragraph`