### PR TITLE
chore(release): bump version to 0.5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.6";
+export const APP_VERSION = "0.5.7";


### PR DESCRIPTION
## 变更内容

- 将 package.json 与 package-lock.json 的版本升级至 0.5.7。
- 将运行时 APP_VERSION 同步升级至 0.5.7。

## 原因与影响

按补丁版本发布流程准备 Scriverse v0.5.7，确保 npm 包、运行时健康接口和后续 Git 标签使用一致版本。

## 验证

- npm run typecheck
- npm test：90 个测试文件、449 项测试通过
- npm run build
- npm pack --dry-run：确认生成 @musnows/scriverse@0.5.7 发布包