### PR TITLE
chore(git): ignore node_modules symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 .data/
 coverage/


### PR DESCRIPTION
## 变更

- 将 `.gitignore` 中的 `node_modules/` 调整为 `node_modules`
- 同时忽略真实目录与工作树中常用的同名符号链接

## 原因

带尾部斜杠的规则只匹配目录，不匹配 `node_modules` 符号链接，导致隔离工作树持续出现未跟踪项。

## 验证

- 使用真实 `node_modules` 符号链接验证 `git check-ignore`
- `npm test`：123 个测试文件、630 项测试全部通过
- `npm run build`：通过
- `git diff --check`：通过