### PR TITLE
fix(search): hide merged characters from search results

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4389,7 +4389,7 @@ export class AiManager {
       const { characters: requestedCharacters, cursor } = args as z.infer<typeof recallRelationshipArguments>;
       const character = this.store.getCharacter(roleplayCharacterId);
       if (String(character.workId) !== workId) throw new Error("Roleplay character belongs to a different work");
-      const characterList = this.store.listCharacters(workId, false, true);
+      const characterList = this.store.listCharacters(workId);
       const characters = new Map(characterList.map((item) => [String(item.id), item]));
       const characterSearchText = (item: Record<string, unknown> | null): string => {
         if (!item) return "";
@@ -7686,6 +7686,7 @@ export class AiManager {
       if (sourceType === "character") {
         const item = this.store.getCharacter(sourceId);
         if (String(item.workId) !== workId) return null;
+        if (item.mergedIntoCharacterId) return null;
         return source(`人物档案：${String(item.name)}`, {
           name: item.name, isDead: item.isDead, aliases: item.aliases, code: item.code, species: item.species, race: item.race,
           organizations: item.organizations, attributes: item.attributes, profile: item.profile,

--- a/src/store.ts
+++ b/src/store.ts
@@ -4845,14 +4845,16 @@ export class Store {
     const rows = [...normalized].length <= 2
       ? this.db.all(
         `${columns} JOIN character_profile_section_short_terms term ON term.search_id = search.id
-         WHERE search.work_id = ? AND term.term = ? ORDER BY character.name, section.sort_order LIMIT ?`,
+         WHERE search.work_id = ? AND character.merged_into_character_id IS NULL AND term.term = ?
+         ORDER BY character.name, section.sort_order LIMIT ?`,
         workId,
         normalized,
         limit
       )
       : this.db.all(
         `${columns} JOIN character_profile_section_search_fts fts ON fts.rowid = search.id
-         WHERE search.work_id = ? AND character_profile_section_search_fts MATCH ?
+         WHERE search.work_id = ? AND character.merged_into_character_id IS NULL
+           AND character_profile_section_search_fts MATCH ?
          ORDER BY bm25(character_profile_section_search_fts), character.name, section.sort_order LIMIT ?`,
         workId,
         `"${normalized.replaceAll('"', '""')}"`,
@@ -8248,7 +8250,7 @@ export class Store {
        SELECT character.id, character.name, character.aliases_json, character.species, character.is_dead,
               COALESCE(path.path, character.species) AS race_path
        FROM characters character LEFT JOIN character_race_paths path ON path.character_id = character.id
-       WHERE character.work_id = ? AND (
+       WHERE character.work_id = ? AND character.merged_into_character_id IS NULL AND (
          character.name LIKE ? ESCAPE '\\' OR character.aliases_json LIKE ? ESCAPE '\\' OR character.species LIKE ? ESCAPE '\\'
          OR EXISTS (SELECT 1 FROM character_race_lineage lineage WHERE lineage.character_id = character.id AND lineage.name LIKE ? ESCAPE '\\')
        ) LIMIT 50`,

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -110,6 +110,93 @@ describe("作品混合检索", () => {
     expect(updated.body.data).toEqual([expect.objectContaining({ id: setting.id, type: "setting" })]);
   });
 
+  it("搜索和 Agent 实体工具不返回已合并角色", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "马克博士曾经守护北港。马克·罗素接替了他。 ");
+    const workId = String(seeded.work.id);
+    const source = runtime.store.createCharacter(workId, { name: "马克博士" });
+    const target = runtime.store.createCharacter(workId, { name: "马克·罗素" });
+    runtime.store.createCharacterProfileSection(String(source.id), {
+      sectionType: "background",
+      title: "旧身份",
+      contentMarkdown: "马克博士曾经守护北港。"
+    });
+    runtime.store.mergeCharacters({
+      reviewId: null,
+      sourceCharacterId: String(source.id),
+      targetCharacterId: String(target.id),
+      expectedSourceVersionNo: Number(source.versionNo),
+      expectedTargetVersionNo: Number(target.versionNo)
+    });
+
+    const metadataResults = runtime.store.search(workId, "马克博士");
+    expect(metadataResults).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "character", id: source.id })
+    ]));
+    expect(metadataResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "character", id: target.id, title: "马克·罗素" })
+    ]));
+    const sectionResults = runtime.store.searchCharacterProfileSections(workId, "旧身份");
+    expect(sectionResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({ characterId: target.id, characterName: "马克·罗素" })
+    ]));
+    expect(sectionResults).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ characterId: source.id })
+    ]));
+
+    const response = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "马克博士", type: "character", limit: 100 })
+      .expect(200);
+    expect(response.body.data).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "character", id: source.id })
+    ]));
+    expect(response.body.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "character", id: target.id, title: "马克·罗素" })
+    ]));
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+    const execution = await internalAi.executeAgentTool(workId, {
+      id: "search-merged-character",
+      type: "function",
+      function: {
+        name: "search_story_entities",
+        arguments: JSON.stringify({ query: "马克博士", categories: ["character"], limit: 30, cursor: 0 })
+      }
+    });
+    const result = execution.result as Record<string, unknown>;
+    const resultData = result.data as Record<string, unknown>;
+    const matches = resultData.matches as Array<Record<string, unknown>>;
+    expect(execution.status).toBe("completed");
+    expect(matches).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "character", id: source.id })
+    ]));
+    expect(matches).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "character", id: target.id, title: "马克·罗素" })
+    ]));
+
+    const relationshipExecution = await internalAi.executeAgentTool(workId, {
+      id: "recall-merged-character",
+      type: "function",
+      function: {
+        name: "recall_relationship",
+        arguments: JSON.stringify({ characters: [source.id], cursor: 0 })
+      }
+    }, 20_000, String(target.id), new Set(["recall_relationship"]));
+    const relationshipResult = relationshipExecution.result as Record<string, unknown>;
+    const relationshipData = relationshipResult.data as Record<string, unknown>;
+    expect(relationshipExecution.status).toBe("completed");
+    expect(relationshipData.unresolvedCharacters).toEqual([source.id]);
+  });
+
   it("拒绝未知类型和越界数量", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime);


### PR DESCRIPTION
## 变更内容

- 全局搜索过滤已合并的角色来源档案。
- 角色 Markdown 章节搜索过滤已合并角色。
- Agent 的 `search_story_entities` 和 `recall_relationship` 不再返回已合并角色。
- 混合搜索读取角色索引时忽略已合并角色，同时保留旧名称对保留角色别名的命中。

## 根因

合并角色会保留历史行并通过 `merged_into_character_id` 标记来源角色。普通角色列表已经过滤该字段，但全局搜索、混合搜索索引和部分 Agent 查询路径没有复用这个过滤条件，因此已合并角色仍会出现在搜索结果中。

## 验证

- `npx vitest run tests/integration/hybrid-search.test.ts --maxWorkers=1`
- `npm run typecheck`
- `npm run build`
- 新增回归测试覆盖全局搜索、章节搜索、`search_story_entities` 和 `recall_relationship`。

完整测试中有既有异步用例偶发失败；相关失败用例单独重跑通过。