### PR TITLE
ci(vercel): deploy only from main

### DIFF
--- a/demo/tests/demo.test.mjs
+++ b/demo/tests/demo.test.mjs
@@ -183,6 +183,7 @@ test("两本预制作品都设置了项目内封面", async () => {
   assert.match(server, /demoCoverCacheControl/);
   assert.match(server, /isDemoCover/);
   assert.equal(demoCoverCacheControl(), "public, max-age=31536000, immutable");
+  assert.deepEqual(vercel.git?.deploymentEnabled, { "*": false, main: true });
   assert.equal(vercel.headers?.[0]?.source, "/demo-covers/(.*)");
   assert.equal(vercel.headers?.[0]?.headers?.[0]?.value, "public, max-age=31536000, immutable");
   assert.deepEqual(Object.keys(coverVersions).sort(), ["city-blank", "silent-tide"]);

--- a/demo/vercel.json
+++ b/demo/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  },
   "framework": null,
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./",
   "buildCommand": "npm run build",

--- a/showcase/tests/docs-pages.test.mjs
+++ b/showcase/tests/docs-pages.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+test("Vercel 仅允许 main 分支自动部署", async () => {
+  const vercel = JSON.parse(await readFile(new URL("../vercel.json", import.meta.url), "utf8"));
+  assert.deepEqual(vercel.git?.deploymentEnabled, { "*": false, main: true });
+});
+
 test("docs 路由提供全局工具调用限制说明页", async () => {
   const indexHtml = await readFile(new URL("../public/docs/index.html", import.meta.url), "utf8");
   const docHtml = await readFile(new URL("../public/docs/global-tool-call-limit.html", import.meta.url), "utf8");

--- a/showcase/vercel.json
+++ b/showcase/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  },
   "framework": null,
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ./",
   "buildCommand": "npm run build:static",


### PR DESCRIPTION
## 变更内容

- 为 `demo` 与 `showcase` 的 Vercel 配置增加 Git 分支部署规则
- 默认关闭所有分支的自动部署，仅允许 `main` 自动部署
- 增加配置回归测试，防止规则被意外移除

## 影响

PR 和功能分支不再创建 Vercel Preview；合并或推送到 `main` 后仍会自动部署生产环境。

## 验证

- `cd demo && npm test`
- `cd demo && npm run build`
- `cd showcase && node --test tests/docs-pages.test.mjs`
- `cd showcase && npm run build:static`