### PR TITLE
chore(release): bump version to 0.5.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.7";
+export const APP_VERSION = "0.5.8";


### PR DESCRIPTION
## 发布版本

将 Scriverse 补丁版本从 0.5.7 更新到 0.5.8。

## 版本文件

- package.json
- package-lock.json
- src/version.ts

## 验证

- npm run typecheck
- safe-ai-fetch 单测 6 项通过
- npm test：450 项通过
- npm run build