### PR TITLE
build(main): bump version to 0.6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ CLI 会按服务器保存登录凭据。所有连接服务的数据命令都可�
 | `APP_AUTH_PASSWORD` | 空 | 可选的部署网关密码，至少 12 个字符；必须通过 HTTPS 传输 |
 | `APP_TRUST_PROXY` | `false` | 位于可信反向代理后时设为代理跳数（通常为 `1`）或 `true` |
 | `APP_ALLOW_PRIVATE_AI_ENDPOINTS` | 开发环境 `true`，生产环境 `false` | 是否允许 AI 供应商连接本机或内网地址；链路本地与云元数据地址始终禁止 |
-| `APP_ALLOW_REGISTRATION` | `false` | 仅明确设为 `true` 时开放注册；未设置或其他值均关闭，首次初始化创建管理员也必须显式开启 |
+| `APP_ALLOW_REGISTRATION` | `false` | 仅明确设为 `true` 或 `1` 时开放注册；未设置或其他值均关闭，首次初始化创建管理员也必须显式开启 |
 | `APP_SETUP_TOKEN` | 空 | 开放注册时必填且至少 32 个字符；仅首位管理员注册需要在页面输入 |
+
+布尔环境变量统一接受 `true`/`1` 表示开启、`false`/`0` 表示关闭；其他数字不会被解析为布尔值。`APP_TRUST_PROXY` 例外，其 `0`–`10` 数字表示可信代理跳数。
 
 自定义示例：
 

--- a/docs/docker-deployment.en.md
+++ b/docs/docker-deployment.en.md
@@ -68,7 +68,7 @@ Recreate the container so the setting takes effect:
 docker compose up -d --force-recreate
 ```
 
-Registration is enabled only when `APP_ALLOW_REGISTRATION` is exactly `true`, and `APP_SETUP_TOKEN` must contain at least 32 characters. Unset, `false`, and all other values disable both the UI and backend registration endpoint, including first-administrator setup on an empty database. The setup token is checked only when creating the first administrator.
+Registration is enabled only when `APP_ALLOW_REGISTRATION` is `true` or `1`; `false` or `0` disables it, and `APP_SETUP_TOKEN` must contain at least 32 characters. Unset and all other values disable both the UI and backend registration endpoint, including first-administrator setup on an empty database. The setup token is checked only when creating the first administrator.
 
 ## Pin a release
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -68,7 +68,7 @@ APP_SETUP_TOKEN=
 docker compose up -d --force-recreate
 ```
 
-`APP_ALLOW_REGISTRATION` 只有明确设置为 `true` 时才开放注册；同时必须配置至少 32 个字符的 `APP_SETUP_TOKEN`。未设置、`false` 或其他值都会同时关闭前端注册入口和后端注册接口，包括空数据库的首位管理员注册。初始化令牌只在创建首位管理员时校验。
+`APP_ALLOW_REGISTRATION` 只有明确设置为 `true` 或 `1` 时才开放注册；`false` 或 `0` 表示关闭，同时必须配置至少 32 个字符的 `APP_SETUP_TOKEN`。未设置或其他值都会同时关闭前端注册入口和后端注册接口，包括空数据库的首位管理员注册。初始化令牌只在创建首位管理员时校验。
 
 ## 固定正式版本
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/security.ts
+++ b/src/security.ts
@@ -6,6 +6,7 @@ import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { Agent } from "undici";
 import { AppError } from "./errors.js";
 import { logger } from "./logger.js";
+import { parseBooleanEnvironmentValue } from "./utils.js";
 
 export type BasicAuthOptions = {
   username: string;
@@ -421,14 +422,14 @@ export function resolveRuntimeSecurity(environment: NodeJS.ProcessEnv, requireAu
   const trustProxyValue = environment.APP_TRUST_PROXY?.trim() ?? "";
   const trustProxy = trustProxyValue === "true" ? true : /^\d+$/u.test(trustProxyValue) ? Number(trustProxyValue) : false;
   if (typeof trustProxy === "number" && (trustProxy < 0 || trustProxy > 10)) throw new Error("APP_TRUST_PROXY 只能是 true 或 0-10 的整数");
-  const allowRegistration = environment.APP_ALLOW_REGISTRATION === "true";
+  const allowRegistration = parseBooleanEnvironmentValue(environment.APP_ALLOW_REGISTRATION) ?? false;
   const setupToken = environment.APP_SETUP_TOKEN ?? "";
   if (allowRegistration && setupToken.length < 32) throw new Error("开放注册时 APP_SETUP_TOKEN 至少需要 32 个字符");
   return {
     ...(username ? { auth: { username, password } } : {}),
     trustProxy,
     enforceSameOrigin: true,
-    allowPrivateAiEndpoints: environment.APP_ALLOW_PRIVATE_AI_ENDPOINTS === "true" || !production,
+    allowPrivateAiEndpoints: parseBooleanEnvironmentValue(environment.APP_ALLOW_PRIVATE_AI_ENDPOINTS) ?? !production,
     allowRegistration,
     ...(setupToken ? { setupToken } : {})
   };
@@ -436,7 +437,7 @@ export function resolveRuntimeSecurity(environment: NodeJS.ProcessEnv, requireAu
 
 export function isDevelopmentAuthBypassEnabled(environment: NodeJS.ProcessEnv, containerRuntime = detectContainerRuntime(environment)): boolean {
   return environment.NODE_ENV === "development"
-    && environment.APP_DEV_SKIP_AUTH === "true"
+    && (parseBooleanEnvironmentValue(environment.APP_DEV_SKIP_AUTH) ?? false)
     && !containerRuntime;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,12 @@
 import { randomUUID } from "node:crypto";
 
+/** 严格解析布尔环境变量；未识别的值交由调用方使用默认配置。 */
+export function parseBooleanEnvironmentValue(value: string | undefined): boolean | undefined {
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  return undefined;
+}
+
 export function id(prefix: string): string {
   return `${prefix}_${randomUUID().replaceAll("-", "")}`;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.6";
+export const APP_VERSION = "0.6.7";

--- a/tests/e2e/real-collaboration-refresh.ts
+++ b/tests/e2e/real-collaboration-refresh.ts
@@ -5,11 +5,12 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { createRuntime } from "../../src/app.js";
 import { runWithRequestActor } from "../../src/request-context.js";
+import { parseBooleanEnvironmentValue } from "../../src/utils.js";
 
 type Json = Record<string, unknown>;
 
 const port = Number(process.env.E2E_COLLAB_PORT ?? 13213);
-const keepAlive = process.env.E2E_COLLAB_KEEP_ALIVE === "1";
+const keepAlive = parseBooleanEnvironmentValue(process.env.E2E_COLLAB_KEEP_ALIVE) ?? false;
 const dataRoot = join(process.cwd(), ".data");
 await mkdir(dataRoot, { recursive: true });
 const isolatedDirectory = await mkdtemp(join(dataRoot, "e2e-collab-refresh-"));

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -17,21 +17,41 @@ afterEach(async () => {
 });
 
 describe("本地服务运行时", () => {
-  it("仅在 APP_ALLOW_REGISTRATION 明确为 true 时开放注册", () => {
+  it("仅在 APP_ALLOW_REGISTRATION 明确开启时开放注册", () => {
+    const setupToken = "server-runtime-setup-token-with-at-least-32-characters";
     expect(resolveRuntimeSecurity({}).allowRegistration).toBe(false);
     expect(resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "false" }).allowRegistration).toBe(false);
+    expect(resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "0" }).allowRegistration).toBe(false);
+    expect(resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "2" }).allowRegistration).toBe(false);
     expect(resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "TRUE" }).allowRegistration).toBe(false);
     expect(() => resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "true" })).toThrow("APP_SETUP_TOKEN");
+    expect(() => resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "1" })).toThrow("APP_SETUP_TOKEN");
     expect(resolveRuntimeSecurity({
       APP_ALLOW_REGISTRATION: "true",
-      APP_SETUP_TOKEN: "server-runtime-setup-token-with-at-least-32-characters"
+      APP_SETUP_TOKEN: setupToken
     }).allowRegistration).toBe(true);
+    expect(resolveRuntimeSecurity({ APP_ALLOW_REGISTRATION: "1", APP_SETUP_TOKEN: setupToken }).allowRegistration).toBe(true);
+  });
+
+  it("允许布尔环境变量使用 0 和 1", () => {
+    expect(resolveRuntimeSecurity({ NODE_ENV: "production", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "true" }).allowPrivateAiEndpoints).toBe(true);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "production", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "1" }).allowPrivateAiEndpoints).toBe(true);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "production", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "false" }).allowPrivateAiEndpoints).toBe(false);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "production", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "0" }).allowPrivateAiEndpoints).toBe(false);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "production", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "2" }).allowPrivateAiEndpoints).toBe(false);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "development", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "false" }).allowPrivateAiEndpoints).toBe(false);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "development", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "0" }).allowPrivateAiEndpoints).toBe(false);
+    expect(resolveRuntimeSecurity({ NODE_ENV: "development", APP_ALLOW_PRIVATE_AI_ENDPOINTS: "2" }).allowPrivateAiEndpoints).toBe(true);
+    expect(resolveRuntimeSecurity({ APP_TRUST_PROXY: "2" }).trustProxy).toBe(2);
   });
 
   it("仅在非生产环境显式开启时允许开发免登录", () => {
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true" }, false)).toBe(true);
+    expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "1" }, false)).toBe(true);
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "production", APP_DEV_SKIP_AUTH: "true" }, false)).toBe(false);
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "false" }, false)).toBe(false);
+    expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "0" }, false)).toBe(false);
+    expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "2" }, false)).toBe(false);
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true" }, true)).toBe(false);
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true", SCRIVERSE_RUNTIME: "container" })).toBe(false);
   });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { parseBooleanEnvironmentValue } from "../../src/utils.js";
+
+describe("布尔环境变量", () => {
+  it("仅接受 true、false、1 和 0", () => {
+    expect(parseBooleanEnvironmentValue("true")).toBe(true);
+    expect(parseBooleanEnvironmentValue("1")).toBe(true);
+    expect(parseBooleanEnvironmentValue("false")).toBe(false);
+    expect(parseBooleanEnvironmentValue("0")).toBe(false);
+    expect(parseBooleanEnvironmentValue("2")).toBeUndefined();
+    expect(parseBooleanEnvironmentValue("-1")).toBeUndefined();
+    expect(parseBooleanEnvironmentValue("TRUE")).toBeUndefined();
+    expect(parseBooleanEnvironmentValue(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 变更内容

将 develop 中已经验收的布尔环境变量兼容功能和 0.6.7 版本提交同步到 main。

- 布尔环境变量支持 true/1 与 false/0
- 其他数字不作为布尔值生效
- APP_TRUST_PROXY 保留 0–10 代理跳数语义
- package.json、package-lock.json 与 APP_VERSION 统一为 0.6.7

## 版本原因

v0.6.6 标签中的 package 版本为 0.6.6，但 APP_VERSION 仍为 0.6.5。由于已发布版本不可重写，本次使用 0.6.7 恢复版本一致性。

## CLI 审计

CLI 命令、参数、API 契约、认证权限及导入导出格式均未变化；真实 CLI E2E 已通过，无需同步 CLI 实现。

## 合并门禁

必须等待 Main PR checks / Test suite 通过。package 清单变化会触发 linux/amd64 Docker 构建及容器 /api/health 检查，不允许绕过。

## 非发布说明

本 PR 只将版本更新合入 main，不创建 Git tag、GitHub Release，也不发布 npm 包或 Docker 镜像。