### PR TITLE
fix(updates): support disabling release checks

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2706,6 +2706,10 @@ async function refreshSystemHealth() {
 
 function scheduleProductUpdateCheck() {
   if (productUpdateTimer !== null) window.clearTimeout(productUpdateTimer);
+  if (productUpdateStatus?.enabled === false) {
+    productUpdateTimer = null;
+    return;
+  }
   const nextCheckAt = Date.parse(String(productUpdateStatus?.nextCheckAt ?? ""));
   const delay = Number.isFinite(nextCheckAt)
     ? Math.max(1000, nextCheckAt - Date.now())
@@ -2717,7 +2721,7 @@ function scheduleProductUpdateCheck() {
 }
 
 async function refreshProductUpdate() {
-  if (productUpdateChecking) return;
+  if (productUpdateChecking || productUpdateStatus?.enabled === false) return;
   productUpdateChecking = true;
   renderBackgroundTaskCenter();
   try {
@@ -6971,21 +6975,24 @@ function updateBackgroundTaskCenterVisibility() {
 
 function backgroundProductUpdateMarkup() {
   const status = productUpdateStatus;
+  const updateCheckDisabled = status?.enabled === false;
   const currentVersion = String(status?.currentVersion ?? "").trim();
   const latestVersion = String(status?.latestVersion ?? "").trim();
   const nextCheckAt = formatDateTime(status?.nextCheckAt) || "等待首次探测";
   const updateAvailable = status?.updateAvailable === true && Boolean(status?.releaseUrl);
-  const badgeClass = productUpdateChecking ? "running" : updateAvailable ? "partial" : status?.checked === true ? "completed" : status ? "unknown" : "pending";
-  const badgeLabel = productUpdateChecking ? "探测中" : updateAvailable ? "有新版本" : status?.checked === true ? "已是最新" : status ? "本次未探测" : "等待探测";
+  const badgeClass = productUpdateChecking ? "running" : updateCheckDisabled ? "unknown" : updateAvailable ? "partial" : status?.checked === true ? "completed" : status ? "unknown" : "pending";
+  const badgeLabel = productUpdateChecking ? "探测中" : updateCheckDisabled ? "已关闭" : updateAvailable ? "有新版本" : status?.checked === true ? "已是最新" : status ? "本次未探测" : "等待探测";
   const detail = productUpdateChecking
     ? "正在请求 GitHub 最新 Release"
-    : updateAvailable
-      ? `当前 v${currentVersion || "—"} · 最新 v${latestVersion} · 下次探测 ${nextCheckAt}`
-      : status?.checked === true
-        ? `当前 v${currentVersion || "—"} · 下次探测 ${nextCheckAt}`
-        : status
-          ? `GitHub 暂不可用 · 下次探测 ${nextCheckAt}`
-          : "应用启动后将在后台探测 GitHub Release";
+    : updateCheckDisabled
+      ? "已通过服务端配置关闭版本更新探测"
+      : updateAvailable
+        ? `当前 v${currentVersion || "—"} · 最新 v${latestVersion} · 下次探测 ${nextCheckAt}`
+        : status?.checked === true
+          ? `当前 v${currentVersion || "—"} · 下次探测 ${nextCheckAt}`
+          : status
+            ? `GitHub 暂不可用 · 下次探测 ${nextCheckAt}`
+            : "应用启动后将在后台探测 GitHub Release";
   return `<section class="background-task-section">
     <div class="background-task-section-heading"><div><strong>版本更新探测</strong><small>按服务端配置定期检查 GitHub Release</small></div></div>
     <div class="background-task-list"><article class="background-task-row">

--- a/src/release-update.ts
+++ b/src/release-update.ts
@@ -4,12 +4,14 @@ const minutesToMilliseconds = 60 * 1000;
 const secondsToMilliseconds = 1000;
 export const defaultReleaseCheckIntervalMs = 60 * minutesToMilliseconds;
 export const minimumReleaseCheckIntervalMs = 10 * minutesToMilliseconds;
+export const maximumReleaseCheckIntervalMs = 7 * 24 * 60 * minutesToMilliseconds;
 export const defaultReleaseCheckTimeoutMs = 90 * secondsToMilliseconds;
 export const maximumReleaseCheckTimeoutMs = 300 * secondsToMilliseconds;
 export const defaultReleaseCheckRetries = 1;
 export const maximumReleaseCheckRetries = 5;
 
 export type ReleaseUpdateResult = {
+  enabled: boolean;
   checked: boolean;
   updateAvailable: boolean;
   currentVersion: string;
@@ -23,7 +25,8 @@ export function resolveReleaseCheckIntervalMs(value: string | undefined): number
   if (value === undefined || value.trim() === "") return defaultReleaseCheckIntervalMs;
   const minutes = Number(value);
   if (!Number.isFinite(minutes)) return defaultReleaseCheckIntervalMs;
-  return Math.max(minimumReleaseCheckIntervalMs, Math.round(minutes * minutesToMilliseconds));
+  if (minutes === 0) return 0;
+  return Math.min(maximumReleaseCheckIntervalMs, Math.max(minimumReleaseCheckIntervalMs, Math.round(minutes * minutesToMilliseconds)));
 }
 
 export function resolveReleaseCheckTimeoutMs(value: string | undefined): number {
@@ -97,13 +100,27 @@ export class ReleaseUpdateChecker {
   ) {
     this.currentVersion = currentVersion;
     this.fetchImpl = fetchImpl;
-    this.intervalMs = Math.max(minimumReleaseCheckIntervalMs, options.intervalMs ?? defaultReleaseCheckIntervalMs);
+    const configuredIntervalMs = options.intervalMs ?? defaultReleaseCheckIntervalMs;
+    this.intervalMs = configuredIntervalMs === 0
+      ? 0
+      : Math.min(
+        maximumReleaseCheckIntervalMs,
+        Math.max(minimumReleaseCheckIntervalMs, Number.isFinite(configuredIntervalMs) ? Math.round(configuredIntervalMs) : defaultReleaseCheckIntervalMs)
+      );
     this.timeoutMs = Math.max(secondsToMilliseconds, Math.min(maximumReleaseCheckTimeoutMs, options.timeoutMs ?? defaultReleaseCheckTimeoutMs));
     this.retries = Math.min(maximumReleaseCheckRetries, Math.max(0, Math.floor(options.retries ?? defaultReleaseCheckRetries)));
     this.now = options.now ?? Date.now;
   }
 
   check(): Promise<ReleaseUpdateResult> {
+    if (this.intervalMs === 0) {
+      return Promise.resolve({
+        enabled: false,
+        checked: false,
+        updateAvailable: false,
+        currentVersion: this.currentVersion
+      });
+    }
     if (this.cached && this.cached.expiresAt > this.now()) return Promise.resolve(this.cached.result);
     if (this.inFlight) return this.inFlight;
     this.inFlight = this.fetchLatestRelease().then((result) => {
@@ -126,6 +143,7 @@ export class ReleaseUpdateChecker {
 
   private async fetchLatestRelease(): Promise<ReleaseUpdateResult> {
     const unavailable: ReleaseUpdateResult = {
+      enabled: true,
       checked: false,
       updateAvailable: false,
       currentVersion: this.currentVersion
@@ -151,6 +169,7 @@ export class ReleaseUpdateChecker {
         if (!parseVersion(latestVersion)) continue;
         const updateAvailable = isNewerRelease(this.currentVersion, latestVersion);
         return {
+          enabled: true,
           checked: true,
           updateAvailable,
           currentVersion: this.currentVersion,

--- a/tests/system/background-task-center-ui.test.ts
+++ b/tests/system/background-task-center-ui.test.ts
@@ -22,6 +22,7 @@ describe("全局后台任务中心界面", () => {
     expect(script).toContain('data-background-index-action="rebuild"');
     expect(script).toContain("function backgroundProductUpdateMarkup()");
     expect(script).toContain("版本更新探测");
+    expect(script).toContain("已通过服务端配置关闭版本更新探测");
     expect(script).toContain("refreshProductUpdate()");
     expect(styles).toContain(".background-task-row");
     expect(styles).toContain(".background-task-count");

--- a/tests/unit/release-update.test.ts
+++ b/tests/unit/release-update.test.ts
@@ -4,6 +4,7 @@ import {
   defaultReleaseCheckRetries,
   defaultReleaseCheckTimeoutMs,
   isNewerRelease,
+  maximumReleaseCheckIntervalMs,
   maximumReleaseCheckRetries,
   maximumReleaseCheckTimeoutMs,
   minimumReleaseCheckIntervalMs,
@@ -27,11 +28,15 @@ describe("GitHub Release 更新探测", () => {
     expect(resolveReleaseCheckIntervalMs(undefined)).toBe(defaultReleaseCheckIntervalMs);
     expect(resolveReleaseCheckIntervalMs("")).toBe(defaultReleaseCheckIntervalMs);
     expect(resolveReleaseCheckIntervalMs("invalid")).toBe(defaultReleaseCheckIntervalMs);
+    expect(resolveReleaseCheckIntervalMs("0")).toBe(0);
     expect(resolveReleaseCheckIntervalMs("-5")).toBe(minimumReleaseCheckIntervalMs);
-    expect(resolveReleaseCheckIntervalMs("0")).toBe(minimumReleaseCheckIntervalMs);
     expect(resolveReleaseCheckIntervalMs("5")).toBe(minimumReleaseCheckIntervalMs);
     expect(resolveReleaseCheckIntervalMs("10")).toBe(minimumReleaseCheckIntervalMs);
     expect(resolveReleaseCheckIntervalMs("25")).toBe(25 * 60 * 1000);
+    expect(maximumReleaseCheckIntervalMs).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(resolveReleaseCheckIntervalMs("10080")).toBe(maximumReleaseCheckIntervalMs);
+    expect(resolveReleaseCheckIntervalMs("20000")).toBe(maximumReleaseCheckIntervalMs);
+    expect(resolveReleaseCheckIntervalMs("1e20")).toBe(maximumReleaseCheckIntervalMs);
   });
 
   it("解析超时与重试配置并限制安全边界", () => {
@@ -61,6 +66,7 @@ describe("GitHub Release 更新探测", () => {
     });
 
     await expect(checker.check()).resolves.toEqual({
+      enabled: true,
       checked: true,
       updateAvailable: true,
       currentVersion: "0.6.7",
@@ -85,6 +91,17 @@ describe("GitHub Release 更新探测", () => {
     now = minimumReleaseCheckIntervalMs;
     await checker.check();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("配置为 0 时关闭探测且不访问 GitHub", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    await expect(new ReleaseUpdateChecker("0.6.7", fetchMock, { intervalMs: 0 }).check()).resolves.toEqual({
+      enabled: false,
+      checked: false,
+      updateAvailable: false,
+      currentVersion: "0.6.7"
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("失败后按配置进行一次内部重试", async () => {


### PR DESCRIPTION
## 变更内容

- 支持通过 `APP_UPDATE_CHECK_INTERVAL_MINUTES=0` 完全关闭 GitHub Release 更新探测。
- 将正数探测间隔限制为最短 10 分钟、最长 7 天。
- 关闭后服务端不访问 GitHub，前端停止自动轮询，并在后台任务中心显示关闭状态。
- 增加配置边界、关闭行为和静态界面回归测试。

## 验证

- `npm run typecheck`
- 4 个相关测试文件，13 个测试通过
- `npm run build`
