### PR TITLE
build(release): bump version to 0.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.10";
+export const APP_VERSION = "0.5.11";


### PR DESCRIPTION
## 改动

- 将 package、lockfile 与运行时版本统一更新为 `0.5.11`。

## 发布前置

- 已完成 `develop` 相对 `main` 的 CLI 契约审计。
- 草稿 CLI 支持已通过独立 PR #234 合入 `develop`。

## 验证

- 编译后真实 CLI E2E 通过，覆盖 12 种资源。
- `npm test` 通过：97 个测试文件、486 项测试。
- `npm run typecheck` 通过。
- 版本一致性及产品页测试通过：2 个文件、3 项测试。
- `npm run build` 通过。
