### PR TITLE
fix(ui): tighten left panel scrollbar spacing

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260731-comments-develop-merge-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260731-left-scroll-gap-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -509,7 +509,7 @@ input[type="checkbox"][hidden] { display: none; }
 
 .left-panel, .ai-panel { position: relative; min-height: 0; background: var(--panel); }
 .left-panel { display: flex; flex-direction: column; border-right: 1px solid var(--line); padding: 0; overflow: hidden; }
-.left-panel-body { flex: 1 1 auto; min-height: 0; padding: 18px 28px 16px 14px; overflow-y: auto; scrollbar-gutter: stable; }
+.left-panel-body { flex: 1 1 auto; min-height: 0; padding: 18px 24px 16px 14px; overflow-y: auto; scrollbar-gutter: stable; }
 .ai-panel { border-left: 1px solid var(--line); display: flex; flex-direction: column; padding: 14px 16px 18px; min-width: 0; }
 .panel-collapse-button { z-index: 8; flex: 0 0 auto; width: 24px; height: 24px; padding: 0; border: 1px solid var(--line); border-radius: 4px; background: var(--panel); color: var(--muted); font-size: 18px; line-height: 1; }
 .ai-heading #ai-panel-toggle { flex-basis: 30px; width: 30px; height: 30px; }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -321,7 +321,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
     expect(page.text).toContain('/app.js?v=20260731-comments-develop-merge-v1');
-    expect(page.text).toContain('/styles.css?v=20260731-comments-develop-merge-v1');
+    expect(page.text).toContain('/styles.css?v=20260731-left-scroll-gap-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');
@@ -719,7 +719,7 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".book-card-settings {");
     expect(styles.text).toContain("padding: 2px 6px;");
     expect(styles.text).toContain(".left-panel { display: flex; flex-direction: column; border-right: 1px solid var(--line); padding: 0; overflow: hidden; }");
-    expect(styles.text).toContain(".left-panel-body { flex: 1 1 auto; min-height: 0; padding: 18px 28px 16px 14px; overflow-y: auto; scrollbar-gutter: stable; }");
+    expect(styles.text).toContain(".left-panel-body { flex: 1 1 auto; min-height: 0; padding: 18px 24px 16px 14px; overflow-y: auto; scrollbar-gutter: stable; }");
     expect(styles.text).toContain(".left-panel-body { padding-inline: 10px 24px; }");
     expect(page.text).toContain('class="left-panel-body"');
     expect(styles.text).toContain(".left-actions { display: block; margin: 0 0 15px; }");

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260731-comments-develop-merge-v1');
+    expect(page.text).toContain('/styles.css?v=20260731-left-scroll-gap-v1');
     expect(page.text).toContain('/app.js?v=20260731-comments-develop-merge-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260731-comments-develop-merge-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');


### PR DESCRIPTION
## 变更内容

- 将桌面端作品侧栏滚动容器的右内边距从 `28px` 缩小到 `24px`
- 更新样式资源缓存版本，确保浏览器加载新样式
- 同步更新相关系统测试断言

## 修复原因

作品目录内容与右侧滚动条之间的留白略大，视觉上显得分离。本次仅收窄 4px，保留原有滚动行为、章节布局和响应式规则。

## 用户影响

目录内容会稍微靠近滚动条，整体更紧凑；窄屏布局和其他面板不受影响。

## 验证

- `npm run typecheck`
- `npm test`：103 个测试文件、517 项用例通过
- `npm run build`
- 内置浏览器桌面与窄屏验收：纵向滚动正常、无横向溢出、无新增控制台错误
- SQLite 隔离验收数据库：`PRAGMA integrity_check` 通过