### PR TITLE
chore(release): bump version to 0.6.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.7";
+export const APP_VERSION = "0.6.8";


### PR DESCRIPTION
## 变更内容

- 将 `package.json`、`package-lock.json` 根包元数据和 `src/version.ts` 的应用版本统一更新为 `0.6.8`。

## 发布前验证

- `tests/unit/version.test.ts` 通过
- `npm run build` 通过
- 已完成 develop 相对 main 的 CLI 影响审计，无需 CLI 同步更新
