### PR TITLE
fix(ui): preserve interface font scaling hierarchy

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-<link rel="stylesheet" href="/styles.css?v=20260801-ui-font-scale-specificity-v2">
+<link rel="stylesheet" href="/styles.css?v=20260801-ui-font-scale-shelf-v3">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-<link rel="stylesheet" href="/styles.css?v=20260801-ui-font-scale-fix-v1">
+<link rel="stylesheet" href="/styles.css?v=20260801-ui-font-scale-specificity-v2">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -664,9 +664,9 @@
           </label>
           <label>界面字号
             <select id="appearance-ui-font-size" name="uiFontSize">
-              <option value="14">14 px（小）</option>
+              <option value="14">14 px（标准）</option>
               <option value="15">15 px</option>
-              <option value="16">16 px（标准）</option>
+              <option value="16">16 px</option>
               <option value="17">17 px</option>
               <option value="18">18 px（大）</option>
             </select>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -3301,10 +3301,10 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 body { font-size: var(--ui-font-size); }
 :is(.module-nav button, .ghost-button.ghost-button, .primary-button.primary-button) { font-size: calc(12px * var(--ui-font-scale)); }
 .module-header p { font-size: calc(13px * var(--ui-font-scale)); }
-.eyebrow, .field-label, .dialog-header-meta, .settings-hub-card small, .book-card small { font-size: calc(10px * var(--ui-font-scale)); }
+.eyebrow, .field-label, .dialog-header-meta, .settings-hub-card small, .book-card small, .book-info > span { font-size: calc(10px * var(--ui-font-scale)); }
 .panel-heading, .dialog-fields label, .dialog-fields .form-field-note, .appearance-grid label,
 .config-section-header p, .config-section .config-save-button { font-size: calc(11px * var(--ui-font-scale)); }
-.settings-hub-card strong { font-size: calc(16px * var(--ui-font-scale)); }
+.settings-hub-card strong, .book-info strong { font-size: calc(16px * var(--ui-font-scale)); }
 .shelf-header p, .topbar { font-size: var(--ui-font-size); }
 .appearance-grid select, .dialog-fields input, .dialog-fields textarea, .dialog-fields select { font-size: calc(13px * var(--ui-font-scale)); }
 

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -3299,7 +3299,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 
 /* 显示设置中的界面字号按原有视觉层级缩放；正文与 Agent 对话分别独立调节。 */
 body { font-size: var(--ui-font-size); }
-.module-nav button, .ghost-button, .primary-button { font-size: calc(12px * var(--ui-font-scale)); }
+:is(.module-nav button, .ghost-button.ghost-button, .primary-button.primary-button) { font-size: calc(12px * var(--ui-font-scale)); }
 .module-header p { font-size: calc(13px * var(--ui-font-scale)); }
 .eyebrow, .field-label, .dialog-header-meta, .settings-hub-card small, .book-card small { font-size: calc(10px * var(--ui-font-scale)); }
 .panel-heading, .dialog-fields label, .dialog-fields .form-field-note, .appearance-grid label,

--- a/tests/system/appearance-typography.test.ts
+++ b/tests/system/appearance-typography.test.ts
@@ -19,7 +19,8 @@ describe("显示设置字号选项", () => {
     expect(application).toContain('form.get("aiFontSize")');
     expect(styles).toContain("body { font-size: var(--ui-font-size); }");
     expect(styles).toContain(":is(.module-nav button, .ghost-button.ghost-button, .primary-button.primary-button) { font-size: calc(12px * var(--ui-font-scale)); }");
-    expect(styles).toContain(".settings-hub-card strong { font-size: calc(16px * var(--ui-font-scale)); }");
+    expect(styles).toContain(".book-card small, .book-info > span { font-size: calc(10px * var(--ui-font-scale)); }");
+    expect(styles).toContain(".settings-hub-card strong, .book-info strong { font-size: calc(16px * var(--ui-font-scale)); }");
     expect(styles).not.toContain("font-size: calc(1em * var(--ui-font-scale));");
     expect(styles).toContain(".assistant-message, .user-message { font-size: var(--ai-font-size); }");
     expect(styles).toContain(".ai-tool-call-dialog { font-size: var(--ai-font-size); }");

--- a/tests/system/appearance-typography.test.ts
+++ b/tests/system/appearance-typography.test.ts
@@ -18,7 +18,7 @@ describe("显示设置字号选项", () => {
     expect(application).toContain('root.style.setProperty("--ai-font-size", `${normalized.aiFontSize}px`);');
     expect(application).toContain('form.get("aiFontSize")');
     expect(styles).toContain("body { font-size: var(--ui-font-size); }");
-    expect(styles).toContain(".module-nav button, .ghost-button, .primary-button { font-size: calc(12px * var(--ui-font-scale)); }");
+    expect(styles).toContain(":is(.module-nav button, .ghost-button.ghost-button, .primary-button.primary-button) { font-size: calc(12px * var(--ui-font-scale)); }");
     expect(styles).toContain(".settings-hub-card strong { font-size: calc(16px * var(--ui-font-scale)); }");
     expect(styles).not.toContain("font-size: calc(1em * var(--ui-font-scale));");
     expect(styles).toContain(".assistant-message, .user-message { font-size: var(--ai-font-size); }");

--- a/tests/system/appearance-typography.test.ts
+++ b/tests/system/appearance-typography.test.ts
@@ -11,6 +11,8 @@ describe("显示设置字号选项", () => {
     ]);
 
     expect(page).toContain('id="appearance-ui-font-size" name="uiFontSize"');
+    expect(page).toContain('<option value="14">14 px（标准）</option>');
+    expect(page).not.toContain('<option value="16">16 px（标准）</option>');
     expect(page).toContain('id="appearance-font-size" name="fontSize"');
     expect(page).toContain('id="appearance-ai-font-size" name="aiFontSize"');
     expect(page).toContain("界面 14 px · Agent 对话 14 px");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -322,7 +322,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
 expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
-    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-fix-v1');
+    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-specificity-v2');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -322,7 +322,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
 expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
-    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-specificity-v2');
+    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-shelf-v3');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-fix-v1');
+    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-specificity-v2');
     expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
   });
 });

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-specificity-v2');
+    expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-shelf-v3');
     expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
   });
 });

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-fix-v1');
+expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-specificity-v2');
     expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260801-timeline-lifecycle-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-specificity-v2');
+expect(page.text).toContain('/styles.css?v=20260801-ui-font-scale-shelf-v3');
     expect(page.text).toContain('/app.js?v=20260801-timeline-lifecycle-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260801-timeline-lifecycle-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');


### PR DESCRIPTION
## 变更内容

- 恢复嵌套按钮对界面字号设置的响应，同时保留固定基准比例，避免 `1em` 二次放大
- 让书架标题、作者信息与简介按原有字号层级同步缩放
- 将默认 14px 界面字号标记为“标准”
- 更新静态资源缓存版本和相关系统测试断言

## 原因

最近的字号缩放修复降低了通用按钮规则的选择器优先级，部分嵌套按钮会被局部固定字号覆盖；书架卡片也只有部分文字参与缩放，默认值文案同时与实际默认配置不一致。

## 验证

- 用户已在开发服务中完成人工验收
- 本轮按用户要求未额外执行自动化测试
