### PR TITLE
build(release): bump version to 0.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",


### PR DESCRIPTION
## 变更内容

- 将 npm 包版本从 `0.6.5` 更新为 `0.6.6`
- 同步更新 `package-lock.json` 根包版本

## 发布前验证

- CLI 变更审计完成，生命周期状态字段已同步 CLI 契约，无额外 CLI 缺口
- 真实 CLI E2E 通过
- 全量测试通过：122 个测试文件、628 项测试
- 生产构建通过
- SQLite `integrity_check` 与 `foreign_key_check` 通过
- 健康检查通过
