### PR TITLE
fix(ui): remove author link from product footer

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -58,7 +58,7 @@
         <p id="auth-error" class="auth-error" role="alert"></p>
       </div>
       <footer class="product-footer auth-product-footer" data-product-footer aria-label="叙界项目信息">
-        <span class="product-footer-meta"><span>© <time data-product-footer-year></time> <a href="https://github.com/musnows" target="_blank" rel="noopener noreferrer">musnows</a></span><span aria-hidden="true">·</span><span>叙界 <span data-product-footer-version>v—</span></span><span aria-hidden="true">·</span><a href="https://github.com/musnows/Scriverse" target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 查看叙界仓库">GitHub</a></span>
+        <span class="product-footer-meta"><span>© <time data-product-footer-year></time></span><span aria-hidden="true">·</span><span>叙界 <span data-product-footer-version>v—</span></span><span aria-hidden="true">·</span><a href="https://github.com/musnows/Scriverse" target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 查看叙界仓库">GitHub</a></span>
         <span class="product-footer-development hidden" data-product-footer-development>开发模式</span>
       </footer>
     </section>
@@ -159,7 +159,7 @@
           </div>
           <div id="book-shelf" class="book-shelf" data-testid="book-shelf"></div>
           <footer class="product-footer" data-product-footer aria-label="叙界项目信息">
-            <span class="product-footer-meta"><span>© <time data-product-footer-year></time> <a href="https://github.com/musnows" target="_blank" rel="noopener noreferrer">musnows</a></span><span aria-hidden="true">·</span><span>叙界 <span data-product-footer-version>v—</span></span><span aria-hidden="true">·</span><a href="https://github.com/musnows/Scriverse" target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 查看叙界仓库">GitHub</a></span>
+            <span class="product-footer-meta"><span>© <time data-product-footer-year></time></span><span aria-hidden="true">·</span><span>叙界 <span data-product-footer-version>v—</span></span><span aria-hidden="true">·</span><a href="https://github.com/musnows/Scriverse" target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 查看叙界仓库">GitHub</a></span>
             <span class="product-footer-development hidden" data-product-footer-development>开发模式</span>
           </footer>
         </section>
@@ -204,7 +204,7 @@
           </div>
           <p id="settings-work-note" class="settings-work-note"></p>
           <footer class="product-footer settings-product-footer" data-product-footer aria-label="叙界项目信息">
-            <span class="product-footer-meta"><span>© <time data-product-footer-year></time> <a href="https://github.com/musnows" target="_blank" rel="noopener noreferrer">musnows</a></span><span aria-hidden="true">·</span><span>叙界 <span data-product-footer-version>v—</span></span><span aria-hidden="true">·</span><a href="https://github.com/musnows/Scriverse" target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 查看叙界仓库">GitHub</a></span>
+            <span class="product-footer-meta"><span>© <time data-product-footer-year></time></span><span aria-hidden="true">·</span><span>叙界 <span data-product-footer-version>v—</span></span><span aria-hidden="true">·</span><a href="https://github.com/musnows/Scriverse" target="_blank" rel="noopener noreferrer" aria-label="在 GitHub 查看叙界仓库">GitHub</a></span>
             <span class="product-footer-development hidden" data-product-footer-development>开发模式</span>
           </footer>
         </section>

--- a/tests/system/product-footer.test.ts
+++ b/tests/system/product-footer.test.ts
@@ -18,7 +18,7 @@ describe("产品信息页脚", () => {
 
   afterAll(() => runtime.close());
 
-  it("在登录、书架和设置页展示作者、版本与仓库信息", async () => {
+  it("在登录、书架和设置页展示版本与仓库信息", async () => {
     const page = await request(runtime.app).get("/").expect(200);
     const application = await request(runtime.app).get("/app.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
@@ -27,6 +27,8 @@ describe("产品信息页脚", () => {
     expect(page.text.match(/<footer class="[^"]*product-footer[^"]*" data-product-footer/gu)).toHaveLength(3);
     expect(page.text.match(/© <time data-product-footer-year><\/time>/gu)).toHaveLength(3);
     expect(page.text.match(/href="https:\/\/github.com\/musnows\/Scriverse"/gu)).toHaveLength(3);
+    expect(page.text).not.toContain('href="https://github.com/musnows"');
+    expect(page.text).not.toContain(">musnows</a>");
     expect(page.text.match(/class="product-footer-meta"/gu)).toHaveLength(3);
     expect(page.text.match(/aria-hidden="true">·<\/span>/gu)).toHaveLength(6);
     expect(page.text.match(/aria-label="在 GitHub 查看叙界仓库">GitHub<\/a>/gu)).toHaveLength(3);


### PR DESCRIPTION
## 变更内容

- 删除登录页、书架页和设置页 footer 中的 `musnows` 文案与个人主页链接
- 保留叙界版本信息和 GitHub 仓库链接
- 更新页脚系统测试，防止个人主页链接回归

## 原因与影响

产品页脚只需保留 GitHub 仓库入口，减少重复的作者入口。该变更不影响现有仓库链接、版本显示或开发模式标识。

## 验证

- `npm run test:system -- --run tests/system/product-footer.test.ts`（24 个测试文件、43 项测试通过）