### PR TITLE
chore(release): bump version to 0.6.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "docx": "^9.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.8";
+export const APP_VERSION = "0.6.9";


### PR DESCRIPTION
## 变更内容

- 将应用补丁版本从 `0.6.8` 更新为 `0.6.9`。
- 同步更新 `package.json`、`package-lock.json` 顶层版本、根包版本和 `src/version.ts` 的 `APP_VERSION`。

## CLI 审计

- 已审计 `develop` 相对 `main` 的全部变更。
- 新增的 `agent-history` 搜索类型由 CLI 与服务端共享的 `HYBRID_SEARCH_TYPES` 自动支持；其余变化为 UI 调整与服务端搜索结果修正，无需修改 CLI 契约或命令入口。

## 验证

- `npx vitest run tests/unit/version.test.ts --maxWorkers=1`
- `npm run check`：125 个测试文件、653 项测试通过，类型检查与生产构建通过
- `npm run test:e2e:cli`：真实 CLI E2E 全部通过