### PR TITLE
fix(security): harden API path matching and captcha glyphs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,7 @@ import { applyImportFileHints, parseNovelText } from "./parser.js";
 import { attachmentPermissionModules, Store, versionedEntityTypes } from "./store.js";
 import { paginated, parsePagination } from "./pagination.js";
 import { normalizeUploadFileName } from "./utils.js";
-import { assertSafeAiEndpoint, createApiRateLimitMiddleware, createAuthenticationRateLimitMiddleware, createBasicAuthMiddleware, createSameOriginMiddleware, createSecurityHeadersMiddleware, createUploadRateLimitMiddleware, verifySetupToken, type RuntimeSecurityOptions } from "./security.js";
+import { assertSafeAiEndpoint, createApiRateLimitMiddleware, createAuthenticationRateLimitMiddleware, createBasicAuthMiddleware, createSameOriginMiddleware, createSecurityHeadersMiddleware, createUploadRateLimitMiddleware, enforceCaseInsensitiveRouting, normalizeApiPath, verifySetupToken, type RuntimeSecurityOptions } from "./security.js";
 import { ImageCaptchaService } from "./image-captcha.js";
 import { assertSafeImportedPlainText, decodeUtf8ImportedText } from "./import-security.js";
 import { InvalidRasterImageError, readRasterImageMetadata } from "./image-metadata.js";
@@ -829,6 +829,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     }
   );
   const app = express();
+  enforceCaseInsensitiveRouting(app);
   const upload = multer({
     storage: multer.memoryStorage(),
     limits: { fileSize: 30 * 1024 * 1024, files: 1, fields: 10, fieldSize: 64 * 1024, parts: 11, headerPairs: 100 }
@@ -1013,6 +1014,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   });
   app.patch("/api/users/:userId", (request, response) => {
     if (!request.authUser) throw new AppError(401, "AUTH_REQUIRED", "请先登录");
+    if (request.authUser.role !== "admin") throw new AppError(403, "ADMIN_REQUIRED", "该操作仅限系统管理员");
     const updated = auth.updateUser(request.authUser, request.params.userId, parse(userUpdateSchema, request.body));
     store.audit(null, "user.updated", "user", updated.userId, { role: updated.role, status: updated.status });
     data(response, updated);
@@ -2295,7 +2297,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       setHeaders: setStaticCacheControl
     }));
     app.get("/{*path}", (request, response, next) => {
-      if (request.path.startsWith("/api/")) return next();
+      if (normalizeApiPath(request.path).startsWith("/api/")) return next();
       sendIndexHtml(request, response);
     });
   }

--- a/src/image-captcha.ts
+++ b/src/image-captcha.ts
@@ -81,12 +81,15 @@ function seededRandom(seed: Buffer): () => number {
   };
 }
 
-function glyphPath(pattern: readonly string[], cellSize: number): string {
+function glyphPath(pattern: readonly string[], cellSize: number, random: () => number): string {
   return pattern.flatMap((row, rowIndex) => [...row].flatMap((pixel, columnIndex) => {
     if (pixel !== "1") return [];
-    const x = columnIndex * cellSize;
-    const y = rowIndex * cellSize;
-    return `M${x} ${y}h${cellSize}v${cellSize}h-${cellSize}Z`;
+    // 把种子派生的扰动直接写入 path 坐标，避免仅依赖浏览器端滤镜、导致同一字符 path 恒定可查表。
+    const x = columnIndex * cellSize + randomBetween(random, -0.65, 0.65);
+    const y = rowIndex * cellSize + randomBetween(random, -0.65, 0.65);
+    const width = cellSize + randomBetween(random, -0.4, 0.4);
+    const height = cellSize + randomBetween(random, -0.4, 0.4);
+    return `M${x.toFixed(2)} ${y.toFixed(2)}h${width.toFixed(2)}v${height.toFixed(2)}h-${width.toFixed(2)}Z`;
   })).join("");
 }
 
@@ -124,7 +127,7 @@ export function renderCaptchaSvg(code: string, seed = randomBytes(8)): string {
     const skew = randomBetween(random, -8, 8);
     const color = ["#132d4b", "#1e3a5f", "#243f64", "#173451"][index % 4];
     const pattern = glyphPatterns[char] ?? fallbackGlyph;
-    return `<path d="${glyphPath(pattern, 4.9)}" transform="translate(${x.toFixed(1)} ${y.toFixed(1)}) rotate(${rotate.toFixed(1)} 12.3 17.2) skewX(${skew.toFixed(1)})" fill="${color}" filter="url(#glyph-roughen)"/>`;
+    return `<path d="${glyphPath(pattern, 4.9, random)}" transform="translate(${x.toFixed(1)} ${y.toFixed(1)}) rotate(${rotate.toFixed(1)} 12.3 17.2) skewX(${skew.toFixed(1)})" fill="${color}" filter="url(#glyph-roughen)"/>`;
   }).join("");
   for (let index = 0; index < 3; index += 1) {
     const startY = randomBetween(random, 8, height - 8).toFixed(1);

--- a/src/security.ts
+++ b/src/security.ts
@@ -29,6 +29,34 @@ export type RuntimeSecurityOptions = {
 type RateEntry = { count: number; resetAt: number };
 const maximumRateEntries = 10_000;
 
+/**
+ * Express 默认路由大小写不敏感，但 request.path 保留原始大小写。
+ * 安全中间件统一用小写路径做匹配，避免 /API/... 一类变体绕过鉴权与限速。
+ */
+export function normalizeApiPath(pathname: string): string {
+  return pathname.toLocaleLowerCase("en-US");
+}
+
+/** 强制保持大小写不敏感路由，并拒绝后续改成大小写敏感。 */
+export function enforceCaseInsensitiveRouting(app: { set: (setting: string, value?: unknown) => unknown }): void {
+  app.set("case sensitive routing", false);
+  const originalSet = app.set.bind(app) as {
+    (setting: string): unknown;
+    (setting: string, value: unknown): unknown;
+  };
+  app.set = function lockedCaseInsensitiveRouting(setting: string, value?: unknown) {
+    // Express 用单参数 app.set(name) 读取配置；不能把它改写成写入。
+    if (arguments.length < 2) return originalSet(setting);
+    if (String(setting).toLocaleLowerCase("en-US") === "case sensitive routing") {
+      if (value) {
+        throw new Error("Case-sensitive routing is disabled; API security matches paths case-insensitively");
+      }
+      return originalSet(setting, false);
+    }
+    return originalSet(setting, value);
+  } as typeof app.set;
+}
+
 const digest = (value: string): Buffer => createHash("sha256").update(value).digest();
 const constantTimeEqual = (left: string, right: string): boolean => timingSafeEqual(digest(left), digest(right));
 
@@ -81,7 +109,7 @@ export function createBasicAuthMiddleware(options: BasicAuthOptions): RequestHan
   const failureWindowMs = options.failureWindowMs ?? 15 * 60_000;
   const failures = new Map<string, RateEntry>();
   return (request, response, next) => {
-    if (request.path === "/api/health") return next();
+    if (normalizeApiPath(request.path) === "/api/health") return next();
     const key = requestKey(request);
     const credentials = parseBasicCredentials(request.get("authorization"));
     const valid = credentials
@@ -114,7 +142,7 @@ export function createSecurityHeadersMiddleware(): RequestHandler {
     response.setHeader("X-Content-Type-Options", "nosniff");
     response.setHeader("X-Frame-Options", "DENY");
     response.setHeader("X-Permitted-Cross-Domain-Policies", "none");
-    response.setHeader("Cache-Control", request.path.startsWith("/api/") ? "no-store" : "private, no-cache");
+    response.setHeader("Cache-Control", normalizeApiPath(request.path).startsWith("/api/") ? "no-store" : "private, no-cache");
     response.vary("Authorization");
     if (request.secure) response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
     next();
@@ -152,7 +180,8 @@ export function createSameOriginMiddleware(): RequestHandler {
 export function createApiRateLimitMiddleware(limit = 600, windowMs = 60_000, entryLimit = maximumRateEntries): RequestHandler {
   const entries = new Map<string, RateEntry>();
   return (request, response, next) => {
-    if (!request.path.startsWith("/api/") || request.path === "/api/health") return next();
+    const path = normalizeApiPath(request.path);
+    if (!path.startsWith("/api/") || path === "/api/health") return next();
     const rate = consumeRate(entries, requestKey(request), limit, windowMs, entryLimit);
     if (rate.allowed) return next();
     logger.warn("security.request.blocked", { control: "api_rate_limit", retryAfterSeconds: rate.retryAfter });
@@ -164,9 +193,10 @@ export function createApiRateLimitMiddleware(limit = 600, windowMs = 60_000, ent
 export function createAuthenticationRateLimitMiddleware(limit = 10, windowMs = 15 * 60_000): RequestHandler {
   const entries = new Map<string, RateEntry>();
   return (request, response, next) => {
-    const authenticationWrite = request.method === "POST" && ["/api/auth/login", "/api/auth/register"].includes(request.path);
+    const path = normalizeApiPath(request.path);
+    const authenticationWrite = request.method === "POST" && ["/api/auth/login", "/api/auth/register"].includes(path);
     if (!authenticationWrite) return next();
-    const rate = consumeRate(entries, `${requestKey(request)}:${request.path}`, limit, windowMs);
+    const rate = consumeRate(entries, `${requestKey(request)}:${path}`, limit, windowMs);
     if (rate.allowed) return next();
     logger.warn("security.request.blocked", { control: "authentication_rate_limit", retryAfterSeconds: rate.retryAfter });
     response.setHeader("Retry-After", String(rate.retryAfter));
@@ -177,10 +207,11 @@ export function createAuthenticationRateLimitMiddleware(limit = 10, windowMs = 1
 export function createUploadRateLimitMiddleware(limit = 30, windowMs = 10 * 60_000, entryLimit = maximumRateEntries): RequestHandler {
   const entries = new Map<string, RateEntry>();
   return (request, response, next) => {
+    const path = normalizeApiPath(request.path);
     const uploadWrite = (request.method === "POST" || request.method === "PUT") && (
-      request.path === "/api/auth/avatar"
-      || request.path === "/api/works/import"
-      || /^\/api\/works\/[^/]+\/(?:import|cover|attachments)$/u.test(request.path)
+      path === "/api/auth/avatar"
+      || path === "/api/works/import"
+      || /^\/api\/works\/[^/]+\/(?:import|cover|attachments)$/u.test(path)
     );
     if (!uploadWrite) return next();
     const actorKey = request.authUser?.userId ?? requestKey(request);

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -6,6 +6,7 @@ import { sanitizeRequestPath } from "./http-logging.js";
 import { accountReference, logger } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
 import { runWithRequestActor, type RequestActor } from "./request-context.js";
+import { normalizeApiPath } from "./security.js";
 import {
   canReadWorkModule,
   canWriteWorkModule,
@@ -167,8 +168,10 @@ function workIdFromPath(database: Database, pathname: string): string | null {
   const decoded = pathname.split("/").map((part) => {
     try { return decodeURIComponent(part); } catch { return part; }
   });
-  if (decoded[1] !== "api") return null;
-  if (decoded[2] === "works" && decoded[3] && decoded[3] !== "import") return decoded[3];
+  const root = (decoded[1] ?? "").toLocaleLowerCase("en-US");
+  const resource = (decoded[2] ?? "").toLocaleLowerCase("en-US");
+  if (root !== "api") return null;
+  if (resource === "works" && decoded[3] && decoded[3].toLocaleLowerCase("en-US") !== "import") return decoded[3];
   const tableByResource: Record<string, string> = {
     volumes: "volumes",
     chapters: "chapters",
@@ -189,7 +192,7 @@ function workIdFromPath(database: Database, pathname: string): string | null {
     "ai-conversations": "ai_conversations",
     suggestions: "ai_suggestions"
   };
-  const table = tableByResource[decoded[2] ?? ""];
+  const table = tableByResource[resource];
   if (table && decoded[3]) {
     const row = database.get<{ work_id: string }>(`SELECT work_id FROM ${table} WHERE id = ?`, decoded[3]);
     if (row) return row.work_id;
@@ -216,7 +219,7 @@ function workIdFromPath(database: Database, pathname: string): string | null {
     }
     throw notFound("记录");
   }
-  if (decoded[2] === "foreshadow-occurrences" && decoded[3]) {
+  if (resource === "foreshadow-occurrences" && decoded[3]) {
     const row = database.get<{ work_id: string }>(
       `SELECT foreshadow.work_id FROM foreshadow_occurrences occurrence
        JOIN foreshadows foreshadow ON foreshadow.id = occurrence.foreshadow_id WHERE occurrence.id = ?`,
@@ -225,10 +228,10 @@ function workIdFromPath(database: Database, pathname: string): string | null {
     if (!row) throw notFound("伏笔出现点");
     return row.work_id;
   }
-  if (decoded[2] === "entity-versions" && decoded[3] && decoded[4]) {
+  if (resource === "entity-versions" && decoded[3] && decoded[4]) {
     const row = database.get<{ work_id: string }>(
       "SELECT work_id FROM entity_versions WHERE entity_type = ? AND entity_id = ? LIMIT 1",
-      decoded[3],
+      decoded[3].toLocaleLowerCase("en-US"),
       decoded[4]
     );
     if (!row) throw notFound("版本记录");
@@ -464,6 +467,7 @@ export class UserAuthService {
   }
 
   updateUser(actor: AuthUser, userId: string, input: { role?: "admin" | "user"; status?: "active" | "disabled" }): AuthUser {
+    if (actor.role !== "admin") throw new AppError(403, "ADMIN_REQUIRED", "该操作仅限系统管理员");
     const current = this.getUser(userId);
     const nextRole = input.role ?? current.role;
     const nextStatus = input.status ?? current.status;
@@ -756,17 +760,18 @@ export function createUserSessionMiddleware(
       request.authUser = session.user;
       request.authMethod = "session";
     }
-    const isPublic = request.path === "/api/health"
-      || request.path === "/api/auth/session"
-      || (request.path === "/api/auth/register" && request.method === "POST")
-      || (request.path === "/api/auth/login" && request.method === "POST")
-      || !request.path.startsWith("/api/");
+    const path = normalizeApiPath(request.path);
+    const isPublic = path === "/api/health"
+      || path === "/api/auth/session"
+      || (path === "/api/auth/register" && request.method === "POST")
+      || (path === "/api/auth/login" && request.method === "POST")
+      || !path.startsWith("/api/");
     if (!session && !apiKey && !isPublic) {
       logger.warn("auth.request.rejected", { reason: "authentication_required", method: request.method, path: sanitizeRequestPath(request.path) });
       response.status(401).json({ error: { code: "AUTH_REQUIRED", message: "请先登录" } });
       return;
     }
-    if (session && !["GET", "HEAD", "OPTIONS"].includes(request.method) && request.path !== "/api/auth/login" && request.path !== "/api/auth/register") {
+    if (session && !["GET", "HEAD", "OPTIONS"].includes(request.method) && path !== "/api/auth/login" && path !== "/api/auth/register") {
       const csrf = request.get("x-csrf-token") ?? "";
       if (!safeEqual(csrf, session.csrfToken)) {
         logger.warn("auth.request.rejected", { reason: "invalid_csrf", method: request.method, path: sanitizeRequestPath(request.path), actorRef: accountReference(session.user.userId) });
@@ -808,7 +813,8 @@ const cliApiRules: Array<{ methods: string[]; path: RegExp }> = [
 export function createCliApiScopeMiddleware(disabled = false): RequestHandler {
   return (request, response, next) => {
     if (disabled || request.authMethod !== "api-key") return next();
-    if (cliApiRules.some((rule) => rule.methods.includes(request.method) && rule.path.test(request.path))) return next();
+    const path = normalizeApiPath(request.path);
+    if (cliApiRules.some((rule) => rule.methods.includes(request.method) && rule.path.test(path))) return next();
     logger.warn("auth.request.rejected", { reason: "cli_scope_denied", method: request.method, path: sanitizeRequestPath(request.path) });
     response.status(403).json({ error: { code: "CLI_SCOPE_DENIED", message: "API Key 不能访问用户管理、系统管理或未开放给 CLI 的接口" } });
   };
@@ -876,7 +882,7 @@ function aiContextReadModules(request: Request): WorkPermissionModule[] {
 }
 
 function workModuleRequirements(request: Request, write: boolean): WorkAuthorizationRequirements {
-  const pathname = request.path;
+  const pathname = normalizeApiPath(request.path);
   const direct = (module: WorkPermissionModule, extraWrite: WorkPermissionModule[] = []): WorkAuthorizationRequirements => (
     write ? { write: [module, ...extraWrite] } : { read: [module] }
   );
@@ -1017,18 +1023,19 @@ function workModuleRequirements(request: Request, write: boolean): WorkAuthoriza
 
 export function createWorkAuthorizationMiddleware(auth: UserAuthService, disabled = false): RequestHandler {
   return (request, _response, next) => {
-    if (disabled || !request.path.startsWith("/api/") || request.path.startsWith("/api/auth/") || request.path === "/api/health") return next();
+    const path = normalizeApiPath(request.path);
+    if (disabled || !path.startsWith("/api/") || path.startsWith("/api/auth/") || path === "/api/health") return next();
     const user = request.authUser;
     if (!user) throw new AppError(401, "AUTH_REQUIRED", "请先登录");
-    if (request.path.startsWith("/api/platform/") || request.path.startsWith("/api/providers/") || request.path.startsWith("/api/models/")) {
+    if (path.startsWith("/api/platform/") || path.startsWith("/api/providers/") || path.startsWith("/api/models/")) {
       if (user.role !== "admin") throw new AppError(403, "ADMIN_REQUIRED", "该操作仅限系统管理员");
       return next();
     }
-    if (/^\/api\/works\/[^/]+\/providers/u.test(request.path)) {
+    if (/^\/api\/works\/[^/]+\/providers/u.test(path)) {
       if (user.role !== "admin") throw new AppError(403, "ADMIN_REQUIRED", "该操作仅限系统管理员");
       return next();
     }
-    if (request.path.startsWith("/api/users") && !request.path.startsWith("/api/users/directory")) {
+    if (path.startsWith("/api/users") && !path.startsWith("/api/users/directory")) {
       if (user.role !== "admin") throw new AppError(403, "ADMIN_REQUIRED", "该操作仅限系统管理员");
       return next();
     }

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -1446,6 +1446,37 @@ describe("用户、作品权限与操作者追踪 API", () => {
     await writer.agent.get("/api/works").expect(401);
   });
 
+  it("大小写变体 API 路径不能绕过鉴权、作品授权或管理员校验", async () => {
+    const admin = await register(runtime, "case_admin");
+    const writer = await register(runtime, "case_writer");
+    const outsider = await register(runtime, "case_outsider");
+    const work = await admin.agent.post("/api/works").set("X-CSRF-Token", admin.csrfToken).send({ title: "大小写作品" }).expect(201);
+    const workId = work.body.data.id as string;
+    await admin.agent.post(`/api/works/${workId}/members`).set("X-CSRF-Token", admin.csrfToken).send({
+      userId: writer.user.userId,
+      role: "editor"
+    }).expect(201);
+
+    await request(runtime.app).get(`/API/WORKS/${workId}`).expect(401);
+    await request(runtime.app).get(`/api/WORKS/${workId}`).expect(401);
+    await outsider.agent.get(`/API/WORKS/${workId}`).expect(403);
+    await outsider.agent.get(`/api/WORKS/${workId}`).expect(403);
+    await writer.agent.get(`/API/WORKS/${workId}`).expect(200);
+    await writer.agent.get(`/api/WORKS/${workId}`).expect(200);
+
+    const escalateUpper = await writer.agent.patch(`/API/USERS/${writer.user.userId}`)
+      .set("X-CSRF-Token", writer.csrfToken)
+      .send({ role: "admin" })
+      .expect(403);
+    expect(escalateUpper.body.error.code).toBe("ADMIN_REQUIRED");
+    const escalateMixed = await writer.agent.patch(`/api/USERS/${writer.user.userId}`)
+      .set("X-CSRF-Token", writer.csrfToken)
+      .send({ role: "admin" })
+      .expect(403);
+    expect(escalateMixed.body.error.code).toBe("ADMIN_REQUIRED");
+    expect(runtime.database.get("SELECT role FROM users WHERE id = ?", writer.user.userId)?.role).toBe("user");
+  });
+
   it("管理员可统一设置界面与分模块分页，普通用户只能读取", async () => {
     const admin = await register(runtime, "ui_admin");
     const writer = await register(runtime, "ui_writer");

--- a/tests/unit/image-captcha.test.ts
+++ b/tests/unit/image-captcha.test.ts
@@ -38,4 +38,17 @@ describe("ImageCaptchaService", () => {
     const untrusted = renderCaptchaSvg("<&>\"", Buffer.alloc(8));
     expect(untrusted).not.toContain("<&>\"");
   });
+
+  it("同一字符的 glyph path 会随种子变化，避免离线查表解码", () => {
+    const extractGlyphPaths = (svg: string): string[] => [...svg.matchAll(/\sd="([^"]+)"\s+transform=/gu)].map((match) => match[1] ?? "");
+    const first = extractGlyphPaths(renderCaptchaSvg("AAAA", Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])));
+    const second = extractGlyphPaths(renderCaptchaSvg("AAAA", Buffer.from([8, 7, 6, 5, 4, 3, 2, 1])));
+    const repeated = extractGlyphPaths(renderCaptchaSvg("AAAA", Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])));
+    expect(first).toHaveLength(4);
+    expect(second).toHaveLength(4);
+    expect(first).toEqual(repeated);
+    expect(first[0]).not.toEqual(second[0]);
+    expect(new Set(first).size).toBeGreaterThan(1);
+    expect(first.every((path) => /\.\d{2}/u.test(path))).toBe(true);
+  });
 });

--- a/tests/unit/security-rate-limit.test.ts
+++ b/tests/unit/security-rate-limit.test.ts
@@ -1,7 +1,13 @@
 import express from "express";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
-import { createApiRateLimitMiddleware, createUploadRateLimitMiddleware } from "../../src/security.js";
+import {
+  createApiRateLimitMiddleware,
+  createAuthenticationRateLimitMiddleware,
+  createUploadRateLimitMiddleware,
+  enforceCaseInsensitiveRouting,
+  normalizeApiPath
+} from "../../src/security.js";
 
 describe("安全限速器", () => {
   it("达到来源状态上限后淘汰最早条目", async () => {
@@ -27,5 +33,41 @@ describe("安全限速器", () => {
     expect(blocked.body.error.code).toBe("UPLOAD_RATE_LIMITED");
     expect(blocked.headers["retry-after"]).toBe("60");
     await request(app).post("/api/works").expect(200);
+  });
+
+  it("API 路径匹配忽略大小写，避免大小写变体绕过限速", async () => {
+    const apiApp = express();
+    enforceCaseInsensitiveRouting(apiApp);
+    apiApp.use(createApiRateLimitMiddleware(1, 60_000));
+    apiApp.all("/{*path}", (_request, response) => response.json({ ok: true }));
+
+    await request(apiApp).get("/api/works/demo").expect(200);
+    await request(apiApp).get("/API/WORKS/demo").expect(429);
+
+    const authApp = express();
+    enforceCaseInsensitiveRouting(authApp);
+    authApp.use(createAuthenticationRateLimitMiddleware(1, 60_000));
+    authApp.all("/{*path}", (_request, response) => response.json({ ok: true }));
+
+    await request(authApp).post("/api/auth/login").expect(200);
+    const blockedLogin = await request(authApp).post("/API/AUTH/LOGIN").expect(429);
+    expect(blockedLogin.body.error.code).toBe("AUTH_RATE_LIMITED");
+  });
+});
+
+describe("API 路径规范化", () => {
+  it("将路径规范为小写供安全匹配使用", () => {
+    expect(normalizeApiPath("/API/WORKS/abc")).toBe("/api/works/abc");
+    expect(normalizeApiPath("/api/Users/Directory")).toBe("/api/users/directory");
+  });
+
+  it("强制保持大小写不敏感路由并拒绝开启", () => {
+    const app = express();
+    enforceCaseInsensitiveRouting(app);
+    expect(app.get("case sensitive routing")).toBe(false);
+    expect(() => app.set("case sensitive routing", true)).toThrow(/Case-sensitive routing is disabled/u);
+    expect(app.get("case sensitive routing")).toBe(false);
+    app.set("case sensitive routing", false);
+    expect(app.get("case sensitive routing")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- 安全中间件与作品授权改为对 API 路径做大小写不敏感匹配，并锁定禁止启用 `case sensitive routing`，堵住 `/API/...`、`/api/USERS/...` 等变体绕过鉴权、限速与管理员校验的攻击链。
- 用户管理写入在 handler 与 `updateUser` 内增加管理员断言，作为纵深防御。
- 验证码字形 `path` 坐标写入种子派生扰动，阻止同一字符离线查表解码。

## Test plan
- [x] `vitest` 单元：路径规范化、限速大小写变体、禁止开启大小写敏感路由、验证码种子扰动
- [x] `vitest` 集成：大小写变体路径下的未授权访问与自提权均返回 401/403
- [ ] CI 全量检查通过


Made with [Cursor](https://cursor.com)