### PR TITLE
perf(characters): defer redundant catalog loading across tabs

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -5147,15 +5147,14 @@ function bindModuleContentInteractions() {
   moduleContentInteractionsBound = true;
   const host = $("#module-content");
   const open = async (card) => {
-    const id = card.dataset.openSetting ?? card.dataset.openCharacter ?? card.dataset.openRace ?? card.dataset.openOrganization;
+    const id = card.dataset.openSetting ?? card.dataset.openRace ?? card.dataset.openOrganization;
     if (!id) return;
     if (card.dataset.openSetting) return openSettingEditor(await api(`/api/settings/${encodeURIComponent(id)}`), { readOnly: true });
-    if (card.dataset.openCharacter) return openCharacterEditor(await api(`/api/characters/${encodeURIComponent(id)}`), { readOnly: true });
     if (card.dataset.openRace) return openRaceDialog(await api(`/api/races/${encodeURIComponent(id)}`), { readOnly: true });
     if (card.dataset.openOrganization) return openOrganizationDialog(await api(`/api/organizations/${encodeURIComponent(id)}`), { readOnly: true });
   };
   const findCard = (target) => target instanceof Element
-    ? target.closest("[data-open-setting], [data-open-character], [data-open-race], [data-open-organization]")
+    ? target.closest("[data-open-setting], [data-open-race], [data-open-organization]")
     : null;
   host.addEventListener("click", (event) => {
     if (event.target instanceof Element && event.target.closest("button, a, summary")) return;

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -5688,10 +5688,7 @@ async function renderRaces() {
 }
 
 async function renderOrganizations(page = moduleListPages.organizations) {
-  [state.organizations, state.characters] = await Promise.all([
-    moduleApiAllPages("organizations", `/api/works/${state.work.id}/organizations`),
-    canReadModule("characters") ? moduleApiAllPages("organizations", `/api/works/${state.work.id}/characters`) : Promise.resolve([])
-  ]);
+  state.organizations = await moduleApiAllPages("organizations", `/api/works/${state.work.id}/organizations`);
   mountModuleCount(state.organizations.length);
   const pageResult = paginateModuleItems(state.organizations, page, "organizations");
   moduleListPages.organizations = pageResult.page;

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -9392,7 +9392,7 @@ function renderKnowledgeEditorFields(kind, item, memberOptions, parentOptions) {
     + field("description", `${label}简介`, "textarea", item?.description, []);
   const memberField = memberOptions.length
     ? field("memberIds", isRace ? "属于该种族的角色（可多选）" : "组织成员（可多选）", "chips", item?.memberIds ?? [], memberOptions)
-    : `<div class="character-editor-empty-field"><strong>${isRace ? "种族成员" : "组织成员"}</strong><span>当前还没有可绑定的角色。</span></div>`;
+    : `<div class="character-editor-empty-field"><strong>${isRace ? "种族成员" : "组织成员"}</strong><span>${readOnly ? "该档案尚未绑定角色。" : "当前还没有可绑定的角色。"}</span></div>`;
   $("#knowledge-editor-fields").innerHTML = knowledgeEditorSection("basic", "基础资料", isRace ? "先定义名称、层级和简介，再补充共同设定。" : "先定义组织名称和简介，再补充完整的组织设定。", basicFields)
     + knowledgeEditorSection("settings", title, "", '<div id="knowledge-markdown-sections" class="knowledge-markdown-sections"></div>')
     + knowledgeEditorSection("members", isRace ? "种族成员" : "组织成员", "成员关系会同步到角色档案中。", memberField);

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -969,6 +969,7 @@ let knowledgeSectionEditorDirty = false;
 let characterEditorVersions = [];
 let characterEditorRelationships = [];
 let characterEditorRelationshipsLoading = false;
+let characterEditorRelationshipsLoaded = false;
 let characterEditorSections = [];
 let characterSectionPendingAttachments = [];
 let markdownEditorPendingAttachments = [];
@@ -8400,6 +8401,15 @@ function activateCharacterEditorTab(key) {
     button.tabIndex = active ? 0 : -1;
   });
   document.querySelectorAll("[data-character-editor-panel]").forEach((panel) => panel.classList.toggle("hidden", panel.dataset.characterEditorPanel !== key));
+  if (
+    key === "relationships"
+    && characterEditorItem?.id
+    && canReadModule("relationships")
+    && !characterEditorRelationshipsLoaded
+    && !characterEditorRelationshipsLoading
+  ) {
+    void loadCharacterEditorRelationships(characterEditorItem.id);
+  }
 }
 
 function setCharacterHistoryVisible(visible) {
@@ -8419,6 +8429,10 @@ function renderCharacterEditorRelationships() {
   }
   if (characterEditorRelationshipsLoading) {
     host.innerHTML = '<p class="character-relationship-status">正在读取人物关系……</p>';
+    return;
+  }
+  if (!characterEditorRelationshipsLoaded) {
+    host.innerHTML = '<p class="character-relationship-status">打开人物关系分区后载入关系。</p>';
     return;
   }
   const characterId = String(characterEditorItem.id);
@@ -8443,20 +8457,23 @@ function renderCharacterEditorRelationships() {
   host.querySelector("[data-character-relationship-create]")?.addEventListener("click", () => void openRelationshipDialog(null, { characterId }));
 }
 
-async function loadCharacterEditorRelationships(characterId) {
+async function loadCharacterEditorRelationships(characterId, { refresh = false } = {}) {
   const workId = state.work?.id;
   if (!workId || characterEditorItem?.id !== characterId) return;
+  if (!refresh && (characterEditorRelationshipsLoaded || characterEditorRelationshipsLoading)) return;
   characterEditorRelationshipsLoading = true;
+  characterEditorRelationshipsLoaded = false;
   renderCharacterEditorRelationships();
   let loaded = false;
   try {
     const [characters, relationships] = await Promise.all([
-      apiAllPages(`/api/works/${workId}/characters`),
-      apiAllPages(`/api/works/${workId}/relationships`)
+      moduleApiAllPages("characters", `/api/works/${workId}/characters`),
+      moduleApiAllPages("relationships", `/api/works/${workId}/relationships`)
     ]);
     if (state.work?.id !== workId || characterEditorItem?.id !== characterId) return;
     state.characters = characters;
     characterEditorRelationships = relationships.filter((relationship) => relationship.fromCharacterId === characterId || relationship.toCharacterId === characterId);
+    characterEditorRelationshipsLoaded = true;
     loaded = true;
   } catch (error) {
     if (state.work?.id === workId && characterEditorItem?.id === characterId) {
@@ -8474,7 +8491,7 @@ async function refreshRelationshipSurfaces(characterId = null) {
   const tasks = [];
   if (state.module === "relationships") tasks.push(renderRelationships());
   if (characterId && entityEditorType === "character" && !$("#entity-editor-view").classList.contains("hidden") && characterEditorItem?.id === characterId) {
-    tasks.push(loadCharacterEditorRelationships(characterId));
+    tasks.push(loadCharacterEditorRelationships(characterId, { refresh: true }));
   }
   await Promise.all(tasks);
 }
@@ -9245,15 +9262,15 @@ async function showCharacterHistory() {
 
 async function openCharacterEditor(item = null, { readOnly = false } = {}) {
   entityEditorReadOnly = readOnly;
-  [state.races, state.organizations, state.characters] = await Promise.all([
+  [state.races, state.organizations] = await Promise.all([
     canReadModule("races") ? api(`/api/works/${state.work.id}/races`) : Promise.resolve([]),
-    canReadModule("organizations") ? apiAllPages(`/api/works/${state.work.id}/organizations`) : Promise.resolve([]),
-    canReadModule("characters") ? apiAllPages(`/api/works/${state.work.id}/characters`) : Promise.resolve([])
+    canReadModule("organizations") ? apiAllPages(`/api/works/${state.work.id}/organizations`) : Promise.resolve([])
   ]);
   characterEditorItem = item ?? null;
   characterEditorVersions = [];
   characterEditorRelationships = [];
-  characterEditorRelationshipsLoading = Boolean(item);
+  characterEditorRelationshipsLoading = false;
+  characterEditorRelationshipsLoaded = false;
   characterEditorSections = [];
   $("#character-editor-eyebrow").textContent = item ? "人物主档案" : "建立人物档案";
   $("#character-editor-title").textContent = item?.name || "新建角色";
@@ -9265,20 +9282,30 @@ async function openCharacterEditor(item = null, { readOnly = false } = {}) {
   const characterMergeButton = $("#character-merge-button");
   const characterDeleteButton = $("#character-delete-button");
   const canManageCharacter = Boolean(item && !readOnly && canEditModule("characters"));
-  characterMergeButton.classList.toggle("hidden", !canManageCharacter || state.characters.length < 2);
+  characterMergeButton.classList.toggle("hidden", !canManageCharacter);
   characterDeleteButton.classList.toggle("hidden", !canManageCharacter);
   characterMergeButton.onclick = async () => {
     if (!item) return;
-    await closeEntityEditor({ force: true });
-    openEntityMergeDialog({
-      typeLabel: "角色",
-      source: item,
-      candidates: state.characters,
-      endpoint: (character) => `/api/characters/${encodeURIComponent(character.id)}/merge`,
-      body: (target) => ({ targetCharacterId: target.id, expectedTargetVersionNo: target.versionNo, expectedSourceVersionNo: item.versionNo }),
-      refresh: renderCharacters,
-      impact: "来源角色的别名、组织、档案章节、时间线与人物关系会迁移到目标角色。"
-    });
+    const workId = state.work?.id;
+    if (!workId) return;
+    try {
+      const candidates = await moduleApiAllPages("characters", `/api/works/${workId}/characters`);
+      if (state.work?.id !== workId || characterEditorItem?.id !== item.id) return;
+      state.characters = candidates;
+      if (candidates.length < 2) return toast("至少需要两个角色才能合并", "error");
+      await closeEntityEditor({ force: true });
+      openEntityMergeDialog({
+        typeLabel: "角色",
+        source: item,
+        candidates,
+        endpoint: (character) => `/api/characters/${encodeURIComponent(character.id)}/merge`,
+        body: (target) => ({ targetCharacterId: target.id, expectedTargetVersionNo: target.versionNo, expectedSourceVersionNo: item.versionNo }),
+        refresh: renderCharacters,
+        impact: "来源角色的别名、组织、档案章节、时间线与人物关系会迁移到目标角色。"
+      });
+    } catch (error) {
+      toast(error.message, "error");
+    }
   };
   characterDeleteButton.onclick = () => {
     if (!item) return;
@@ -9336,7 +9363,6 @@ async function openCharacterEditor(item = null, { readOnly = false } = {}) {
   };
   showEntityEditorPage("character", { readOnly });
   if (item) {
-    if (canReadModule("relationships")) void loadCharacterEditorRelationships(item.id);
     void loadCharacterMarkdownSections(item.id);
   }
 }
@@ -9693,7 +9719,7 @@ function openTimelineSplitDialog(item) {
 
 async function openRelationshipDialog(item, options = {}) {
   if (!canReadModule("characters")) return toast("配置人物关系前需要角色模块读取权限", "error");
-  state.characters = await apiAllPages(`/api/works/${state.work.id}/characters`);
+  state.characters = await moduleApiAllPages("characters", `/api/works/${state.work.id}/characters`);
   if (state.characters.length < 2) return toast("至少需要两个角色才能创建关系", "error");
   const characterOptions = state.characters.map((item) => [item.id, item.name]);
   const defaultFrom = options.characterId && state.characters.some((character) => character.id === options.characterId) ? options.characterId : characterOptions[0][0];

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -9409,8 +9409,13 @@ async function openKnowledgeEditor(kind, item, { readOnly = false } = {}) {
   entityEditorReadOnly = readOnly;
   await discardPendingMarkdownAttachments();
   if (kind === "race" && !(await ensureCompleteRaceList())) return;
-  state.characters = canReadModule("characters") ? await apiAllPages(`/api/works/${state.work.id}/characters`) : [];
-  const memberOptions = state.characters.map((character) => [character.id, `${character.name}${character.aliases.length ? `（${character.aliases.join("、")}）` : ""}`]);
+  const memberCharacters = readOnly
+    ? (Array.isArray(item?.members) ? item.members : []).map((member) => ({ id: member.characterId, name: member.name, aliases: [] }))
+    : canReadModule("characters")
+      ? await moduleApiAllPages("characters", `/api/works/${state.work.id}/characters`)
+      : [];
+  if (!readOnly) state.characters = memberCharacters;
+  const memberOptions = memberCharacters.map((character) => [character.id, `${character.name}${character.aliases.length ? `（${character.aliases.join("、")}）` : ""}`]);
   const isRace = kind === "race";
   const module = isRace ? "races" : "organizations";
   const label = isRace ? "种族" : "组织";

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -5993,10 +5993,11 @@ async function renderReviews(page = moduleListPages.reviews) {
   const canResolveReview = canEditModule("reviews");
   const canMergeCharacters = canResolveReview
     && ["characters", "races", "organizations", "timeline", "relationships"].every((module) => canEditModule(module));
-  const [reviews, characters] = await Promise.all([
-    moduleApiAllPages("reviews", `/api/works/${state.work.id}/reviews`),
-    canReadCharacters ? moduleApiAllPages("reviews", `/api/works/${state.work.id}/characters?includeMerged=1`) : Promise.resolve([])
-  ]);
+  const reviews = await moduleApiAllPages("reviews", `/api/works/${state.work.id}/reviews`);
+  const hasCharacterDuplicateReviews = reviews.some((item) => item.itemType === "character-duplicate");
+  const characters = canReadCharacters && hasCharacterDuplicateReviews
+    ? await moduleApiAllPages("reviews", `/api/works/${state.work.id}/characters?includeMerged=1`)
+    : [];
   mountModuleCount(reviews.length);
   const pageResult = paginateModuleItems(reviews, page, "reviews");
   moduleListPages.reviews = pageResult.page;

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -588,7 +588,7 @@ expect(page.text).toContain('/styles.css?v=20260802-release-update-v1');
     expect(styles.text).toContain("body.work-viewer-mode [data-edit-setting]");
     expect(styles.text).toContain("body.work-viewer-mode [data-merge-review]");
     expect(application.text).toContain('item.status === "pending" && canResolveReview');
-    expect(application.text).toContain('canReadCharacters ? moduleApiAllPages("reviews"');
+    expect(application.text).toContain('canReadCharacters && hasCharacterDuplicateReviews');
     expect(application.text).toContain('const canReadAggregate = hasWork && canReadAggregateContent()');
     expect(styles.text).not.toContain(".app-shell.prose-read-only-mode:not(.shelf-mode) #new-chapter-button");
     expect(styles.text).toContain(".add-button { width: 24px; height: 24px;");

--- a/tests/system/lazy-work-loading.test.ts
+++ b/tests/system/lazy-work-loading.test.ts
@@ -137,4 +137,16 @@ describe("作品工作台按需加载", () => {
     expect(renderCharactersSource).toContain('openCharacterEditor(pageCharacters.find((item) => item.id === id)');
     expect(openCharacterEditorSource).toContain('canReadModule("characters") ? apiAllPages(`/api/works/${state.work.id}/characters`)');
   });
+
+  it("角色卡预览只由角色列表处理，避免模块事件代理重复打开", async () => {
+    const application = await readFile(join(process.cwd(), "src/public/app.js"), "utf8");
+    const moduleInteractionSource = application.slice(
+      application.indexOf("function bindModuleContentInteractions()"),
+      application.indexOf("function openReviewDetailDialog(")
+    );
+
+    expect(moduleInteractionSource).not.toContain("openCharacter");
+    expect(moduleInteractionSource).not.toContain("openCharacterEditor(await api");
+    expect(application).toContain('bindRecordPreview("[data-open-character]"');
+  });
 });

--- a/tests/system/lazy-work-loading.test.ts
+++ b/tests/system/lazy-work-loading.test.ts
@@ -135,7 +135,11 @@ describe("作品工作台按需加载", () => {
     expect(renderCharactersSource).toContain("const pageCharacters = characterPage.items;");
     expect(renderCharactersSource).not.toContain("state.characters = characterPage.items");
     expect(renderCharactersSource).toContain('openCharacterEditor(pageCharacters.find((item) => item.id === id)');
-    expect(openCharacterEditorSource).toContain('canReadModule("characters") ? apiAllPages(`/api/works/${state.work.id}/characters`)');
+    expect(openCharacterEditorSource).not.toContain('canReadModule("characters") ? apiAllPages(`/api/works/${state.work.id}/characters`)');
+    expect(openCharacterEditorSource).toContain('const candidates = await moduleApiAllPages("characters", `/api/works/${workId}/characters`)');
+    expect(openCharacterEditorSource).not.toContain("loadCharacterEditorRelationships(item.id)");
+    expect(application).toContain('moduleApiAllPages("characters", `/api/works/${workId}/characters`)');
+    expect(application).toContain('key === "relationships"');
   });
 
   it("角色卡预览只由角色列表处理，避免模块事件代理重复打开", async () => {

--- a/tests/system/lazy-work-loading.test.ts
+++ b/tests/system/lazy-work-loading.test.ts
@@ -124,6 +124,18 @@ describe("作品工作台按需加载", () => {
     expect(openKnowledgeEditorSource).not.toContain('state.characters = canReadModule("characters") ? await apiAllPages(`/api/works/${state.work.id}/characters`) : []');
   });
 
+  it("组织列表不预加载未用于列表渲染的角色目录", async () => {
+    const application = await readFile(join(process.cwd(), "src/public/app.js"), "utf8");
+    const renderOrganizationsSource = application.slice(
+      application.indexOf("async function renderOrganizations("),
+      application.indexOf("function updateTimelineMultiSelectControls(")
+    );
+
+    expect(renderOrganizationsSource).toContain('state.organizations = await moduleApiAllPages("organizations", `/api/works/${state.work.id}/organizations`)');
+    expect(renderOrganizationsSource).not.toContain("/characters");
+    expect(renderOrganizationsSource).toContain("item.members");
+  });
+
   it("角色分页不覆盖跨模块全量引用缓存", async () => {
     const application = await readFile(join(process.cwd(), "src/public/app.js"), "utf8");
     const renderCharactersSource = application.slice(

--- a/tests/system/lazy-work-loading.test.ts
+++ b/tests/system/lazy-work-loading.test.ts
@@ -118,7 +118,10 @@ describe("作品工作台按需加载", () => {
     expect(renderRacesSource).toContain("dismissLoadingToast();");
     expect(renderRacesSource).not.toContain("apiAllPages");
     expect(renderRacesSource).not.toContain('/characters');
-    expect(openKnowledgeEditorSource).toContain('state.characters = canReadModule("characters") ? await apiAllPages(`/api/works/${state.work.id}/characters`) : []');
+    expect(openKnowledgeEditorSource).toContain('const memberCharacters = readOnly');
+    expect(openKnowledgeEditorSource).toContain('await moduleApiAllPages("characters", `/api/works/${state.work.id}/characters`)');
+    expect(openKnowledgeEditorSource).toContain('if (!readOnly) state.characters = memberCharacters;');
+    expect(openKnowledgeEditorSource).not.toContain('state.characters = canReadModule("characters") ? await apiAllPages(`/api/works/${state.work.id}/characters`) : []');
   });
 
   it("角色分页不覆盖跨模块全量引用缓存", async () => {

--- a/tests/system/lazy-work-loading.test.ts
+++ b/tests/system/lazy-work-loading.test.ts
@@ -136,6 +136,19 @@ describe("作品工作台按需加载", () => {
     expect(renderOrganizationsSource).toContain("item.members");
   });
 
+  it("审核面板仅为角色查重审核项加载角色目录", async () => {
+    const application = await readFile(join(process.cwd(), "src/public/app.js"), "utf8");
+    const renderReviewsSource = application.slice(
+      application.indexOf("async function renderReviews("),
+      application.indexOf("async function renderTasks(")
+    );
+
+    expect(renderReviewsSource).toContain('const reviews = await moduleApiAllPages("reviews", `/api/works/${state.work.id}/reviews`)');
+    expect(renderReviewsSource).toContain('const hasCharacterDuplicateReviews = reviews.some((item) => item.itemType === "character-duplicate");');
+    expect(renderReviewsSource).toContain('canReadCharacters && hasCharacterDuplicateReviews');
+    expect(renderReviewsSource).toContain('`/api/works/${state.work.id}/characters?includeMerged=1`');
+  });
+
   it("角色分页不覆盖跨模块全量引用缓存", async () => {
     const application = await readFile(join(process.cwd(), "src/public/app.js"), "utf8");
     const renderCharactersSource = application.slice(


### PR DESCRIPTION
## 变更内容

- 角色卡片预览只保留单一打开入口，避免重复打开详情。
- 角色列表首次只加载当前分页；角色合并、人物关系分区等确实需要全量角色时再按需加载，并复用模块请求缓存。
- 种族和组织只读详情直接使用详情接口返回的成员信息，不再额外加载全量角色列表。
- 组织列表移除未使用的角色预加载。
- 审核队列仅在存在“角色查重”审核项时加载角色目录。
- 增加对应的系统级静态回归断言。

## 根因

多个详情或 tab 初始化路径为了构造成员、关系或审核展示，直接无条件请求全量角色目录；角色卡片同时存在卡片事件和统一委托事件，导致预览入口重复触发。

## 验证结果

- `npm test`：124 个测试文件、640 个测试通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。
- 使用主目录数据库副本在独立端口 `23211` 运行内置浏览器 E2E：
  - 209 个角色的角色列表只加载首屏，打开角色详情不再重新拉全量角色。
  - 种族、组织详情及成员 tab 不产生角色目录请求。
  - 有角色查重项的审核页按需加载角色；无审核项的作品只请求审核数据。
  - 人物关系首次加载所需的角色分页后，重复进入命中缓存。
  - 浏览器控制台无错误，相关请求均返回 200。
- 隔离数据库 `PRAGMA integrity_check` 通过，`foreign_key_check` 无异常。