### PR TITLE
build(release): bump version to 0.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.4";
+export const APP_VERSION = "0.6.5";


### PR DESCRIPTION
## 变更内容

- 将应用版本从 `0.6.4` 更新为 `0.6.5`
- 同步 `package.json`、`package-lock.json` 与 `src/version.ts`

## 发布范围

`develop` 相对 `main` 仅包含 PR #309：优化 AI 设定上下文注入交互，增加作品级全局注入开关并避免重复注入。

CLI 契约审计确认无需更新：本次没有修改 CLI 命令、认证与权限范围、导入导出格式或既有请求结构。

## 验证

- 类型检查通过
- 全量测试 616/616 通过
- 生产构建通过
- 健康检查返回版本 `0.6.5`
- SQLite `integrity_check` 通过、无外键错误、schema v71