### PR TITLE
fix(ai): accept thinking-only probe responses

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1827,7 +1827,8 @@ export class AiManager {
     } catch {
       throw new Error(`${protocol === "anthropic-messages" ? "Anthropic Messages" : "Chat Completions"} 返回了无效 JSON`);
     }
-    if (!payload.choices?.[0]?.message?.content?.trim()) {
+    const message = payload.choices?.[0]?.message;
+    if (!message?.content?.trim() && !message?.reasoning_content?.trim()) {
       throw new Error(`${protocol === "anthropic-messages" ? "Anthropic Messages" : "Chat Completions"} 响应缺少可用回复`);
     }
   }

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -90,7 +90,7 @@ describe("AI 供应商、模型与建议 API", () => {
     }).expect(409);
   });
 
-  it("连接测试必须用 max_tokens=10 收到真实助手回复", async () => {
+  it("连接测试必须用 max_tokens=10 收到正文或 thinking", async () => {
     const { providerId } = await configureAi();
     fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) {
@@ -107,6 +107,30 @@ describe("AI 供应商、模型与建议 API", () => {
     const tested = await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
     expect(tested.body.data).toMatchObject({ ok: false, provider: { connectionStatus: "failed" } });
     expect(tested.body.data.error).toContain("响应缺少可用回复");
+  });
+
+  it("连接测试在只有 thinking 时也视为成功", async () => {
+    const { providerId } = await configureAi();
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) {
+        return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      }
+      const body = JSON.parse(String(init?.body)) as { max_tokens?: number };
+      expect(body.max_tokens).toBe(10);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "", reasoning_content: "正在确认连接。" } }]
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    });
+
+    const tested = await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    expect(tested.body.data).toMatchObject({
+      ok: true,
+      availableModels: ["mock-novel-model"],
+      provider: { connectionStatus: "success" }
+    });
   });
 
   it("可以单独测试指定模型并使用该模型标识符", async () => {


### PR DESCRIPTION
## 变更

- 模型连接探测同时接受非空正文或非空 thinking/reasoning 响应。
- 增加仅返回 `reasoning_content`、正文为空时仍判定连接成功的回归测试。
- 保留超时、非成功 HTTP、无效 JSON，以及正文和 thinking 均为空时的失败行为。

## 原因与影响

连接探测只给模型 `max_tokens=10`。推理模型可能把这部分预算全部用于 thinking，返回有效的 `reasoning_content`，但最终正文仍为空。旧逻辑只检查 `message.content`，因此会误报“响应缺少可用回复”。

修复后，只要探测响应包含正文或 thinking，供应商/模型连接状态即可标记为成功。

## 验证

- `npm run typecheck`：通过。
- `npm test`：此前完整运行 513/513 通过；同步最新 `develop` 后一次运行 512/513 通过，唯一失败为 `safe-ai-fetch` 对 `example.com` 的 DNS 解析超过 5 秒。
- `npx vitest run tests/unit/safe-ai-fetch.test.ts`：重跑 6/6 通过。
- `npm run build`：通过。
- `git diff --check origin/develop...HEAD`：通过。