### PR TITLE
fix(docker): optimize runtime layer ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,6 @@ RUN npm run build
 
 FROM ${NODE_IMAGE} AS runtime
 
-ENV NODE_ENV=production \
-    SCRIVERSE_RUNTIME=container \
-    LOG_LEVEL=info \
-    HOST=0.0.0.0 \
-    PORT=13210 \
-    DATA_DIR=/app/.data
-
 WORKDIR /app
 
 RUN mkdir -p /app/.data && chown node:node /app/.data
@@ -39,10 +32,16 @@ RUN mkdir -p /app/.data && chown node:node /app/.data
 COPY --from=dependency-manifests /manifests/package.json /manifests/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci --omit=dev
 
-COPY --chown=node:node src/public ./src/public
 COPY --from=build /app/dist ./dist
 
 COPY package.json package-lock.json ./
+
+ENV NODE_ENV=production \
+    SCRIVERSE_RUNTIME=container \
+    LOG_LEVEL=info \
+    HOST=0.0.0.0 \
+    PORT=13210 \
+    DATA_DIR=/app/.data
 
 USER node
 

--- a/tests/unit/docker-package-manifests.test.ts
+++ b/tests/unit/docker-package-manifests.test.ts
@@ -69,14 +69,15 @@ describe("Docker 依赖清单规范化", () => {
     const runtimeStage = dockerfile.slice(dockerfile.indexOf("AS runtime"));
     const normalizedManifestCopy = runtimeStage.indexOf("COPY --from=dependency-manifests");
     const productionInstall = runtimeStage.indexOf("npm ci --omit=dev");
-    const publicCopy = runtimeStage.indexOf("COPY --chown=node:node src/public");
     const buildCopy = runtimeStage.indexOf("COPY --from=build /app/dist");
     const versionedManifestCopy = runtimeStage.lastIndexOf("COPY package.json package-lock.json");
+    const runtimeEnv = runtimeStage.indexOf("ENV NODE_ENV=production");
 
     expect(normalizedManifestCopy).toBeGreaterThan(-1);
     expect(productionInstall).toBeGreaterThan(normalizedManifestCopy);
-    expect(publicCopy).toBeGreaterThan(productionInstall);
-    expect(buildCopy).toBeGreaterThan(publicCopy);
+    expect(runtimeStage).not.toContain("COPY --chown=node:node src/public");
+    expect(buildCopy).toBeGreaterThan(productionInstall);
     expect(versionedManifestCopy).toBeGreaterThan(buildCopy);
+    expect(runtimeEnv).toBeGreaterThan(versionedManifestCopy);
   });
 });


### PR DESCRIPTION
## 变更

- 将 runtime 阶段的 `ENV` 移到依赖安装和应用文件复制之后，避免运行时默认配置变化导致 `npm ci` 缓存失效。
- 删除重复的 `src/public` 复制；构建产物中的 `dist/public` 已包含运行时所需静态资源。
- 更新 Docker 分层回归测试，锁定上述顺序和重复复制约束。

## 验证

- `npx vitest run tests/unit/docker-package-manifests.test.ts`：3/3 通过。
- `npm run typecheck`：通过。
- `npm run build`：通过。
- `docker buildx build --check .`：通过。
- `docker buildx build --target runtime --progress=plain .`：通过。

全量 unit 测试中有 1 项既有公网地址测试因访问 `example.com` 超时，其他 241 项通过，与本次改动无关。