### PR TITLE
build(release): bump version to 0.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.6";
+export const APP_VERSION = "0.6.7";


### PR DESCRIPTION
## 变更内容

将 Scriverse 版本从 0.6.6 统一更新为 0.6.7：

- package.json
- package-lock.json 根版本与根包版本
- src/version.ts 中的 APP_VERSION

此提交用于修复 v0.6.6 发布物中包版本与应用版本不一致的问题。

## CLI 审计

本次功能差异仅涉及服务端布尔环境变量解析、测试和文档；CLI 命令、参数、API 契约、认证权限及导入导出格式均未变化，scriverse serve 已直接透传环境变量，因此无需额外 CLI 实现。

## 验证

- 版本一致性测试通过
- 123 个测试文件、630 项测试通过
- TypeScript 类型检查通过
- 生产构建通过
- 真实 CLI E2E 通过

本 PR 只将版本提交合入 develop，不创建 tag、GitHub Release 或发布产物。