### PR TITLE
fix(ui): preserve font hierarchy when scaling

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-<link rel="stylesheet" href="/styles.css?v=20260801-character-code-pill-center-v1">
+<link rel="stylesheet" href="/styles.css?v=20260801-ui-font-scale-fix-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -3297,15 +3297,15 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
   .dialog-submit-progress > span { width: 100%; transform: none; }
 }
 
-/* 显示设置中的界面字号覆盖常用控件和辅助文字；正文与 Agent 对话分别独立调节。 */
+/* 显示设置中的界面字号按原有视觉层级缩放；正文与 Agent 对话分别独立调节。 */
 body { font-size: var(--ui-font-size); }
-:is(.module-nav button, .ghost-button, .primary-button, .module-header p, .eyebrow,
-  .panel-heading, .field-label, .dialog-header-meta, .dialog-fields label,
-  .dialog-fields .form-field-note, .appearance-grid label, .config-section-header p,
-  .config-section .config-save-button, .font-preview span, .settings-hub-card small,
-  .settings-hub-card strong, .shelf-header p, .topbar, .book-card small) {
-  font-size: calc(1em * var(--ui-font-scale));
-}
+.module-nav button, .ghost-button, .primary-button { font-size: calc(12px * var(--ui-font-scale)); }
+.module-header p { font-size: calc(13px * var(--ui-font-scale)); }
+.eyebrow, .field-label, .dialog-header-meta, .settings-hub-card small, .book-card small { font-size: calc(10px * var(--ui-font-scale)); }
+.panel-heading, .dialog-fields label, .dialog-fields .form-field-note, .appearance-grid label,
+.config-section-header p, .config-section .config-save-button { font-size: calc(11px * var(--ui-font-scale)); }
+.settings-hub-card strong { font-size: calc(16px * var(--ui-font-scale)); }
+.shelf-header p, .topbar { font-size: var(--ui-font-size); }
 .appearance-grid select, .dialog-fields input, .dialog-fields textarea, .dialog-fields select { font-size: calc(13px * var(--ui-font-scale)); }
 
 /* Agent 面板原有的细小字号统一以可读的对话字号为基准缩放。 */

--- a/tests/system/appearance-typography.test.ts
+++ b/tests/system/appearance-typography.test.ts
@@ -18,6 +18,9 @@ describe("显示设置字号选项", () => {
     expect(application).toContain('root.style.setProperty("--ai-font-size", `${normalized.aiFontSize}px`);');
     expect(application).toContain('form.get("aiFontSize")');
     expect(styles).toContain("body { font-size: var(--ui-font-size); }");
+    expect(styles).toContain(".module-nav button, .ghost-button, .primary-button { font-size: calc(12px * var(--ui-font-scale)); }");
+    expect(styles).toContain(".settings-hub-card strong { font-size: calc(16px * var(--ui-font-scale)); }");
+    expect(styles).not.toContain("font-size: calc(1em * var(--ui-font-scale));");
     expect(styles).toContain(".assistant-message, .user-message { font-size: var(--ai-font-size); }");
     expect(styles).toContain(".ai-tool-call-dialog { font-size: var(--ai-font-size); }");
   });

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -322,7 +322,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
 expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
-    expect(page.text).toContain('/styles.css?v=20260801-character-code-pill-center-v1');
+    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-fix-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260801-timeline-lifecycle-v1');
+    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-fix-v1');
     expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
   });
 });

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-expect(page.text).toContain('/styles.css?v=20260801-character-code-pill-center-v1');
+expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-fix-v1');
     expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260801-timeline-lifecycle-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');


### PR DESCRIPTION
## 变更说明

- 恢复界面字号设置前既有的字体层级，避免 14px 将按钮、辅助文字和卡片标题统一放大
- 按各控件原始基准字号进行单次线性缩放，修复 15–18px 档位重复缩放
- 保持正文预览字号与界面字号相互独立
- 更新静态资源缓存版本及系统测试断言

## 根因

界面字号同时设置根字号，并通过 `1em * --ui-font-scale` 再次缩放常用控件，导致字号重复放大且覆盖原有视觉层级。

## 验证

- `npm run typecheck`
- `npm test -- --reporter=dot`：122 个测试文件、628 项测试通过
- `npm run build`
- 浏览器自动化验证 1280×720 与 390×844，覆盖 14px 和 18px 档位
- 浏览器控制台无错误，页面无横向溢出
- 健康检查与 SQLite 完整性检查通过