### PR TITLE
fix(ai): complete chat streams without title or EOF delays

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2784,16 +2784,17 @@ export class AiManager {
         }
       })
       : null;
-    let conversationTitle: string | undefined;
     if (shouldGenerateTitle && conversationMessage && input.conversationId) {
-      conversationTitle = await this.generateConversationTitle(
+      void this.generateConversationTitle(
         input.workId,
         input.conversationId,
         titleModelId,
         firstUserContent,
         generated.content,
         defaultTitle
-      ) ?? undefined;
+      ).catch((error) => {
+        logger.warn("ai.conversation_title.failed", { workId: input.workId, conversationId: input.conversationId, error: aiErrorForLog(error) });
+      });
     }
     return {
       ...this.getSuggestion(suggestionId),
@@ -2802,7 +2803,6 @@ export class AiManager {
       toolCalls: generated.toolCalls,
       processSteps: generated.processSteps,
       contextUsage: generated.contextUsage,
-      ...(conversationTitle ? { conversationTitle } : {}),
       ...(conversationMessage ? { conversationMessage } : {})
     };
   }

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4682,6 +4682,7 @@ export class AiManager {
     let reasoning = "";
     let finishReason = "unknown";
     let usage: unknown = null;
+    let upstreamDone = false;
     const contentRedactor = new ProviderSecretStreamRedactor(apiKey);
     const reasoningRedactor = new ProviderSecretStreamRedactor(apiKey);
     const appendContent = (value: string): void => {
@@ -4729,7 +4730,11 @@ export class AiManager {
         .map((line) => line.slice(5).trimStart())
         .join("\n")
         .trim();
-      if (!data || data === "[DONE]") return;
+      if (!data) return;
+      if (data === "[DONE]") {
+        upstreamDone = true;
+        return;
+      }
       const payload = JSON.parse(data) as Record<string, unknown>;
       const error = payload.error && typeof payload.error === "object" && !Array.isArray(payload.error)
         ? payload.error as Record<string, unknown>
@@ -4824,7 +4829,15 @@ export class AiManager {
       buffer += decoder.decode(chunk.value, { stream: !chunk.done });
       const events = buffer.split(/\r?\n\r?\n/u);
       buffer = events.pop() ?? "";
-      for (const eventText of events) consumeEvent(eventText);
+      for (const eventText of events) {
+        consumeEvent(eventText);
+        if (upstreamDone) break;
+      }
+      if (upstreamDone) {
+        await reader.cancel().catch(() => undefined);
+        buffer = "";
+        break;
+      }
       if (chunk.done) break;
     }
     if (buffer.trim()) consumeEvent(buffer);

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1299,6 +1299,37 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(settingsAfter.body.data.titleGenerationModelId).toBe(modelId);
   });
 
+  it("首轮标题生成失败时不影响主回答", async () => {
+    const { providerId, modelId } = await configureAi();
+    await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ titleGenerationModelId: modelId, agentTools: [] }).expect(200);
+    let titleRequestCount = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      const body = JSON.parse(String(init?.body)) as { stream?: boolean };
+      if (body.stream) {
+        return new Response('data: {"choices":[{"delta":{"content":"主回答"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n', {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" }
+        });
+      }
+      titleRequestCount += 1;
+      return new Response(JSON.stringify({ error: { message: "标题模型不可用" } }), { status: 400 });
+    });
+
+    const streamed = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+      instruction: "标题生成失败时仍保留默认",
+      scope: { type: "none" },
+      modelId
+    }).expect(200).expect("Content-Type", /text\/event-stream/u);
+
+    for (let index = 0; index < 50 && titleRequestCount < 1; index += 1) await new Promise((resolve) => setTimeout(resolve, 2));
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"主回答"}');
+    expect(streamed.text).toContain("event: complete");
+    expect(streamed.text).not.toContain("event: error");
+    expect(titleRequestCount).toBe(1);
+  });
+
   it("侧栏问答失败时通过 SSE 返回受控错误信息", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1250,6 +1250,8 @@ describe("AI 供应商、模型与建议 API", () => {
 
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ titleGenerationModelId: modelId, agentTools: [] }).expect(200);
     const completionBodies: Array<{ stream?: boolean; tools?: unknown; messages?: Array<{ content?: string }> }> = [];
+    let titleRequestStarted = false;
+    let releaseTitleRequest: (() => void) | null = null;
     fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
       const body = JSON.parse(String(init?.body)) as { stream?: boolean; tools?: unknown; messages?: Array<{ content?: string }> };
@@ -1263,21 +1265,34 @@ describe("AI 供应商、模型与建议 API", () => {
       expect(body.tools).toBeUndefined();
       expect(body.messages?.some((message) => message.content?.includes("请规划北港跃迁路线"))).toBe(true);
       expect(body.messages?.some((message) => message.content?.includes("助手回答"))).toBe(true);
-      return new Response(JSON.stringify({ choices: [{ message: { content: "标题：北港跃迁路线" } }] }), { status: 200 });
+      titleRequestStarted = true;
+      return new Promise<Response>((resolve) => {
+        releaseTitleRequest = () => resolve(new Response(JSON.stringify({ choices: [{ message: { content: "标题：北港跃迁路线" } }] }), { status: 200 }));
+      });
     });
 
-    const streamed = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+    const streamPromise = request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
       instruction: "请规划北港跃迁路线",
       scope: { type: "chapter", chapterId },
       modelId
-    }).expect(200).expect("Content-Type", /text\/event-stream/u);
+    }).expect(200).expect("Content-Type", /text\/event-stream/u).then((response) => response);
+    for (let index = 0; index < 50 && !titleRequestStarted; index += 1) await new Promise((resolve) => setTimeout(resolve, 2));
+    expect(titleRequestStarted).toBe(true);
+    const streamed = await Promise.race([
+      streamPromise,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("流式回答被标题生成阻塞")), 500))
+    ]).finally(() => releaseTitleRequest?.());
 
     expect(streamed.text).toContain("event: context");
     expect(streamed.text).toContain("event: user_message");
-    expect(streamed.text).toContain('"conversationTitle":"北港跃迁路线"');
+    expect(streamed.text).not.toContain('"conversationTitle":"北港跃迁路线"');
     expect(completionBodies).toHaveLength(2);
     const completePayload = JSON.parse(streamed.text.match(/event: complete\ndata: ([^\n]+)/u)?.[1] ?? "{}") as { conversationId?: string };
-    const reloaded = await request(runtime.app).get(`/api/ai-conversations/${completePayload.conversationId}`).expect(200);
+    let reloaded = await request(runtime.app).get(`/api/ai-conversations/${completePayload.conversationId}`).expect(200);
+    for (let index = 0; index < 50 && reloaded.body.data.title !== "北港跃迁路线"; index += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      reloaded = await request(runtime.app).get(`/api/ai-conversations/${completePayload.conversationId}`).expect(200);
+    }
     expect(reloaded.body.data.title).toBe("北港跃迁路线");
     expect(reloaded.body.data.messages.map((message: { role: string }) => message.role)).toEqual(["user", "assistant"]);
     const settingsAfter = await request(runtime.app).get(`/api/works/${workId}/ai-settings`).expect(200);

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1361,6 +1361,38 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(suggestions.body.data[0].content).toBe("安全前缀 sk-s*****lue 安全后缀");
   });
 
+  it("收到 OpenAI 流式 DONE 标记后不等待供应商关闭连接", async () => {
+    const { providerId, modelId } = await configureAi();
+    await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: [] }).expect(200);
+    let cancelled = false;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const encoder = new TextEncoder();
+          controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"已结束"},"finish_reason":"stop"}]}\n\n'));
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          init?.signal?.addEventListener("abort", () => controller.error(init.signal?.reason), { once: true });
+        },
+        cancel() {
+          cancelled = true;
+        }
+      });
+      return new Response(stream, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    });
+
+    const streamed = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+      instruction: "测试 DONE 结束标记",
+      scope: { type: "none" },
+      modelId
+    }).timeout({ deadline: 1_000 }).expect(200).expect("Content-Type", /text\/event-stream/u);
+
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"已结束"}');
+    expect(streamed.text).toContain("event: complete");
+    expect(cancelled).toBe(true);
+  });
+
   it("首轮上下文超限时不请求模型并提示减少上下文", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);


### PR DESCRIPTION
## 变更内容

- 将首轮会话标题生成改为后台异步执行，不再阻塞主回答完成。
- 标题生成失败仅记录日志并忽略，不影响主回答或 SSE 状态。
- 流式响应收到 OpenAI 兼容协议的 `[DONE]` 后立即取消 reader，不再等待供应商关闭连接。
- 增加标题异步、标题失败隔离和 `[DONE]` 提前结束的集成测试。

## 根因

主回答正文已经通过 `delta` 发给浏览器后，后端原先还会同步等待标题模型；同时流解析会忽略 `[DONE]` 并继续等待底层连接 EOF，导致界面在正文完成后仍显示生成中。

## 验证

- `npm run typecheck`
- `npm test -- --run tests/integration/ai-api.test.ts`（43/43）
- `npm test`（584/584）
- `npm run build`

auto-generated changes are limited to AI streaming completion and conversation title generation.