### PR TITLE
feat(cli): list annotations across a work

### DIFF
--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -496,6 +496,7 @@ function helpText(): string {
   scriverse audit <workId>
   scriverse writing progress <workId>
   scriverse annotation list <chapterId>
+  scriverse annotation list-work <workId>
 
 编辑：
   scriverse work create --input <json-file|->
@@ -536,7 +537,7 @@ function schemaList(): Record<string, unknown> {
     commands: {
       writing: ["progress", "goal"],
       chapter: ["move", "batch"],
-      annotation: ["list", "create", "update", "delete"],
+      annotation: ["list", "list-work", "create", "update", "delete"],
       manuscript: ["get"]
     },
     prohibited: ["用户管理", "作品成员管理", "系统管理", "AI 供应商与模型管理", "永久删除及作品、分卷、知识实体删除", "任意 HTTP 请求"],
@@ -845,11 +846,16 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
   }
 
   if (group === "annotation") {
-    const id = requiredPosition(parsed.positionals, 2, action === "list" || action === "create" ? "chapterId" : "annotationId");
+    const id = requiredPosition(parsed.positionals, 2, action === "list-work" ? "workId" : (action === "list" || action === "create" ? "chapterId" : "annotationId"));
     assertPositionCount(parsed.positionals, 3);
     if (action === "list") {
       assertAllowedOptions(parsed, []);
       emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/chapters/${encoded(id)}/annotations`), compact);
+      return;
+    }
+    if (action === "list-work") {
+      assertAllowedOptions(parsed, []);
+      emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/works/${encoded(id)}/chapter-annotations`), compact);
       return;
     }
     if (action === "create") {

--- a/tests/unit/cli-core.test.ts
+++ b/tests/unit/cli-core.test.ts
@@ -359,11 +359,13 @@ describe("Scriverse CLI 核心", () => {
     const updatePath = jsonFile(root, "annotation-update.json", { status: "resolved", expectedVersionNo: 1 });
 
     expect(await run(["annotation", "list", "chapter-1"])).toBe(0);
+    expect(await run(["annotation", "list-work", "work-1"])).toBe(0);
     expect(await run(["annotation", "create", "chapter-1", "--input", createPath])).toBe(0);
     expect(await run(["annotation", "update", "annotation-1", "--input", updatePath])).toBe(0);
     expect(await run(["annotation", "delete", "annotation-1", "--expected-version", "2"])).toBe(0);
     expect(calls).toEqual([
       { url: "http://127.0.0.1:13210/api/chapters/chapter-1/annotations", method: "GET", body: null },
+      { url: "http://127.0.0.1:13210/api/works/work-1/chapter-annotations", method: "GET", body: null },
       { url: "http://127.0.0.1:13210/api/chapters/chapter-1/annotations", method: "POST", body: createBody },
       { url: "http://127.0.0.1:13210/api/chapter-annotations/annotation-1", method: "PATCH", body: { status: "resolved", expectedVersionNo: 1 } },
       { url: "http://127.0.0.1:13210/api/chapter-annotations/annotation-1", method: "DELETE", body: { expectedVersionNo: 2 } }


### PR DESCRIPTION
## 变更

- 新增 `scriverse annotation list-work <workId>` 命令
- 将作品级批注汇总接口加入 CLI 帮助与 schema 输出
- 增加命令路由回归测试

## 原因

`develop` 已支持跨章节浏览作品批注，发布前需要同步 CLI 入口，避免 Web 与 CLI 能力不一致。

## 验证

- `npm run test:unit -- --run tests/unit/cli-core.test.ts`（55 个测试文件、267 个测试通过）
- `npm run typecheck`