### PR TITLE
fix(ui): center draft filter controls

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260730-drafts-stream-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260730-drafts-filter-align-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1275,7 +1275,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .character-filter-toolbar-actions { display: flex; align-items: center; justify-content: flex-end; gap: 12px; min-height: 38px; }
 .character-filter-result-count { color: var(--muted); font-size: 11px; white-space: nowrap; }
 .character-filter-toolbar-actions button:disabled { cursor: default; opacity: .45; }
-.draft-filter-toolbar { display: flex; align-items: end; gap: 10px; margin-bottom: 18px; padding: 12px 14px; border: 1px solid var(--line); background: var(--surface-soft); }
+.draft-filter-toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; padding: 12px 14px; border: 1px solid var(--line); background: var(--surface-soft); }
 .draft-filter-toolbar label { color: var(--muted); font-size: 11px; }
 .draft-filter-toolbar select { min-width: 180px; min-height: 38px; padding: 8px 10px; background: var(--surface); font-size: 11px; }
 .draft-filter-toolbar span { margin-left: auto; align-self: center; color: var(--muted); font-size: 11px; }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -321,7 +321,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
     expect(page.text).toContain('/app.js?v=20260730-volume-lazy-module-cache-v1');
-    expect(page.text).toContain('/styles.css?v=20260730-drafts-stream-v1');
+    expect(page.text).toContain('/styles.css?v=20260730-drafts-filter-align-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');

--- a/tests/system/drafts-ui.test.ts
+++ b/tests/system/drafts-ui.test.ts
@@ -41,6 +41,7 @@ describe("草稿模块界面", () => {
     expect(application.text).not.toContain('data-delete-draft');
     expect(application.text).toContain('editor: true');
     expect(application.text).toContain('dialog.classList.toggle("editor-dialog", Boolean(options.editor))');
+    expect(styles.text).toContain('.draft-filter-toolbar { display: flex; align-items: center;');
     expect(styles.text).toContain('.draft-filter-toolbar select { min-width: 180px; min-height: 38px;');
     expect(styles.text).toContain('font-size: 11px; }');
     expect(styles.text).toContain('.editor-dialog { width: min(1180px, 94vw); max-height: calc(100dvh - 16px); }');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260730-drafts-stream-v1');
+    expect(page.text).toContain('/styles.css?v=20260730-drafts-filter-align-v1');
     expect(page.text).toContain('/app.js?v=20260730-volume-lazy-module-cache-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260730-volume-lazy-module-cache-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');


### PR DESCRIPTION
## 变更

- 将草稿筛选栏的标签与下拉框改为垂直居中。
- 保留窄屏下的纵向布局。
- 更新 CSS 缓存版本并增加回归断言。

## 根因

草稿筛选栏原先使用 `align-items: end`，导致标签贴近下边缘，与下拉框的垂直中心线错位。

## 验证

- `npm run test:system -- --run tests/system/drafts-ui.test.ts`：21 个测试文件、36 个测试通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。
- 内置浏览器验证 1280×720 与 390×844，确认控件对齐、无横向溢出且控制台无错误。