### PR TITLE
build(release): bump version to 0.5.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.9";
+export const APP_VERSION = "0.5.10";


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本更新为 `0.5.10`。
- 同步应用展示版本与锁文件版本。

## 验证

- `npm run typecheck`
- 版本相关测试：2 个测试文件、5 个测试通过
- `npm run build`