### PR TITLE
build(release): bump version to 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.1";
+export const APP_VERSION = "0.6.2";


### PR DESCRIPTION
## 概述

- 将 npm 包和应用版本从 `0.6.1` 更新为 `0.6.2`
- 保持 `package.json`、`package-lock.json` 与 `APP_VERSION` 一致

## CLI 契约审计

已审计 `develop` 相对 `main` 的用户操作、API 路由、认证权限、导入导出格式和现有 CLI 命令。本批次没有新增 API 路由或 CLI 资源契约变化；安全加固已同步 CLI 的远程连接限制，并补充对应测试，因此无需额外 CLI 同步 PR。

## 验证

- `npm run typecheck`
- `npm run test:unit`：56 个测试文件、271 项测试通过
- `npm run build`