### PR TITLE
build(release): bump version to 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",


### PR DESCRIPTION
## 变更

- 将 npm 包版本从 `0.6.1` 更新为 `0.6.2`
- 同步更新 `package-lock.json`

## 验证

- `npm run typecheck`
- `npx vitest run tests/system/product-footer.test.ts`
- `npm run build`
- 发布前全量测试：105 个测试文件、537 个测试通过
- 真实 CLI E2E、桌面与窄屏浏览器验收、健康检查和隔离 SQLite 完整性检查通过