### PR TITLE
fix(release): sync application version

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.1";
+export const APP_VERSION = "0.6.2";


### PR DESCRIPTION
## 问题

版本提交更新了 `package.json` 与 `package-lock.json`，但遗漏了 `src/version.ts`，导致应用报告版本仍为 `0.6.1`。

## 修复

- 将 `APP_VERSION` 同步为 `0.6.2`

## 验证

- `npx vitest run tests/unit/version.test.ts tests/system/product-footer.test.ts`
- `npm run typecheck`
- `npm run build`