### PR TITLE
chore(release): bump version to 0.6.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.9";
+export const APP_VERSION = "0.6.10";


### PR DESCRIPTION
## 变更内容

- 将应用版本从 0.6.9 递增到 0.6.10。
- 同步更新 package.json、package-lock.json 顶层与根包、src/version.ts。

## 发布审计

- develop 相对 main 的差异未触及 CLI 实现或 CLI E2E，无需 CLI 同步。

## 验证

- npm run typecheck
- npx vitest run tests/unit/version.test.ts
- npm test：130 个测试文件、669 项测试通过
- npm run build