### PR TITLE
fix(ai): retain context usage between chat rounds

### DIFF
--- a/src/public/ai-context-meter.js
+++ b/src/public/ai-context-meter.js
@@ -13,6 +13,10 @@ function tokenCount(value) {
   return Math.max(0, Math.round(Number(value) || 0));
 }
 
+export function resolveAiContextUsage(previousUsage, nextUsage) {
+  return nextUsage && typeof nextUsage === "object" ? nextUsage : previousUsage ?? null;
+}
+
 export function formatAiContextUsagePercent(occupiedTokens, contextWindow) {
   const occupied = tokenCount(occupiedTokens);
   const window = tokenCount(contextWindow);

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -11,7 +11,7 @@ import { estimateAiMessageTokens, formatAiMessageMeta } from "/ai-message-meta.j
 import { createStreamTypewriter } from "/stream-typewriter.js?v=20260730-ai-stream-typewriter-v3";
 import { buildUsageCalendar, formatCacheHitRate, formatTokenCount } from "/ai-usage.js?v=20260727-ai-usage-v1";
 import { formatAiMessageTime } from "/ai-message-time.js?v=20260713-cross-day-time";
-import { formatAiContextUsagePercent, formatAiContextUsageTooltip, normalizeAiContextTokenDistribution } from "/ai-context-meter.js?v=20260731-skills-description-v1";
+import { formatAiContextUsagePercent, formatAiContextUsageTooltip, normalizeAiContextTokenDistribution, resolveAiContextUsage } from "/ai-context-meter.js?v=20260801-retain-usage-v1";
 import { copyAiRawMarkdown } from "/ai-message-actions.js?v=20260713-copy-raw-markdown";
 import { THEME_STORAGE_KEY, nextTheme, normalizeTheme, themeToggleLabel } from "/theme.js?v=20260713-dark-mode";
 import { buildCharacterDetails, buildCharacterState, characterStateEntries, normalizeCharacterDetails, normalizeCharacterSections } from "/character-profile.js?v=20260713-character-editor";
@@ -395,6 +395,7 @@ let aiReferencesLoadPromise = null;
 let aiReferencesLoadWorkId = null;
 let aiConversationsLoadPromise = null;
 let aiConversationsLoadWorkId = null;
+let latestAiContextUsage = null;
 const aiConversationHistoryPageLimit = 20;
 let aiConversationHistoryPage = { page: 1, limit: aiConversationHistoryPageLimit, hasMore: false, nextPage: null };
 let workScopedUiGeneration = 0;
@@ -1759,6 +1760,7 @@ async function openAiConversation(conversationId, hideHistory = true) {
   upsertAiConversationSummary(conversation);
   state.aiConversationId = conversation.id;
   state.aiPromptSent = conversation.messages.some((message) => message.role === "user");
+  resetAiContextMeter();
   $("#ai-conversation-title").textContent = conversation.title;
   resetAiFeed();
   for (const message of conversation.messages) appendMessage(message.role, message.content, message.citations, message.createdAt, message.metadata, message.id);
@@ -1786,7 +1788,7 @@ async function createNewAiConversation() {
   $("#ai-conversation-title").textContent = conversation.title;
   resetAiFeed();
   hideAiContextWarning();
-  setAiContextMeter(null);
+  resetAiContextMeter();
   renderAiQuickActions();
   setAiHistoryVisible(false);
 }
@@ -3651,7 +3653,7 @@ function resetWorkScopedUiCaches() {
   resetAiFeed();
   $("#ai-conversation-title").textContent = "新对话";
   $("#ai-model").innerHTML = '<option value="">使用创作助手时加载模型</option>';
-  setAiContextMeter(null);
+  resetAiContextMeter();
   renderAiConversationHistory();
 }
 
@@ -6917,10 +6919,12 @@ function renderAiContextDistribution(usage) {
 }
 
 function setAiContextMeter(usage) {
+  const displayUsage = resolveAiContextUsage(latestAiContextUsage, usage);
+  latestAiContextUsage = displayUsage;
   const meter = $("#ai-context-meter");
   const value = meter.querySelector("b");
-  renderAiContextDistribution(usage);
-  if (!usage) {
+  renderAiContextDistribution(displayUsage);
+  if (!displayUsage) {
     meter.classList.add("is-empty");
     meter.classList.remove("is-warning", "is-danger");
     meter.style.setProperty("--context-usage", "0");
@@ -6930,15 +6934,20 @@ function setAiContextMeter(usage) {
     meter.setAttribute("aria-label", tooltip);
     return;
   }
-  const percent = Math.max(0, Math.min(100, Number(usage.usagePercent) || 0));
+  const percent = Math.max(0, Math.min(100, Number(displayUsage.usagePercent) || 0));
   meter.classList.remove("is-empty");
   meter.classList.toggle("is-warning", percent >= 70 && percent < 90);
   meter.classList.toggle("is-danger", percent >= 90);
   meter.style.setProperty("--context-usage", String(percent));
   value.textContent = `${percent}%`;
-  const tooltip = formatAiContextUsageTooltip(usage);
+  const tooltip = formatAiContextUsageTooltip(displayUsage);
   meter.dataset.tooltip = tooltip;
   meter.setAttribute("aria-label", `当前上下文用量：${tooltip}`);
+}
+
+function resetAiContextMeter() {
+  latestAiContextUsage = null;
+  setAiContextMeter(null);
 }
 
 function setAiContextDistributionVisible(visible) {

--- a/tests/system/ai-context-compact-ui.test.ts
+++ b/tests/system/ai-context-compact-ui.test.ts
@@ -36,6 +36,9 @@ describe("AI 对话上下文 compact 界面", () => {
     expect(application).toContain('compaction.dataset.testid = "ai-process-context-compaction"');
     expect(application).toContain('compaction.innerHTML = "<span>已压缩上下文</span>"');
     expect(application).toContain('setAiContextMeter(payload.contextUsage);');
+    expect(application).toContain("const displayUsage = resolveAiContextUsage(latestAiContextUsage, usage);");
+    expect(application).toContain("latestAiContextUsage = displayUsage;");
+    expect(application).toContain("function resetAiContextMeter()");
     expect(application).toContain("normalizeAiContextTokenDistribution");
     expect(application).toContain("formatAiContextUsagePercent");
     expect(application).toContain("setAiContextDistributionVisible");

--- a/tests/unit/ai-context-meter.test.ts
+++ b/tests/unit/ai-context-meter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 // @ts-expect-error 浏览器端模块没有单独的类型声明，测试仅调用纯函数导出。
-import { formatAiContextUsagePercent, formatAiContextUsageTooltip, normalizeAiContextTokenDistribution } from "../../src/public/ai-context-meter.js";
+import { formatAiContextUsagePercent, formatAiContextUsageTooltip, normalizeAiContextTokenDistribution, resolveAiContextUsage } from "../../src/public/ai-context-meter.js";
 
 describe("AI 上下文用量提示", () => {
   it("按实际占用量显示一位小数百分比", () => {
@@ -17,6 +17,16 @@ describe("AI 上下文用量提示", () => {
       conversationBudgetTokens: 30_000,
       outputReserveTokens: 32_000
     })).toBe("总输入 12,345 / 128,000 tok · 作品上下文 6,000 tok · 对话历史 2,500 / 30,000 tok · 输出预留 32,000 tok");
+  });
+
+  it("下一轮用量返回前保留上一轮结果", () => {
+    const previousUsage = { inputTokens: 12_345, contextWindow: 128_000, usagePercent: 9.6 };
+    const nextUsage = { inputTokens: 18_000, contextWindow: 128_000, usagePercent: 14.1 };
+
+    expect(resolveAiContextUsage(previousUsage, null)).toBe(previousUsage);
+    expect(resolveAiContextUsage(previousUsage, undefined)).toBe(previousUsage);
+    expect(resolveAiContextUsage(previousUsage, nextUsage)).toBe(nextUsage);
+    expect(resolveAiContextUsage(null, null)).toBeNull();
   });
 
   it("按上下文窗口归一化五类 Token 分布", () => {


### PR DESCRIPTION
## 变更说明

- 缓存最近一次有效的 Chat 上下文 Token 用量。
- 输入框和引用在下一轮发送时清空，不再将 Token 用量覆盖为“—”。
- 下一轮上下文或完整响应返回后更新用量；切换作品、新建或打开其他对话时正常重置。
- 更新前端静态资源缓存版本并补充单元、系统回归测试。

## 根因

Chat 流先返回 `context` 事件并更新用量，随后 `user_message` 事件清空输入区，间接触发 `setAiContextMeter(null)`，导致刚收到的用量被覆盖为空状态。

## 用户影响

连续对话发送期间会持续显示最近一次有效用量，不再在生成过程中短暂显示“—”。

## 验证

- `npm test`：105 个测试文件、538 项测试通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。
- 内置浏览器真实交互验证：上一轮 51%，下一轮生成中保持 51%，完成后更新为 58%，控制台无警告或错误。
- Rebase 到最新 `origin/develop` 后，相关 2 个测试文件、5 项测试及类型检查再次通过。
