### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.0";
+export const APP_VERSION = "0.6.1";


### PR DESCRIPTION
## 变更

- 将 npm 包版本更新为 `0.6.1`
- 将 lockfile 根包版本更新为 `0.6.1`
- 将应用运行时版本更新为 `0.6.1`

## 验证

- `npm exec vitest -- run tests/unit/version.test.ts tests/unit/cli-core.test.ts --maxWorkers=1`（12 个测试通过）
- `npm run typecheck`