### PR TITLE
fix(ui): hide member checkbox inputs in entity editor

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260730-table-wrap-menu-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260730-member-chip-input-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -2613,6 +2613,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .character-editor-section-fields textarea { min-height: 120px; resize: vertical; line-height: 1.65; }
 .character-editor-section-fields .section-list-row textarea { min-height: 180px; }
 .character-editor-section-fields .member-chip { position: relative; display: inline-flex; width: auto; cursor: pointer; }
+.character-editor-section-fields .member-chip input[type="checkbox"] { position: absolute; width: 1px !important; min-width: 1px; height: 1px; padding: 0; border: 0; opacity: 0; }
 .character-editor-section-fields .item-list-row button, .character-editor-section-fields .structured-list-row button { min-width: 54px; }
 .knowledge-markdown-sections { display: grid; grid-column: 1 / -1; gap: 14px; min-width: 0; }
 .knowledge-markdown-list-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -321,7 +321,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
     expect(page.text).toContain('/app.js?v=20260730-table-wrap-menu-v1');
-    expect(page.text).toContain('/styles.css?v=20260730-table-wrap-menu-v1');
+    expect(page.text).toContain('/styles.css?v=20260730-member-chip-input-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260730-table-wrap-menu-v1');
+    expect(page.text).toContain('/styles.css?v=20260730-member-chip-input-v1');
     expect(page.text).toContain('/app.js?v=20260730-table-wrap-menu-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260730-table-wrap-menu-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
@@ -36,6 +36,7 @@ describe("知识模块布局切换", () => {
     expect(application.text).toContain('/module-layout.js?v=20260723-module-layout-toggle');
     expect(styles.text).toContain('input[type="checkbox"] {');
     expect(styles.text).toContain('input[type="checkbox"]:checked::before');
+    expect(styles.text).toContain('.character-editor-section-fields .member-chip input[type="checkbox"] { position: absolute; width: 1px !important; min-width: 1px; height: 1px; padding: 0; border: 0; opacity: 0; }');
     expect(styles.text).toContain('.setting-editor-lock span { display: inline-flex; align-items: center; min-height: 16px; line-height: 16px; }');
     expect(application.text).toContain('data-module-layout="cards"');
     expect(application.text).toContain('data-module-layout="rows"');


### PR DESCRIPTION
## 变更内容

- 在人物、种族和组织档案的成员标签作用域内，稳定隐藏原生复选框控件。
- 更新 `styles.css` 缓存版本，确保浏览器加载修复后的样式。
- 增加系统测试断言，防止成员标签的隐藏控件再次被通用表单样式覆盖。

## 问题原因

只读档案会禁用成员复选框。全局禁用样式把本应透明的控件改为半透明，同时档案编辑器的通用输入框规则覆盖了控件尺寸和边框，导致每个角色标签左上角露出一个方框。

## 用户影响

只读组织或种族档案中的角色标签不再显示异常方框；进入编辑模式后，点击标签选择角色的行为保持不变。

## 验证

- `npx vitest run tests/system/module-layout-toggle.test.ts tests/system/author-journey.test.ts --maxWorkers=1`：9 项通过。
- `npm test`：97 个测试文件、486 项测试全部通过。
- `npm run build`：通过。
- 隔离开发服务健康检查：HTTP 200。
- 隔离 SQLite：`PRAGMA integrity_check` 与 `PRAGMA foreign_key_check` 通过。
- 内置浏览器验证只读和编辑状态：异常方框消失、角色标签仍可选择、控制台无新增错误。