### PR TITLE
feat(showcase): add leaderboard link

### DIFF
--- a/showcase/app/globals.css
+++ b/showcase/app/globals.css
@@ -38,9 +38,9 @@ a { color: inherit; text-decoration: none; }
 .header-cta { padding: 10px 14px; border: 1px solid var(--line); border-radius: 4px; background: rgba(255,255,255,.35); font-size: 11px; }
 .header-cta:hover { border-color: var(--accent); color: var(--accent-dark); }
 .header-cta span { margin-left: 10px; }
-.header-github { display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid var(--line); border-radius: 4px; background: rgba(255,255,255,.35); color: var(--ink); }
-.header-github:hover, .header-github:focus-visible { border-color: var(--accent); color: var(--accent-dark); }
-.header-github svg { width: 18px; height: 18px; display: block; }
+.header-icon-link { display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid var(--line); border-radius: 4px; background: rgba(255,255,255,.35); color: var(--ink); }
+.header-icon-link:hover, .header-icon-link:focus-visible { border-color: var(--accent); color: var(--accent-dark); }
+.header-icon-link svg { width: 18px; height: 18px; display: block; }
 
 .hero { position: relative; display: grid; grid-template-columns: 1.05fr .95fr; min-height: calc(100vh - 72px); align-items: center; gap: 6vw; overflow: hidden; padding: 9vh clamp(24px, 8vw, 132px); background: radial-gradient(circle at 78% 42%, rgba(139,61,44,.08), transparent 27%), linear-gradient(90deg, transparent 49.9%, rgba(217,210,197,.48) 50%, transparent 50.1%); }
 .hero::before { position: absolute; inset: 0; opacity: .22; background-image: linear-gradient(rgba(37,35,31,.12) 1px, transparent 1px), linear-gradient(90deg, rgba(37,35,31,.12) 1px, transparent 1px); background-size: 64px 64px; mask-image: linear-gradient(to bottom, transparent, #000 20%, #000 75%, transparent); content: ""; pointer-events: none; }
@@ -138,7 +138,7 @@ a { color: inherit; text-decoration: none; }
 }
 
 @media (max-width: 760px) {
-  .site-header { height: 62px; padding: 0 18px; }.header-cta { padding: 8px 10px; }.header-cta > span { display: none; }.header-github { width: 34px; height: 34px; }.header-github svg { width: 16px; height: 16px; }
+  .site-header { height: 62px; padding: 0 18px; }.header-cta { padding: 8px 10px; }.header-cta > span { display: none; }.header-icon-link { width: 34px; height: 34px; }.header-icon-link svg { width: 16px; height: 16px; }
   .hero { min-height: auto; padding: 100px 24px 80px; background: radial-gradient(circle at 50% 70%, rgba(139,61,44,.09), transparent 30%); }.hero h1 { font-size: clamp(49px, 15vw, 70px); }.hero-copy > p { font-size: 14px; }.hero-actions { align-items: flex-start; flex-direction: column; gap: 20px; }.hero-orbit { width: 104vw; margin-left: -12vw; }.orbit-note { right: 5%; }.orbit-node { min-width: 50px; height: 50px; }
   .principles { grid-template-columns: 1fr; }.principles article { justify-content: flex-start; padding: 0 24px; }.principles article + article { border-top: 1px solid var(--line); border-left: 0; }
   .section, .graph-section { padding: 88px 22px; }.split-heading, .graph-heading { grid-template-columns: 1fr; gap: 28px; }.section-heading h2, .galaxy-heading h2 { font-size: 42px; }

--- a/showcase/app/page.tsx
+++ b/showcase/app/page.tsx
@@ -107,6 +107,21 @@ function GitHubIcon() {
   );
 }
 
+function LeaderboardIcon() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        d="M8 3h8v5a4 4 0 0 1-8 0V3Zm0 2H5v1a3 3 0 0 0 3 3m8-4h3v1a3 3 0 0 1-3 3m-4 3v4m-3 4h6m-5-4h4"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
 function RelationshipGraph() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const hostRef = useRef<HTMLDivElement>(null);
@@ -520,8 +535,17 @@ export default function Home() {
         <div className="header-actions">
           <a className="header-cta" href="https://showcase.scriverse.top/">在线体验 <span>↗</span></a>
           <a
+            aria-label="查看模型排行榜"
+            className="header-icon-link header-leaderboard"
+            href="https://llm-racing.scriverse.top/?utm_source=scriverse"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <LeaderboardIcon />
+          </a>
+          <a
             aria-label="在 GitHub 查看源代码"
-            className="header-github"
+            className="header-icon-link"
             href="https://github.com/musnows/Scriverse"
             rel="noreferrer"
             target="_blank"

--- a/showcase/tests/rendered-html.test.mjs
+++ b/showcase/tests/rendered-html.test.mjs
@@ -27,9 +27,12 @@ test("服务端渲染叙界介绍页", async () => {
   assert.match(html, /章节回收站/);
   assert.match(html, /Markdown ZIP/);
   assert.match(html, /href="https:\/\/showcase\.scriverse\.top\/"[^>]*>在线体验/);
+  assert.match(html, /href="https:\/\/llm-racing\.scriverse\.top\/\?utm_source=scriverse"/);
+  assert.match(html, /aria-label="查看模型排行榜"/);
+  assert.match(html, /class="[^"]*header-leaderboard[^"]*"/);
   assert.match(html, /href="https:\/\/github\.com\/musnows\/Scriverse"/);
   assert.match(html, /aria-label="在 GitHub 查看源代码"/);
-  assert.match(html, /class="[^"]*header-github[^"]*"/);
+  assert.match(html, /class="[^"]*header-icon-link[^"]*"/);
   assert.match(html, /data-scroll-target="workspace"[^>]*>进入叙界世界/);
   assert.doesNotMatch(html, /打开演示站/);
   assert.doesNotMatch(html, /href="\/demo"/);


### PR DESCRIPTION
## 变更

- 在介绍页右上角新增模型排行榜奖杯图标。
- 链接至 `https://llm-racing.scriverse.top/?utm_source=scriverse`，在新标签页打开。
- 复用现有图标按钮样式，并补充服务端渲染回归断言。

## 验证

- `cd showcase && npm test`
- `cd showcase && npm run lint`
- 内置浏览器：1280×720 与 390×844 响应式检查，以及实际链接跳转验证。