### PR TITLE
fix(ai): expose sanitized provider failures

### DIFF
--- a/src/ai-protocol.ts
+++ b/src/ai-protocol.ts
@@ -19,7 +19,7 @@ export type CompletionMessage = AiMessage | {
   role: "assistant";
   content: string | null;
   reasoning_content?: string | null;
-  tool_calls: CompletionToolCall[];
+  tool_calls?: CompletionToolCall[];
   anthropic_content?: AnthropicReplayContentBlock[];
 } | {
   role: "tool";
@@ -92,13 +92,17 @@ function parsedToolInput(value: unknown): Record<string, unknown> {
   }
 }
 
-function anthropicAssistantContent(message: Extract<CompletionMessage, { role: "assistant" }>): Array<Record<string, unknown>> {
+function anthropicAssistantContent(message: {
+  content: string | null;
+  tool_calls?: CompletionToolCall[];
+  anthropic_content?: AnthropicReplayContentBlock[];
+}): Array<Record<string, unknown>> {
   if (Array.isArray(message.anthropic_content) && message.anthropic_content.length > 0) {
     return structuredClone(message.anthropic_content);
   }
   return [
     ...textContent(message.content),
-    ...message.tool_calls.map((toolCall) => ({
+    ...(message.tool_calls ?? []).map((toolCall) => ({
       type: "tool_use",
       id: toolCall.id,
       name: toolCall.function.name,
@@ -145,7 +149,7 @@ function anthropicMessages(messages: CompletionMessage[]): {
       append("user", [anthropicToolResult(message)]);
       continue;
     }
-    if (message.role === "assistant" && "tool_calls" in message) {
+    if (message.role === "assistant") {
       append("assistant", anthropicAssistantContent(message));
       continue;
     }

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -3473,7 +3473,6 @@ export class AiManager {
         role: "assistant",
         content: message.content,
         ...(reasoningContent === undefined ? {} : { reasoning_content: reasoningContent }),
-        tool_calls: [],
         ...(anthropicContent.length > 0 ? { anthropic_content: structuredClone(anthropicContent) } : {})
       };
     }) ?? [];

--- a/src/app.ts
+++ b/src/app.ts
@@ -785,7 +785,7 @@ function redactAiConversation(record: Record<string, unknown>, permissions: Work
   return { ...result, restricted: true };
 }
 
-/** SSE 错误事件只暴露 AppError 的公开信息，避免透传内部异常 message。 */
+/** SSE 错误事件只暴露 AppError 的公开信息；AI_CALL_FAILED 的 failure 已在 AI 层完成密钥脱敏。 */
 export function publicAiStreamError(error: unknown): {
   code: string;
   message: string;
@@ -805,7 +805,7 @@ export function publicAiStreamError(error: unknown): {
       code: error.code,
       message: error.message,
       status: error.status,
-      ...(error.status < 500 && typeof details?.failure === "string" ? { failure: details.failure } : {}),
+      ...((error.status < 500 || error.code === "AI_CALL_FAILED") && typeof details?.failure === "string" ? { failure: details.failure } : {}),
       ...(typeof details?.callId === "string" ? { callId: details.callId } : {}),
       ...(typeof details?.providerName === "string" ? { providerName: details.providerName } : {}),
       ...(typeof details?.providerId === "string" ? { providerId: details.providerId } : {}),

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1311,8 +1311,7 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text).toContain(`"providerId":"${providerId}"`);
     expect(streamed.text).toContain('"modelId":"mock-novel-model"');
     expect(streamed.text).toContain(`"modelRecordId":"${modelId}"`);
-    expect(streamed.text).not.toContain('"failure"');
-    expect(streamed.text).not.toContain("上游参数无效");
+    expect(streamed.text).toContain('"failure":"HTTP 400: {\\"error\\":{\\"message\\":\\"上游参数无效：Bearer sk-s*****lue\\"}}"');
     expect(streamed.text).not.toContain("sk-sensitive-test-value");
     expect(streamed.text).toMatch(/"callId":"call_[^"]+"/u);
     const calls = await request(runtime.app).get(`/api/works/${workId}/ai-calls`).expect(200);

--- a/tests/integration/longcat-multiturn.test.ts
+++ b/tests/integration/longcat-multiturn.test.ts
@@ -40,6 +40,7 @@ describe("LongCat OpenAI 多轮推理兼容", () => {
           content: "第一轮回答",
           reasoning_content: "第一轮思考"
         });
+        expect(assistant).not.toHaveProperty("tool_calls");
       }
       const suffix = requestCount === 1 ? "第一轮回答" : "第二轮回答";
       const reasoning = requestCount === 1 ? "第一轮思考" : "第二轮思考";

--- a/tests/unit/ai-protocol.test.ts
+++ b/tests/unit/ai-protocol.test.ts
@@ -85,7 +85,7 @@ describe("AI 供应商协议适配", () => {
     ]);
   });
 
-  it("切换到 OpenAI 协议时不携带 Anthropic 回放字段", () => {
+  it("切换到 OpenAI 协议时不携带 Anthropic 回放字段或空工具调用", () => {
     const body = buildCompletionRequestBody({
       protocol: "openai-chat-completions",
       model: "mock-model",
@@ -94,18 +94,21 @@ describe("AI 供应商协议适配", () => {
         {
           role: "assistant",
           content: "回答",
-          tool_calls: [],
           anthropic_content: [{ type: "thinking", thinking: "内部思考", signature: "opaque" }]
         },
         { role: "user", content: "第二轮" }
       ],
-      parameters: {}
+      parameters: {},
+      tools: [{ type: "function", function: { name: "story_index", parameters: {} } }],
+      toolChoice: "auto"
     });
     expect(body.messages).toEqual([
       { role: "user", content: "第一轮" },
-      { role: "assistant", content: "回答", tool_calls: [] },
+      { role: "assistant", content: "回答" },
       { role: "user", content: "第二轮" }
     ]);
+    expect(body).toHaveProperty("tools");
+    expect((body.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty("tool_calls");
   });
 
   it("把 Anthropic 正文、思考和工具调用归一化并保留可回放内容块", () => {

--- a/tests/unit/ai-stream-error.test.ts
+++ b/tests/unit/ai-stream-error.test.ts
@@ -31,7 +31,7 @@ describe("publicAiStreamError", () => {
     });
   });
 
-  it("不向客户端透传服务端 AppError 中记录的底层失败详情", () => {
+  it("向客户端透传已脱敏的 AI 上游失败详情", () => {
     expect(publicAiStreamError(new AppError(502, "AI_CALL_FAILED", "AI 调用失败", {
       failure: "ENOENT: /secret/path.sql failed at https://provider.example/v1",
       callId: "call_secret",
@@ -40,8 +40,19 @@ describe("publicAiStreamError", () => {
       code: "AI_CALL_FAILED",
       message: "AI 调用失败",
       status: 502,
+      failure: "ENOENT: /secret/path.sql failed at https://provider.example/v1",
       callId: "call_secret",
       providerId: "provider_1"
+    });
+  });
+
+  it("仍然隐藏非 AI 调用的内部 5xx 详情", () => {
+    expect(publicAiStreamError(new AppError(500, "INTERNAL_ERROR", "服务器内部错误", {
+      failure: "内部数据库路径和堆栈"
+    }))).toEqual({
+      code: "INTERNAL_ERROR",
+      message: "服务器内部错误",
+      status: 500
     });
   });
 });


### PR DESCRIPTION
## 变更内容

- 将 `AI_CALL_FAILED` 中已由 AI 层完成密钥脱敏的上游失败详情通过 SSE 传给前端。
- 修复多轮对话历史助手消息无条件携带 `tool_calls: []` 的问题。
- 保留真实工具调用数组，并保持 Anthropic 思考签名与正文块的回放。
- 保留普通内部 5xx 错误的隐藏策略，避免泄露内部异常信息。

## 根因

DeepSeek 多轮请求中的上游 400 会被项目统一包装为 `AI_CALL_FAILED` / HTTP 502。原始错误被隐藏的原因是 SSE 错误转换只允许状态码小于 500 的错误携带 `failure` 字段。

同时，历史助手消息构造逻辑无条件发送 `tool_calls: []`。顶层 `tools` 是否开启，与某条历史助手消息是否发生过工具调用是两回事；DeepSeek 会拒绝空的 `tool_calls` 数组并返回参数错误。现在没有真实工具调用时会省略该字段。

## 验证

- `npm test`：113 个测试文件、583 个测试全部通过
- `npm run typecheck`
- `git diff --check`