### PR TITLE
fix(security): close ai reference and vertex token leaks

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -32,6 +32,7 @@ import { CredentialVault } from "./credential-vault.js";
 import { PLATFORM_AI_WORK_ID, type Row } from "./database.js";
 import { AppError, notFound } from "./errors.js";
 import {
+  assertOfficialGoogleVertexBaseUrl,
   fetchGoogleOAuthAccessToken,
   GoogleVertexTokenCache,
   maskServiceAccountHint,
@@ -2335,8 +2336,9 @@ export class AiManager {
   }
 
   private async resolveProviderAccessToken(row: ProviderRow): Promise<{ accessToken: string; credentialSecret: string }> {
-    const credentialSecret = this.decryptKey(row);
     const protocol = providerProtocol(row);
+    if (protocol === "google-vertex") assertOfficialGoogleVertexBaseUrl(stringValue(row, "base_url"));
+    const credentialSecret = this.decryptKey(row);
     if (protocol !== "google-vertex") {
       return { accessToken: credentialSecret, credentialSecret };
     }
@@ -2382,6 +2384,7 @@ export class AiManager {
     const timestamp = now();
     const protocol = input.protocol ?? "openai-chat-completions";
     const baseUrl = normalizeProviderBaseUrl(input.baseUrl);
+    if (protocol === "google-vertex") assertOfficialGoogleVertexBaseUrl(baseUrl);
     this.store.db.run(
       `INSERT INTO providers (id, work_id, name, base_url, protocol, encrypted_key, key_iv, key_tag, key_hint, status,
        connection_status, concurrency_limit, rpm_limit, note, created_at, updated_at)
@@ -2422,6 +2425,9 @@ export class AiManager {
 
   updateProvider(providerId: string, input: Partial<ProviderInput>): Record<string, unknown> {
     const row = this.getProviderRow(providerId);
+    const nextProtocol = input.protocol ?? providerProtocol(row);
+    const nextBaseUrl = input.baseUrl ? normalizeProviderBaseUrl(input.baseUrl) : stringValue(row, "base_url");
+    if (nextProtocol === "google-vertex") assertOfficialGoogleVertexBaseUrl(nextBaseUrl);
     let encryptedKey = stringValue(row, "encrypted_key");
     let keyIv = stringValue(row, "key_iv");
     let keyTag = stringValue(row, "key_tag");
@@ -2432,7 +2438,6 @@ export class AiManager {
       encryptedKey = encrypted.encrypted;
       keyIv = encrypted.iv;
       keyTag = encrypted.tag;
-      const nextProtocol = input.protocol ?? providerProtocol(row);
       keyHint = providerCredentialHint(nextProtocol, input.apiKey);
       connectionStatus = "unchecked";
       this.vertexTokenCache.clear(providerId);
@@ -2446,8 +2451,8 @@ export class AiManager {
       `UPDATE providers SET name = ?, base_url = ?, protocol = ?, encrypted_key = ?, key_iv = ?, key_tag = ?, key_hint = ?,
        status = ?, connection_status = ?, concurrency_limit = ?, rpm_limit = ?, note = ?, updated_at = ? WHERE id = ?`,
       input.name ?? stringValue(row, "name"),
-      input.baseUrl ? normalizeProviderBaseUrl(input.baseUrl) : stringValue(row, "base_url"),
-      input.protocol ?? providerProtocol(row),
+      nextBaseUrl,
+      nextProtocol,
       encryptedKey,
       keyIv,
       keyTag,

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,7 @@ import { Database } from "./database.js";
 import { assertSafeDocxArchive } from "./docx-security.js";
 import { DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
 import { AppError } from "./errors.js";
-import { parseGoogleServiceAccount } from "./google-vertex-auth.js";
+import { isOfficialGoogleVertexBaseUrl, parseGoogleServiceAccount } from "./google-vertex-auth.js";
 import { HYBRID_SEARCH_TYPES } from "./hybrid-search.js";
 import { applyImportFileHints, parseNovelText } from "./parser.js";
 import { aiConversationTaskTypes, attachmentPermissionModules, Store, versionedEntityTypes } from "./store.js";
@@ -348,9 +348,16 @@ const providerBaseSchema = z.object({
 });
 
 function refineProviderApiKey(
-  value: { protocol?: (typeof AI_PROVIDER_PROTOCOLS)[number]; apiKey?: string },
+  value: { protocol?: (typeof AI_PROVIDER_PROTOCOLS)[number]; baseUrl?: string; apiKey?: string },
   ctx: z.RefinementCtx
 ): void {
+  if (value.protocol === "google-vertex" && value.baseUrl && !isOfficialGoogleVertexBaseUrl(value.baseUrl)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["baseUrl"],
+      message: "Google Vertex 接口地址必须使用官方 aiplatform.googleapis.com 或 *-aiplatform.googleapis.com 域名"
+    });
+  }
   if (!value.apiKey) return;
   const protocol = value.protocol ?? "openai-chat-completions";
   if (protocol === "google-vertex") {

--- a/src/google-vertex-auth.ts
+++ b/src/google-vertex-auth.ts
@@ -6,6 +6,7 @@ export const GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/clou
 
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
 const JWT_LIFETIME_SECONDS = 3_600;
+const GOOGLE_VERTEX_REGIONAL_HOST_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-aiplatform\.googleapis\.com$/u;
 
 export type GoogleServiceAccount = {
   type: "service_account";
@@ -18,6 +19,30 @@ type CachedToken = {
   accessToken: string;
   expiresAtMs: number;
 };
+
+export function isOfficialGoogleVertexBaseUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    const hostname = url.hostname.toLowerCase();
+    return url.protocol === "https:"
+      && !url.username
+      && !url.password
+      && (url.port === "" || url.port === "443")
+      && (hostname === "aiplatform.googleapis.com" || GOOGLE_VERTEX_REGIONAL_HOST_PATTERN.test(hostname));
+  } catch {
+    return false;
+  }
+}
+
+export function assertOfficialGoogleVertexBaseUrl(raw: string): void {
+  if (!isOfficialGoogleVertexBaseUrl(raw)) {
+    throw new AppError(
+      400,
+      "INVALID_VERTEX_BASE_URL",
+      "Google Vertex 接口地址必须使用 aiplatform.googleapis.com 或官方区域 *-aiplatform.googleapis.com 域名"
+    );
+  }
+}
 
 function base64UrlEncode(value: string | Buffer): string {
   const buffer = typeof value === "string" ? Buffer.from(value, "utf8") : value;

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -885,8 +885,17 @@ function hasBodyField(request: Request, field: string): boolean {
 
 function aiContextReadModules(request: Request): WorkPermissionModule[] {
   const scope = requestBodyRecord(request).scope;
-  if (!scope || typeof scope !== "object" || Array.isArray(scope) || (scope as Record<string, unknown>).type === "none") return [];
-  return [...contentPermissionModules];
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) return [];
+  const scopeValue = scope as Record<string, unknown>;
+  if (scopeValue.type !== "none") return [...contentPermissionModules];
+  const modules = new Set<WorkPermissionModule>();
+  const hasReferences = (field: string): boolean => Array.isArray(scopeValue[field]) && scopeValue[field].length > 0;
+  if (hasReferences("chapterIds") || scopeValue.includeBookSummary === true) modules.add("prose");
+  if (hasReferences("characterIds") || hasReferences("mentionCharacterIds")) modules.add("characters");
+  if (hasReferences("settingIds")) modules.add("settings");
+  if (hasReferences("raceIds")) modules.add("races");
+  if (hasReferences("organizationIds")) modules.add("organizations");
+  return [...modules];
 }
 
 function workModuleRequirements(request: Request, write: boolean): WorkAuthorizationRequirements {

--- a/tests/integration/google-vertex-api.test.ts
+++ b/tests/integration/google-vertex-api.test.ts
@@ -90,6 +90,15 @@ describe("Google Vertex 供应商 API", () => {
 
   it("拒绝非法服务账号 JSON，并在合法配置下换票后完成探测与调用", async () => {
     await request(runtime.app).post("/api/platform/ai/providers").send({
+      name: "恶意 Vertex 地址",
+      protocol: "google-vertex",
+      baseUrl: "https://attacker.example/v1/projects/scriverse-demo",
+      apiKey: serviceAccountJson,
+      status: "enabled"
+    }).expect(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await request(runtime.app).post("/api/platform/ai/providers").send({
       name: "非法 Vertex",
       protocol: "google-vertex",
       baseUrl: vertexBaseUrl,
@@ -110,6 +119,11 @@ describe("Google Vertex 供应商 API", () => {
     expect(provider.body.data.protocol).toBe("google-vertex");
     expect(provider.body.data.apiKey).toBe("sa:vertex-bot@scriverse-demo.iam.gserviceaccount.com");
     expect(JSON.stringify(provider.body.data)).not.toContain("BEGIN PRIVATE KEY");
+    await request(runtime.app).patch(`/api/providers/${provider.body.data.id}`).send({
+      baseUrl: "https://aiplatform.googleapis.com.attacker.example/v1"
+    }).expect(400);
+    const unchangedProvider = await request(runtime.app).get(`/api/providers/${provider.body.data.id}`).expect(200);
+    expect(unchangedProvider.body.data.baseUrl).toBe(vertexBaseUrl);
 
     const model = await request(runtime.app).post(`/api/providers/${provider.body.data.id}/models`).send({
       displayName: "Gemini Flash",
@@ -142,6 +156,27 @@ describe("Google Vertex 供应商 API", () => {
     for (const [, init] of completionCalls) {
       expect(new Headers(init?.headers).get("authorization")).toBe("Bearer ya29.vertex-access-token");
     }
+  });
+
+  it("出站前再次拒绝数据库中遗留的非官方 Vertex 地址", async () => {
+    const provider = await request(runtime.app).post("/api/platform/ai/providers").send({
+      name: "遗留 Vertex",
+      protocol: "google-vertex",
+      baseUrl: vertexBaseUrl,
+      apiKey: serviceAccountJson,
+      status: "enabled"
+    }).expect(201);
+    runtime.database.run(
+      "UPDATE providers SET base_url = ? WHERE id = ?",
+      "https://attacker.example/v1/projects/scriverse-demo",
+      provider.body.data.id
+    );
+    fetchMock.mockClear();
+
+    const result = await request(runtime.app).post(`/api/providers/${provider.body.data.id}/test`).send({}).expect(200);
+    expect(result.body.data).toMatchObject({ ok: false });
+    expect(result.body.data.error).toContain("Google Vertex 接口地址必须使用");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("上游模型列表失败时可回退到本地模型探测", async () => {

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -1250,6 +1250,78 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(JSON.stringify(protectedTraceFull.body)).not.toContain("TOP_SECRET_PROSE");
   });
 
+  it("type none 的显式 AI 引用仍要求对应模块读取权限", async () => {
+    const owner = await register(runtime, "ai_explicit_ref_owner");
+    const collaborator = await register(runtime, "ai_explicit_ref_collaborator");
+    const work = await owner.agent.post("/api/works")
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "AI 显式引用权限作品" })
+      .expect(201);
+    const workId = String(work.body.data.id);
+    const volume = await owner.agent.post(`/api/works/${workId}/volumes`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "第一卷" })
+      .expect(201);
+    const chapter = await owner.agent.post(`/api/works/${workId}/chapters`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ volumeId: volume.body.data.id, title: "机密章节", content: "不得泄露的正文" })
+      .expect(201);
+    const character = await owner.agent.post(`/api/works/${workId}/characters`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ name: "机密角色" })
+      .expect(201);
+    const setting = await owner.agent.post(`/api/works/${workId}/settings`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "机密设定", category: "规则", content: "不得泄露的设定" })
+      .expect(201);
+    const race = await owner.agent.post(`/api/works/${workId}/races`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ name: "机密种族" })
+      .expect(201);
+    const organization = await owner.agent.post(`/api/works/${workId}/organizations`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ name: "机密组织" })
+      .expect(201);
+    await owner.agent.post(`/api/works/${workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({
+        userId: collaborator.user.userId,
+        permissions: {
+          prose: "none",
+          drafts: "none",
+          settings: "none",
+          characters: "none",
+          races: "none",
+          organizations: "none",
+          timeline: "none",
+          relationships: "none",
+          outlines: "none",
+          reviews: "none",
+          "ai-chat": "write",
+          "ai-analysis": "none",
+          "ai-settings": "none"
+        }
+      })
+      .expect(201);
+
+    const restrictedScopes = [
+      { type: "none", chapterIds: [chapter.body.data.id] },
+      { type: "none", includeBookSummary: true },
+      { type: "none", characterIds: [character.body.data.id] },
+      { type: "none", mentionCharacterIds: [character.body.data.id] },
+      { type: "none", settingIds: [setting.body.data.id] },
+      { type: "none", raceIds: [race.body.data.id] },
+      { type: "none", organizationIds: [organization.body.data.id] }
+    ];
+    for (const scope of restrictedScopes) {
+      const denied = await collaborator.agent.post(`/api/works/${workId}/chat/stream`)
+        .set("X-CSRF-Token", collaborator.csrfToken)
+        .send({ instruction: "复述显式引用资料", scope })
+        .expect(403);
+      expect(denied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
+    }
+  });
+
   it("AI 工具按当前成员模块权限限制正文读取", async () => {
     const owner = await register(runtime, "ai_tool_owner");
     const collaborator = await register(runtime, "ai_tool_collaborator");

--- a/tests/unit/google-vertex-auth.test.ts
+++ b/tests/unit/google-vertex-auth.test.ts
@@ -1,11 +1,13 @@
 import { generateKeyPairSync } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import {
+  assertOfficialGoogleVertexBaseUrl,
   createGoogleServiceAccountJwt,
   exchangeGoogleServiceAccountToken,
   GOOGLE_CLOUD_PLATFORM_SCOPE,
   GOOGLE_OAUTH_TOKEN_URL,
   GoogleVertexTokenCache,
+  isOfficialGoogleVertexBaseUrl,
   maskServiceAccountHint,
   parseGoogleServiceAccount
 } from "../../src/google-vertex-auth.js";
@@ -27,6 +29,23 @@ function createTestServiceAccountJson(overrides: Record<string, unknown> = {}): 
 }
 
 describe("Google Vertex 服务账号鉴权", () => {
+  it("只接受 Google Vertex 官方 HTTPS 域名", () => {
+    expect(isOfficialGoogleVertexBaseUrl("https://aiplatform.googleapis.com/v1/projects/demo/locations/global/endpoints/openapi")).toBe(true);
+    expect(isOfficialGoogleVertexBaseUrl("https://us-central1-aiplatform.googleapis.com/v1/projects/demo/locations/us-central1/endpoints/openapi")).toBe(true);
+    expect(isOfficialGoogleVertexBaseUrl("https://europe-west4-aiplatform.googleapis.com:443/v1/projects/demo")).toBe(true);
+    for (const baseUrl of [
+      "https://attacker.example/v1",
+      "https://aiplatform.googleapis.com.attacker.example/v1",
+      "https://foo.aiplatform.googleapis.com/v1",
+      "http://aiplatform.googleapis.com/v1",
+      "https://aiplatform.googleapis.com:8443/v1",
+      "https://user@aiplatform.googleapis.com/v1"
+    ]) {
+      expect(isOfficialGoogleVertexBaseUrl(baseUrl)).toBe(false);
+      expect(() => assertOfficialGoogleVertexBaseUrl(baseUrl)).toThrowError(AppError);
+    }
+  });
+
   it("解析合法服务账号 JSON 并生成掩码", () => {
     const raw = createTestServiceAccountJson();
     const account = parseGoogleServiceAccount(raw);


### PR DESCRIPTION
## 概要

- 按显式章节、角色、设定、种族和组织引用分别校验模块读取权限
- 阻止 scope.type=none 绕过作品模块权限
- 将 Google Vertex 限制为官方 HTTPS aiplatform.googleapis.com 域名
- 在创建、更新和换取 Token 前重复校验 Vertex 地址

## 安全影响

修复仅有 ai-chat 权限的协作者通过已知实体 ID 读取受限资料的问题，并阻止 GCP Bearer Token 被发送到非 Google 公网地址。

## 验证

- npm run typecheck
- 权限集成测试 29 项
- Vertex/AI 针对性测试 55 项
- npm test（613 项）
- npm run build