### PR TITLE
chore(release): bump version to 0.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.5.11";
+export const APP_VERSION = "0.5.12";


### PR DESCRIPTION
### 变更

- 将 package、lockfile 和运行时版本从 0.5.11 bump 到 0.5.12。

### 验证

- npm run check
- npm run test:e2e:cli

CLI 审计确认本次 develop 相对 main 的功能改动未改变 CLI 契约，无需同步 CLI。