### PR TITLE
build(release): bump version to 0.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.3";
+export const APP_VERSION = "0.6.4";


### PR DESCRIPTION
## 概要

- 将 package 版本从 0.6.3 升级到 0.6.4
- 同步 package-lock 与运行时 APP_VERSION

## 发布门禁

- 已审计 develop 相对 main 的 CLI 契约
- 本次 AI 交互与供应商管理变更不影响现有 CLI 数据命令，无需 CLI 同步提交
- 类型检查与版本相关测试通过