### PR TITLE
chore(release): bump version to 0.6.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.10";
+export const APP_VERSION = "0.6.11";


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 顶层与根包、`src/version.ts` 统一更新为 0.6.11。

## 发布前验证

- `tests/unit/version.test.ts` 通过。
- `npm run check` 通过：132 个测试文件、673 个测试通过，类型检查和构建通过。
- 隔离服务健康检查返回版本 0.6.11，SQLite 完整性和外键检查通过。
- 已审计 develop 相对 main 的变更，无需同步 CLI。