### PR TITLE
fix(cli): allow HTTP server connections with warnings

### DIFF
--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -150,14 +150,6 @@ function normalizeServer(value: string): string {
   if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
     throw new CliError("CLI_SERVER_INVALID", "服务端地址必须是无内嵌凭据的 HTTP 或 HTTPS 地址");
   }
-  const loopbackHttp = url.protocol === "http:" && (
-    url.hostname === "localhost"
-    || url.hostname === "127.0.0.1"
-    || url.hostname === "[::1]"
-  );
-  if (url.protocol === "http:" && !loopbackHttp) {
-    throw new CliError("CLI_SERVER_INSECURE", "远程服务端地址必须使用 HTTPS；HTTP 仅允许连接本机回环地址");
-  }
   if (url.pathname !== "/" && url.pathname !== "") {
     throw new CliError("CLI_SERVER_INVALID", "服务端地址不能包含路径，请只填写协议、主机和端口");
   }

--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -133,6 +133,17 @@ function emitText(stream: OutputStream, value: string): void {
   stream.write(value.endsWith("\n") ? value : `${value}\n`);
 }
 
+function emitHttpServerWarning(stream: OutputStream, server: string, compact: boolean): void {
+  if (new URL(server).protocol !== "http:") return;
+  emitJson(stream, {
+    warning: {
+      code: "CLI_SERVER_HTTP_WARNING",
+      message: "当前服务端使用 HTTP，API Key 和业务数据将以明文传输；请仅在可信局域网中使用，公网访问请配置 HTTPS",
+      server
+    }
+  }, compact);
+}
+
 function configPath(parsed: ParsedArguments, dependencies: Required<Pick<CliDependencies, "env" | "cwd" | "homeDirectory">>): string {
   const configured = option(parsed, "config") ?? dependencies.env.SCRIVERSE_CONFIG;
   if (configured) return isAbsolute(configured) ? configured : resolve(dependencies.cwd, configured);
@@ -591,8 +602,11 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
     const config = readOptionalConfig(path);
     const requested = parsed.positionals[1];
     if (requested) {
-      config.defaultServer = normalizeServer(requested);
+      const server = normalizeServer(requested);
+      const shouldWarn = server !== config.defaultServer;
+      config.defaultServer = server;
       writeConfig(path, config);
+      if (shouldWarn) emitHttpServerWarning(dependencies.stderr, server, compact);
     }
     emitJson(dependencies.stdout, {
       defaultServer: config.defaultServer,
@@ -616,6 +630,7 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
         throw new CliError("CLI_API_KEY_REQUIRED", "请通过 --api-key、--api-key-file 或 SCRIVERSE_API_KEY 三者之一提供 API Key");
       }
       const apiKey = supplied[0]!;
+      emitHttpServerWarning(dependencies.stderr, server, compact);
       const temporary: CliRequestConfig = {
         server,
         apiKey,

--- a/tests/e2e/real-cli.ts
+++ b/tests/e2e/real-cli.ts
@@ -62,6 +62,14 @@ function cliJson(args: string[], input?: string): unknown {
   return JSON.parse(result.stdout);
 }
 
+function cliJsonWithHttpWarning(args: string[], input?: string): unknown {
+  const result = cli(args, input);
+  const payload = JSON.parse(result.stderr) as { warning?: Record<string, unknown> };
+  assert.equal(payload.warning?.code, "CLI_SERVER_HTTP_WARNING");
+  assert.equal(payload.warning?.server, baseUrl);
+  return JSON.parse(result.stdout);
+}
+
 function cliError(args: string[], expectedCode: string): Record<string, unknown> {
   const result = cli(args, undefined, 1);
   const payload = JSON.parse(result.stderr) as { error?: Record<string, unknown> };
@@ -227,7 +235,7 @@ async function run(): Promise<void> {
   assert.match(help.stdout, /Scriverse CLI/u);
   assert.doesNotMatch(help.stdout, /用户管理|供应商管理/u);
   assert.deepEqual(cliJson(["auth", "status"]), { authenticated: false, defaultServer: null, configPath });
-  assert.deepEqual(cliJson(["connect", baseUrl]), { defaultServer: baseUrl, authenticated: false, configPath });
+  assert.deepEqual(cliJsonWithHttpWarning(["connect", baseUrl]), { defaultServer: baseUrl, authenticated: false, configPath });
   assert.deepEqual(cliJson(["auth", "status"]), { authenticated: false, server: baseUrl, defaultServer: baseUrl, configPath });
   const schemaList = cliJson(["schema", "list"]) as { prohibited: string[]; resources: unknown[] };
   assert.ok(schemaList.prohibited.includes("用户管理"));
@@ -250,7 +258,7 @@ async function run(): Promise<void> {
   const keyPath = textFile("admin-api-key", `${adminKey}\n`);
   chmodSync(keyPath, 0o600);
 
-  const login = cliJson(["auth", "login", "--api-key-file", keyPath]) as {
+  const login = cliJsonWithHttpWarning(["auth", "login", "--api-key-file", keyPath]) as {
     authenticated: boolean;
     user: { userId: string };
   };

--- a/tests/e2e/real-cli.ts
+++ b/tests/e2e/real-cli.ts
@@ -548,7 +548,7 @@ async function run(): Promise<void> {
   assert.deepEqual(cliJson(["auth", "logout"]), { authenticated: false, server: baseUrl, defaultServer: baseUrl, configPath });
   cliError(["work", "list"], "CLI_LOGIN_REQUIRED");
   const writerKeyPath = textFile("writer-api-key", writerKey);
-  cliJson(["auth", "login", "--api-key-file", writerKeyPath]);
+  cliJsonWithHttpWarning(["auth", "login", "--api-key-file", writerKeyPath]);
   const writerWorks = cliJson(["work", "list"]) as Array<Record<string, unknown>>;
   assert.deepEqual(writerWorks.map((item) => item.id), [writerWork.id]);
   cliError(["work", "get", workId], "WORK_ACCESS_DENIED");

--- a/tests/unit/cli-core.test.ts
+++ b/tests/unit/cli-core.test.ts
@@ -46,16 +46,20 @@ describe("Scriverse CLI 核心", () => {
     expect(parsed.options.get("compact")).toEqual(["true"]);
   });
 
-  it("拒绝使用公网 HTTP 服务端地址", async () => {
+  it("允许连接局域网 HTTP 服务端", async () => {
     const root = temporaryRoot();
     const path = join(root, "cli.json");
-    const stderr = outputCapture();
+    const stdout = outputCapture();
 
     expect(await runCli([
-      "connect", "http://192.0.2.10:13210", "--config", path
-    ], { stderr: stderr.stream })).toBe(1);
-    expect(JSON.parse(stderr.text())).toMatchObject({
-      error: { code: "CLI_SERVER_INSECURE" }
+      "connect", "http://192.168.1.10:13210", "--config", path
+    ], { stdout: stdout.stream })).toBe(0);
+    expect(JSON.parse(stdout.text())).toMatchObject({
+      defaultServer: "http://192.168.1.10:13210",
+      authenticated: false
+    });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+      defaultServer: "http://192.168.1.10:13210"
     });
   });
 

--- a/tests/unit/cli-core.test.ts
+++ b/tests/unit/cli-core.test.ts
@@ -50,10 +50,11 @@ describe("Scriverse CLI 核心", () => {
     const root = temporaryRoot();
     const path = join(root, "cli.json");
     const stdout = outputCapture();
+    const stderr = outputCapture();
 
     expect(await runCli([
       "connect", "http://192.168.1.10:13210", "--config", path
-    ], { stdout: stdout.stream })).toBe(0);
+    ], { stdout: stdout.stream, stderr: stderr.stream })).toBe(0);
     expect(JSON.parse(stdout.text())).toMatchObject({
       defaultServer: "http://192.168.1.10:13210",
       authenticated: false
@@ -61,6 +62,18 @@ describe("Scriverse CLI 核心", () => {
     expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
       defaultServer: "http://192.168.1.10:13210"
     });
+    const warning = stderr.text();
+    expect(JSON.parse(warning)).toMatchObject({
+      warning: {
+        code: "CLI_SERVER_HTTP_WARNING",
+        server: "http://192.168.1.10:13210"
+      }
+    });
+
+    expect(await runCli([
+      "connect", "http://192.168.1.10:13210", "--config", path
+    ], { stdout: outputCapture().stream, stderr: stderr.stream })).toBe(0);
+    expect(stderr.text()).toBe(warning);
   });
 
   it("资源契约只开放受控读写动作且不包含删除", () => {
@@ -99,7 +112,13 @@ describe("Scriverse CLI 核心", () => {
     expect(await runCli([
       "auth", "login", "--server", "http://127.0.0.1:13210", "--api-key", "scrv_test_key", "--config", path
     ], { fetchImpl, stdout: stdout.stream, stderr: stderr.stream })).toBe(0);
-    expect(stderr.text()).toBe("");
+    const warning = stderr.text();
+    expect(JSON.parse(warning)).toMatchObject({
+      warning: {
+        code: "CLI_SERVER_HTTP_WARNING",
+        server: "http://127.0.0.1:13210"
+      }
+    });
     expect(JSON.parse(stdout.text())).toMatchObject({ authenticated: true, apiKeyPrefix: "scrv_test" });
     expect(statSync(path).mode & 0o777).toBe(0o600);
     expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
@@ -124,6 +143,7 @@ describe("Scriverse CLI 核心", () => {
       stderr: stderr.stream
     })).toBe(0);
     expect(JSON.parse(logoutOutput.text())).toMatchObject({ authenticated: false });
+    expect(stderr.text()).toBe(warning);
   });
 
   it("保存默认服务器，并允许子命令临时覆盖到已登录的其他服务器", async () => {


### PR DESCRIPTION
## 变更概述

- 允许 Scriverse CLI 连接局域网或 NAS 上的 HTTP 服务端。
- 首次配置新的 HTTP 地址时输出非阻断警告，重复配置同一地址不重复提示。
- 通过 HTTP 执行 `auth login`、发送 API Key 时输出警告；后续业务命令不重复提示。
- 保持公网 AI 供应商端点 HTTPS 限制和外部 Markdown 图片策略不变。

## 原因与影响

此前 CLI 将非回环 HTTP 地址全部拒绝，导致局域网 NAS 部署无法使用 CLI。现在由部署者自行选择 HTTP 或 HTTPS，同时在凭据配置边界明确提示明文传输风险。

## 验证

- `npm run test:unit -- tests/unit/cli-core.test.ts`
- `npm run typecheck`
- `npm test`（112 个测试文件、574 项测试）
- `npm run test:e2e:cli`
- 生产构建及隔离服务健康检查
- SQLite `PRAGMA integrity_check` 与 `PRAGMA foreign_key_check`