### PR TITLE
ci(main): require tests for pull requests

### DIFF
--- a/.github/workflows/main-pr-checks.yml
+++ b/.github/workflows/main-pr-checks.yml
@@ -1,0 +1,35 @@
+name: Main PR checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run required checks
+        run: npm run check


### PR DESCRIPTION
## 变更内容

- 新增仅针对目标分支为 main 的 PR 检查工作流
- 运行依赖安装、类型检查、全量测试和生产构建
- 将检查任务命名为 Test suite，供 main 分支保护设为必需检查

## 影响

指向 main 的 PR 会展示 Main PR checks / Test suite。检查失败或未完成时，main 的必需状态检查会阻止合并。

## 验证

- actionlint 通过
- npm run check 通过
- 122 个测试文件、628 项测试通过
- TypeScript 类型检查和生产构建通过