### PR TITLE
fix(ci): set main pr check timezone

### DIFF
--- a/.github/workflows/main-pr-checks.yml
+++ b/.github/workflows/main-pr-checks.yml
@@ -17,6 +17,8 @@ jobs:
     name: Test suite
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      TZ: Asia/Shanghai
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 根因

GitHub Actions 的 Ubuntu Runner 默认使用 UTC，而 AI prompt cache 集成测试按项目服务端时区 Asia/Shanghai 验证冻结时钟，导致 main PR 的 Test suite 在 Runner 上失败。

## 修复

为 Main PR checks 的 Test suite job 设置 TZ=Asia/Shanghai，不修改业务代码或测试断言。

## 验证

- UTC 环境下相关测试可稳定复现 2 项失败
- Asia/Shanghai 环境下相关测试 2 项通过
- actionlint 通过
- TZ=Asia/Shanghai npm run check 通过
- 122 个测试文件、628 项测试、类型检查和生产构建全部通过