### PR TITLE
build(release): bump version to 0.5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.8";
+export const APP_VERSION = "0.5.9";


### PR DESCRIPTION
## 变更

- 将 package.json、package-lock.json 与 src/version.ts 统一更新为 0.5.9。
- 该补丁版本基于最新 develop，包含已合入的 #218。

## 验证

- npm run typecheck
- npm test（93 个测试文件、473 个测试通过）
- npm run build