### PR TITLE
ci(main): check docker builds for relevant changes

### DIFF
--- a/.github/workflows/main-pr-checks.yml
+++ b/.github/workflows/main-pr-checks.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -38,3 +40,66 @@ jobs:
 
       - name: Run CLI end-to-end tests
         run: npm run test:e2e:cli
+
+      - name: Detect Docker build changes
+        id: docker-changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          required=false
+          while IFS= read -r file; do
+            case "$file" in
+              Dockerfile|.dockerignore|package.json|package-lock.json|tsconfig*.json|scripts/*)
+                required=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA")
+          echo "required=$required" >> "$GITHUB_OUTPUT"
+          echo "Docker build required: $required"
+
+      - name: Set up Docker Buildx
+        if: steps.docker-changes.outputs.required == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image
+        if: steps.docker-changes.outputs.required == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: scriverse:pr-check
+          cache-from: type=gha,scope=main-pr-docker
+          cache-to: type=gha,mode=max,scope=main-pr-docker
+
+      - name: Check Docker container health
+        if: steps.docker-changes.outputs.required == 'true'
+        run: |
+          container_id="$(docker run --detach --publish 127.0.0.1:13212:13210 scriverse:pr-check)"
+          stop_container() {
+            docker stop "$container_id" >/dev/null
+          }
+          trap stop_container EXIT
+
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:13212/api/health >/dev/null; then
+              echo "Container health check passed"
+              exit 0
+            fi
+
+            if [ "$(docker inspect --format='{{.State.Running}}' "$container_id")" != "true" ]; then
+              echo "Container exited before health check passed"
+              docker logs "$container_id"
+              exit 1
+            fi
+
+            sleep 1
+          done
+
+          echo "Container health check timed out"
+          docker logs "$container_id"
+          exit 1


### PR DESCRIPTION
## 变更内容

在现有 Main PR checks / Test suite 中增加条件式 Docker 验证，不创建新的工作流或独立必需检查。

仅当 PR 修改以下 Docker 构建输入时执行：

- Dockerfile
- .dockerignore
- package.json 或 package-lock.json
- tsconfig*.json
- scripts/**

命中条件后构建 linux/amd64 镜像但不上传，随后将容器映射到本地 13212 端口并请求 /api/health。构建失败、容器提前退出或健康检查超时都会使原有 Test suite 失败。

## 验证

- actionlint 通过
- 路径过滤正反例通过
- linux/amd64 镜像本地构建通过
- 容器启动及 /api/health 检查通过
- 非 Docker 相关文件不会触发 Docker 构建