### PR TITLE
fix(runtime): prevent failed startup backup loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ CLI 会按服务器保存登录凭据。所有连接服务的数据命令都可�
 | `HOST` | `127.0.0.1` | 监听地址；服务器部署时可设为 `0.0.0.0` |
 | `DATA_DIR` | `<项目目录>/.data` | 默认数据目录 |
 | `DATABASE_PATH` | `<DATA_DIR>/novel.db` | SQLite 数据库路径 |
+| `SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION` | `5` | 启动迁移备份最多保留的完整版本数；小于 `2` 时按 `2` 处理，启动时清理最旧的超额备份 |
 | `AI_NOVEL_MASTER_KEY` | 自动生成并保存在 `<DATA_DIR>/master.key` | 加密 AI 供应商密钥的主密钥；手动配置时至少 32 个字符 |
 | `APP_AUTH_USERNAME` | 空 | 可选的部署网关账号；应用内用户系统始终启用 |
 | `APP_AUTH_PASSWORD` | 空 | 可选的部署网关密码，至少 12 个字符；必须通过 HTTPS 传输 |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ CLI 会按服务器保存登录凭据。所有连接服务的数据命令都可�
 | `DATA_DIR` | `<项目目录>/.data` | 默认数据目录 |
 | `DATABASE_PATH` | `<DATA_DIR>/novel.db` | SQLite 数据库路径 |
 | `SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION` | `5` | 启动迁移备份最多保留的完整版本数；小于 `2` 时按 `2` 处理，启动时清理最旧的超额备份 |
+| `SCRIVERSE_STARTUP_RETRY_LIMIT` | `2` | 连续启动失败最多允许的次数；达到上限后停止重复初始化，修复问题并删除 `<DATA_DIR>/.startup-retry.json` 后才能重新启动 |
 | `AI_NOVEL_MASTER_KEY` | 自动生成并保存在 `<DATA_DIR>/master.key` | 加密 AI 供应商密钥的主密钥；手动配置时至少 32 个字符 |
 | `APP_AUTH_USERNAME` | 空 | 可选的部署网关账号；应用内用户系统始终启用 |
 | `APP_AUTH_PASSWORD` | 空 | 可选的部署网关密码，至少 12 个字符；必须通过 HTTPS 传输 |

--- a/docs/docker-deployment.en.md
+++ b/docs/docker-deployment.en.md
@@ -28,6 +28,7 @@ services:
       APP_ALLOW_REGISTRATION: "${APP_ALLOW_REGISTRATION:-false}"
       APP_SETUP_TOKEN: "${APP_SETUP_TOKEN:-}"
       APP_TRUST_PROXY: "${APP_TRUST_PROXY:-false}"
+      SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION: "${SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION:-5}"
     volumes:
       - scriverse-data:/app/.data
 
@@ -43,6 +44,7 @@ SCRIVERSE_TAG=latest
 APP_ALLOW_REGISTRATION=true
 APP_SETUP_TOKEN=replace-with-at-least-32-random-characters
 APP_TRUST_PROXY=false
+SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION=5
 ```
 
 Start the service:
@@ -69,6 +71,8 @@ docker compose up -d --force-recreate
 ```
 
 Registration is enabled only when `APP_ALLOW_REGISTRATION` is `true` or `1`; `false` or `0` disables it, and `APP_SETUP_TOKEN` must contain at least 32 characters. Unset and all other values disable both the UI and backend registration endpoint, including first-administrator setup on an empty database. The setup token is checked only when creating the first administrator.
+
+`SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION` controls how many complete pre-migration database backups are retained. It defaults to 5 and is clamped to a minimum of 2. On each startup, the oldest excess complete backups are removed before a new migration backup is created, preventing a failed-migration restart loop from filling the disk.
 
 ## Pin a release
 

--- a/docs/docker-deployment.en.md
+++ b/docs/docker-deployment.en.md
@@ -29,6 +29,7 @@ services:
       APP_SETUP_TOKEN: "${APP_SETUP_TOKEN:-}"
       APP_TRUST_PROXY: "${APP_TRUST_PROXY:-false}"
       SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION: "${SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION:-5}"
+      SCRIVERSE_STARTUP_RETRY_LIMIT: "${SCRIVERSE_STARTUP_RETRY_LIMIT:-2}"
     volumes:
       - scriverse-data:/app/.data
 
@@ -45,6 +46,7 @@ APP_ALLOW_REGISTRATION=true
 APP_SETUP_TOKEN=replace-with-at-least-32-random-characters
 APP_TRUST_PROXY=false
 SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION=5
+SCRIVERSE_STARTUP_RETRY_LIMIT=2
 ```
 
 Start the service:
@@ -73,6 +75,8 @@ docker compose up -d --force-recreate
 Registration is enabled only when `APP_ALLOW_REGISTRATION` is `true` or `1`; `false` or `0` disables it, and `APP_SETUP_TOKEN` must contain at least 32 characters. Unset and all other values disable both the UI and backend registration endpoint, including first-administrator setup on an empty database. The setup token is checked only when creating the first administrator.
 
 `SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION` controls how many complete pre-migration database backups are retained. It defaults to 5 and is clamped to a minimum of 2. On each startup, the oldest excess complete backups are removed before a new migration backup is created, preventing a failed-migration restart loop from filling the disk.
+
+`SCRIVERSE_STARTUP_RETRY_LIMIT` controls consecutive failed startup attempts and defaults to 2. Once the limit is reached, the service stops repeating initialization and migration, preserving `<DATA_DIR>/.startup-retry.json` for diagnosis. Fix the root cause, remove that file, and restart the service.
 
 ## Pin a release
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -29,6 +29,7 @@ services:
       APP_SETUP_TOKEN: "${APP_SETUP_TOKEN:-}"
       APP_TRUST_PROXY: "${APP_TRUST_PROXY:-false}"
       SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION: "${SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION:-5}"
+      SCRIVERSE_STARTUP_RETRY_LIMIT: "${SCRIVERSE_STARTUP_RETRY_LIMIT:-2}"
     volumes:
       - scriverse-data:/app/.data
 
@@ -45,6 +46,7 @@ APP_ALLOW_REGISTRATION=true
 APP_SETUP_TOKEN=请替换为至少32个字符的随机初始化令牌
 APP_TRUST_PROXY=false
 SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION=5
+SCRIVERSE_STARTUP_RETRY_LIMIT=2
 ```
 
 启动服务：
@@ -73,6 +75,8 @@ docker compose up -d --force-recreate
 `APP_ALLOW_REGISTRATION` 只有明确设置为 `true` 或 `1` 时才开放注册；`false` 或 `0` 表示关闭，同时必须配置至少 32 个字符的 `APP_SETUP_TOKEN`。未设置或其他值都会同时关闭前端注册入口和后端注册接口，包括空数据库的首位管理员注册。初始化令牌只在创建首位管理员时校验。
 
 `SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION` 控制启动迁移前的完整数据库备份保留数量，默认保留 5 个版本，最少保留 2 个版本。每次启动时会清理超出数量的最旧完整备份，再为本次迁移保留一个备份位置，避免迁移失败后的重启循环持续占满磁盘。
+
+`SCRIVERSE_STARTUP_RETRY_LIMIT` 控制连续启动失败的次数，默认允许 2 次。达到上限后服务会停止重复执行初始化和迁移流程，并保留 `<DATA_DIR>/.startup-retry.json` 供排查；修复根因后删除该文件再启动服务。
 
 ## 固定正式版本
 

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -28,6 +28,7 @@ services:
       APP_ALLOW_REGISTRATION: "${APP_ALLOW_REGISTRATION:-false}"
       APP_SETUP_TOKEN: "${APP_SETUP_TOKEN:-}"
       APP_TRUST_PROXY: "${APP_TRUST_PROXY:-false}"
+      SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION: "${SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION:-5}"
     volumes:
       - scriverse-data:/app/.data
 
@@ -43,6 +44,7 @@ SCRIVERSE_TAG=latest
 APP_ALLOW_REGISTRATION=true
 APP_SETUP_TOKEN=请替换为至少32个字符的随机初始化令牌
 APP_TRUST_PROXY=false
+SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION=5
 ```
 
 启动服务：
@@ -69,6 +71,8 @@ docker compose up -d --force-recreate
 ```
 
 `APP_ALLOW_REGISTRATION` 只有明确设置为 `true` 或 `1` 时才开放注册；`false` 或 `0` 表示关闭，同时必须配置至少 32 个字符的 `APP_SETUP_TOKEN`。未设置或其他值都会同时关闭前端注册入口和后端注册接口，包括空数据库的首位管理员注册。初始化令牌只在创建首位管理员时校验。
+
+`SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION` 控制启动迁移前的完整数据库备份保留数量，默认保留 5 个版本，最少保留 2 个版本。每次启动时会清理超出数量的最旧完整备份，再为本次迁移保留一个备份位置，避免迁移失败后的重启循环持续占满磁盘。
 
 ## 固定正式版本
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statfsSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { logger, sanitizeError } from "./logger.js";
@@ -7,19 +7,66 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
 export const DATABASE_SCHEMA_VERSION = 76;
+export const SQLITE_IOERR_SHMSIZE = 4874;
+
+export type AvailableDiskSpace = {
+  availableBytes: number;
+  availableMiB: number;
+};
+
+export function isSqliteDiskIoError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const candidate = error as Error & { code?: unknown; errcode?: unknown; errstr?: unknown };
+  return Number(candidate.errcode) === SQLITE_IOERR_SHMSIZE
+    || (candidate.code === "ERR_SQLITE_ERROR" && candidate.errstr === "disk I/O error")
+    || (candidate.code === "ERR_SQLITE_ERROR" && error.message === "disk I/O error");
+}
+
+export function readAvailableDiskSpace(path: string): AvailableDiskSpace | null {
+  try {
+    const stats = statfsSync(path);
+    const availableBytes = Number(stats.bavail) * Number(stats.bsize);
+    if (!Number.isFinite(availableBytes) || availableBytes < 0) return null;
+    return {
+      availableBytes,
+      availableMiB: Math.round(availableBytes / (1024 * 1024) * 100) / 100
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function logSqliteDiskIoError(filename: string, error: unknown): void {
+  if (!isSqliteDiskIoError(error)) return;
+  const diskSpace = readAvailableDiskSpace(filename === ":memory:" ? "." : dirname(filename));
+  logger.error("database.disk_io_error.space_check", {
+    databasePath: filename,
+    availableBytes: diskSpace?.availableBytes ?? null,
+    availableMiB: diskSpace?.availableMiB ?? null,
+    spaceCheck: diskSpace ? "completed" : "failed"
+  });
+  logger.error("database.disk_io_error.guidance", {
+    databasePath: filename,
+    message: "SQLite reported a disk I/O error. Check the host disk's available space and ensure the database directory is writable before restarting Scriverse."
+  });
+}
 
 export function readDatabaseSchemaVersion(filename: string): number | null {
   if (!existsSync(filename)) return null;
-  const database = new DatabaseSync(filename, { readOnly: true });
+  let database: DatabaseSync | null = null;
   try {
+    database = new DatabaseSync(filename, { readOnly: true });
     const migrationTable = database.prepare(
       "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'"
     ).get();
     if (!migrationTable) return 0;
     const row = database.prepare("SELECT MAX(version) AS version FROM schema_migrations").get() as { version?: unknown } | undefined;
     return Number(row?.version ?? 0);
+  } catch (error) {
+    logSqliteDiskIoError(filename, error);
+    throw error;
   } finally {
-    database.close();
+    database?.close();
   }
 }
 
@@ -44,6 +91,7 @@ export class Database {
       const migration = this.get<{ version: number }>("SELECT MAX(version) AS version FROM schema_migrations");
       logger.info("database.ready", { inMemory: filename === ":memory:", schemaVersion: Number(migration?.version ?? 0) });
     } catch (error) {
+      logSqliteDiskIoError(filename, error);
       logger.error("database.open_failed", { databasePath: filename, error: sanitizeError(error) });
       throw error;
     }

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,5 +1,5 @@
 import type { Server } from "node:http";
-import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { basename, join } from "node:path";
 import { createRuntime, type Runtime } from "./app.js";
@@ -33,6 +33,9 @@ const publicPath = fileURLToPath(new URL("./public/", import.meta.url));
 export const PRE_MIGRATION_BACKUP_RETENTION_ENV = "SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION";
 export const DEFAULT_PRE_MIGRATION_BACKUP_RETENTION = 5;
 export const MIN_PRE_MIGRATION_BACKUP_RETENTION = 2;
+export const STARTUP_RETRY_LIMIT_ENV = "SCRIVERSE_STARTUP_RETRY_LIMIT";
+export const DEFAULT_STARTUP_RETRY_LIMIT = 2;
+export const STARTUP_RETRY_STATE_FILENAME = ".startup-retry.json";
 
 export function isDevelopmentServer(environment: NodeJS.ProcessEnv): boolean {
   return environment.NODE_ENV === "development" || environment.npm_lifecycle_event === "dev";
@@ -49,6 +52,69 @@ export function resolvePreMigrationBackupRetention(environment: NodeJS.ProcessEn
   const configured = Number(raw);
   if (!Number.isFinite(configured)) return DEFAULT_PRE_MIGRATION_BACKUP_RETENTION;
   return Math.max(MIN_PRE_MIGRATION_BACKUP_RETENTION, Math.floor(configured));
+}
+
+export function resolveStartupRetryLimit(environment: NodeJS.ProcessEnv): number {
+  const raw = environment[STARTUP_RETRY_LIMIT_ENV]?.trim() ?? "";
+  if (raw === "") return DEFAULT_STARTUP_RETRY_LIMIT;
+  const configured = Number(raw);
+  if (!Number.isFinite(configured) || configured < 1) return DEFAULT_STARTUP_RETRY_LIMIT;
+  return Math.floor(configured);
+}
+
+function startupRetryStatePath(dataDirectory: string): string {
+  return join(dataDirectory, STARTUP_RETRY_STATE_FILENAME);
+}
+
+function readStartupRetryCount(dataDirectory: string): number {
+  const statePath = startupRetryStatePath(dataDirectory);
+  if (!existsSync(statePath)) return 0;
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, "utf8")) as { attempts?: unknown };
+    const attempts = Number(parsed.attempts);
+    return Number.isInteger(attempts) && attempts >= 0 ? attempts : 0;
+  } catch (error) {
+    logger.warn("server.startup_retry_state.invalid", { retryStatePath: statePath, error: sanitizeError(error) });
+    return 0;
+  }
+}
+
+function writeStartupRetryCount(dataDirectory: string, attempts: number): void {
+  const statePath = startupRetryStatePath(dataDirectory);
+  const temporaryPath = `${statePath}.tmp`;
+  writeFileSync(temporaryPath, JSON.stringify({ attempts, updatedAt: new Date().toISOString() }, null, 2), { encoding: "utf8", mode: 0o600 });
+  chmodSync(temporaryPath, 0o600);
+  renameSync(temporaryPath, statePath);
+  chmodSync(statePath, 0o600);
+}
+
+function recordStartupAttempt(dataDirectory: string, environment: NodeJS.ProcessEnv): void {
+  const retryLimit = resolveStartupRetryLimit(environment);
+  const previousAttempts = readStartupRetryCount(dataDirectory);
+  const retryStatePath = startupRetryStatePath(dataDirectory);
+  if (previousAttempts >= retryLimit) {
+    logger.error("server.startup_retry_limit_reached", {
+      retryStatePath,
+      attempts: previousAttempts,
+      retryLimit,
+      message: "Startup retry limit reached. Fix the previous initialization error, remove the startup retry state file, and restart Scriverse."
+    });
+    throw new Error(`Startup retry limit reached (${retryLimit}); fix the previous initialization error and remove ${retryStatePath} before restarting`);
+  }
+  const attempts = previousAttempts + 1;
+  writeStartupRetryCount(dataDirectory, attempts);
+  logger.warn("server.startup_attempt.recorded", { retryStatePath, attempts, retryLimit });
+}
+
+function clearStartupRetryState(dataDirectory: string): void {
+  const statePath = startupRetryStatePath(dataDirectory);
+  if (!existsSync(statePath)) return;
+  try {
+    rmSync(statePath, { force: true });
+    logger.info("server.startup_retry_state.cleared", { retryStatePath: statePath });
+  } catch (error) {
+    logger.error("server.startup_retry_state.clear_failed", { retryStatePath: statePath, error: sanitizeError(error) });
+  }
 }
 
 type PreMigrationBackup = {
@@ -141,6 +207,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
   try {
     mkdirSync(options.dataDirectory, { recursive: true, mode: 0o700 });
     chmodSync(options.dataDirectory, 0o700);
+    recordStartupAttempt(options.dataDirectory, options.env);
     security = resolveRuntimeSecurity(options.env);
     createPreMigrationBackup(options, options.env);
     const devAuthBypass = isDevelopmentAuthBypassEnabled(options.env);
@@ -185,6 +252,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
       }
       const port = address.port;
       const displayHost = options.host.includes(":") ? `[${options.host}]` : options.host;
+      clearStartupRetryState(options.dataDirectory);
       let closed = false;
       const close = async (): Promise<void> => {
         if (closed) return;

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -1,5 +1,5 @@
 import type { Server } from "node:http";
-import { chmodSync, cpSync, existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { basename, join } from "node:path";
 import { createRuntime, type Runtime } from "./app.js";
@@ -30,6 +30,9 @@ export type RunningLocalServer = {
 };
 
 const publicPath = fileURLToPath(new URL("./public/", import.meta.url));
+export const PRE_MIGRATION_BACKUP_RETENTION_ENV = "SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION";
+export const DEFAULT_PRE_MIGRATION_BACKUP_RETENTION = 5;
+export const MIN_PRE_MIGRATION_BACKUP_RETENTION = 2;
 
 export function isDevelopmentServer(environment: NodeJS.ProcessEnv): boolean {
   return environment.NODE_ENV === "development" || environment.npm_lifecycle_event === "dev";
@@ -40,11 +43,61 @@ export function isLoopbackHost(host: string): boolean {
   return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/u.test(normalized);
 }
 
-export function createPreMigrationBackup(options: Pick<LocalServerOptions, "dataDirectory" | "databasePath">): string | null {
+export function resolvePreMigrationBackupRetention(environment: NodeJS.ProcessEnv): number {
+  const raw = environment[PRE_MIGRATION_BACKUP_RETENTION_ENV]?.trim() ?? "";
+  if (raw === "") return DEFAULT_PRE_MIGRATION_BACKUP_RETENTION;
+  const configured = Number(raw);
+  if (!Number.isFinite(configured)) return DEFAULT_PRE_MIGRATION_BACKUP_RETENTION;
+  return Math.max(MIN_PRE_MIGRATION_BACKUP_RETENTION, Math.floor(configured));
+}
+
+type PreMigrationBackup = {
+  directory: string;
+  modifiedAt: number;
+};
+
+function listPreMigrationBackups(backupsDirectory: string): PreMigrationBackup[] {
+  if (!existsSync(backupsDirectory)) return [];
+  return readdirSync(backupsDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("pre-migration-v") && !entry.name.endsWith(".incomplete"))
+    .map((entry) => {
+      const directory = join(backupsDirectory, entry.name);
+      return { directory, modifiedAt: statSync(directory).mtimeMs };
+    })
+    .filter(({ directory }) => existsSync(join(directory, "backup.json")))
+    .sort((left, right) => left.modifiedAt - right.modifiedAt || left.directory.localeCompare(right.directory));
+}
+
+function prunePreMigrationBackups(backupsDirectory: string, maximumCount: number): void {
+  const backups = listPreMigrationBackups(backupsDirectory);
+  const excessCount = Math.max(0, backups.length - maximumCount);
+  for (const backup of backups.slice(0, excessCount)) {
+    try {
+      rmSync(backup.directory, { recursive: true, force: true });
+      logger.info("database.pre_migration_backup.pruned", {
+        backupDirectory: backup.directory,
+        retentionCount: maximumCount
+      });
+    } catch (error) {
+      logger.warn("database.pre_migration_backup.prune_failed", {
+        backupDirectory: backup.directory,
+        error: sanitizeError(error)
+      });
+    }
+  }
+}
+
+export function createPreMigrationBackup(
+  options: Pick<LocalServerOptions, "dataDirectory" | "databasePath">,
+  environment: NodeJS.ProcessEnv = process.env
+): string | null {
+  const backupsDirectory = join(options.dataDirectory, "backups");
+  const retentionCount = resolvePreMigrationBackupRetention(environment);
+  prunePreMigrationBackups(backupsDirectory, retentionCount);
   const schemaVersion = readDatabaseSchemaVersion(options.databasePath);
   if (schemaVersion === null || schemaVersion >= DATABASE_SCHEMA_VERSION) return null;
+  prunePreMigrationBackups(backupsDirectory, retentionCount - 1);
   const timestamp = new Date().toISOString().replace(/[:.]/gu, "-");
-  const backupsDirectory = join(options.dataDirectory, "backups");
   const backupName = `pre-migration-v${schemaVersion}-to-v${DATABASE_SCHEMA_VERSION}-${timestamp}`;
   const incompleteDirectory = join(backupsDirectory, `${backupName}.incomplete`);
   const backupDirectory = join(backupsDirectory, backupName);
@@ -89,7 +142,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
     mkdirSync(options.dataDirectory, { recursive: true, mode: 0o700 });
     chmodSync(options.dataDirectory, 0o700);
     security = resolveRuntimeSecurity(options.env);
-    createPreMigrationBackup(options);
+    createPreMigrationBackup(options, options.env);
     const devAuthBypass = isDevelopmentAuthBypassEnabled(options.env);
     if (devAuthBypass && !isLoopbackHost(options.host)) {
       throw new Error("APP_DEV_SKIP_AUTH 仅允许绑定本机回环地址");

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -7,7 +7,10 @@ import {
   isDevelopmentServer,
   isLoopbackHost,
   PRE_MIGRATION_BACKUP_RETENTION_ENV,
+  STARTUP_RETRY_LIMIT_ENV,
+  STARTUP_RETRY_STATE_FILENAME,
   resolvePreMigrationBackupRetention,
+  resolveStartupRetryLimit,
   startLocalServer,
   type RunningLocalServer
 } from "../../src/server-runtime.js";
@@ -78,6 +81,14 @@ describe("本地服务运行时", () => {
     expect(resolvePreMigrationBackupRetention({ [PRE_MIGRATION_BACKUP_RETENTION_ENV]: "invalid" })).toBe(5);
   });
 
+  it("解析启动失败重试上限", () => {
+    expect(resolveStartupRetryLimit({})).toBe(2);
+    expect(resolveStartupRetryLimit({ [STARTUP_RETRY_LIMIT_ENV]: "1" })).toBe(1);
+    expect(resolveStartupRetryLimit({ [STARTUP_RETRY_LIMIT_ENV]: "2.9" })).toBe(2);
+    expect(resolveStartupRetryLimit({ [STARTUP_RETRY_LIMIT_ENV]: "0" })).toBe(2);
+    expect(resolveStartupRetryLimit({ [STARTUP_RETRY_LIMIT_ENV]: "invalid" })).toBe(2);
+  });
+
   it("开发免登录仅允许绑定回环地址", async () => {
     expect(isLoopbackHost("localhost")).toBe(true);
     expect(isLoopbackHost("127.0.0.2")).toBe(true);
@@ -93,6 +104,48 @@ describe("本地服务运行时", () => {
       databasePath: join(root, "novel.db"),
       env: { NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true" }
     })).rejects.toThrow("APP_DEV_SKIP_AUTH 仅允许绑定本机回环地址");
+  });
+
+  it("连续启动失败达到上限后阻断后续重试", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-startup-retry-limit-"));
+    roots.push(root);
+    const options = {
+      host: "0.0.0.0",
+      port: 0,
+      dataDirectory: root,
+      databasePath: join(root, "novel.db"),
+      env: { NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true", [STARTUP_RETRY_LIMIT_ENV]: "2" }
+    } as const;
+
+    await expect(startLocalServer(options)).rejects.toThrow("APP_DEV_SKIP_AUTH 仅允许绑定本机回环地址");
+    await expect(startLocalServer(options)).rejects.toThrow("APP_DEV_SKIP_AUTH 仅允许绑定本机回环地址");
+    await expect(startLocalServer(options)).rejects.toThrow("Startup retry limit reached");
+
+    expect(JSON.parse(readFileSync(join(root, STARTUP_RETRY_STATE_FILENAME), "utf8"))).toMatchObject({ attempts: 2 });
+  });
+
+  it("服务器正常监听后清理启动失败重试次数", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-startup-retry-reset-"));
+    roots.push(root);
+    const failedOptions = {
+      host: "0.0.0.0",
+      port: 0,
+      dataDirectory: root,
+      databasePath: join(root, "novel.db"),
+      env: { NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true", [STARTUP_RETRY_LIMIT_ENV]: "2" }
+    } as const;
+    await expect(startLocalServer(failedOptions)).rejects.toThrow("APP_DEV_SKIP_AUTH 仅允许绑定本机回环地址");
+    expect(existsSync(join(root, STARTUP_RETRY_STATE_FILENAME))).toBe(true);
+
+    const running = await startLocalServer({
+      host: "127.0.0.1",
+      port: 0,
+      dataDirectory: root,
+      databasePath: join(root, "novel.db"),
+      env: { NODE_ENV: "test", [STARTUP_RETRY_LIMIT_ENV]: "2" }
+    });
+    runningServers.push(running);
+    expect(existsSync(join(root, STARTUP_RETRY_STATE_FILENAME))).toBe(false);
   });
 
   it("使用隔离数据目录启动 API 和完整网页", async () => {

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -124,6 +124,36 @@ describe("本地服务运行时", () => {
     expect(JSON.parse(readFileSync(join(root, STARTUP_RETRY_STATE_FILENAME), "utf8"))).toMatchObject({ attempts: 2 });
   });
 
+  it("启动异常重试不会重复生成超过上限的迁移备份", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-startup-retry-backup-"));
+    roots.push(root);
+    const databasePath = join(root, "novel.db");
+    const legacy = new Database(databasePath);
+    legacy.raw.exec("DROP TABLE attachment_cleanup_queue; DROP TABLE attachment_access_modules; DELETE FROM schema_migrations WHERE version >= 58");
+    legacy.close();
+
+    const options = {
+      host: "0.0.0.0",
+      port: 0,
+      dataDirectory: root,
+      databasePath,
+      env: { NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true", [STARTUP_RETRY_LIMIT_ENV]: "2" }
+    } as const;
+    const expectedFailure = "APP_DEV_SKIP_AUTH 仅允许绑定本机回环地址";
+
+    await expect(startLocalServer(options)).rejects.toThrow(expectedFailure);
+    await expect(startLocalServer(options)).rejects.toThrow(expectedFailure);
+    const backupsDirectory = join(root, "backups");
+    const backupNamesAfterFailures = readdirSync(backupsDirectory).filter((name) => name.startsWith("pre-migration-v"));
+    expect(backupNamesAfterFailures).toHaveLength(2);
+    expect(backupNamesAfterFailures.every((name) => existsSync(join(backupsDirectory, name, "backup.json")))).toBe(true);
+
+    await expect(startLocalServer(options)).rejects.toThrow("Startup retry limit reached");
+    const backupNamesAfterBlock = readdirSync(backupsDirectory).filter((name) => name.startsWith("pre-migration-v"));
+    expect(backupNamesAfterBlock).toEqual(backupNamesAfterFailures);
+    expect(JSON.parse(readFileSync(join(root, STARTUP_RETRY_STATE_FILENAME), "utf8"))).toMatchObject({ attempts: 2 });
+  });
+
   it("服务器正常监听后清理启动失败重试次数", async () => {
     const root = mkdtempSync(join(tmpdir(), "scriverse-startup-retry-reset-"));
     roots.push(root);

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -1,9 +1,16 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { isDevelopmentAuthBypassEnabled, resolveRuntimeSecurity } from "../../src/security.js";
-import { isDevelopmentServer, isLoopbackHost, startLocalServer, type RunningLocalServer } from "../../src/server-runtime.js";
+import {
+  isDevelopmentServer,
+  isLoopbackHost,
+  PRE_MIGRATION_BACKUP_RETENTION_ENV,
+  resolvePreMigrationBackupRetention,
+  startLocalServer,
+  type RunningLocalServer
+} from "../../src/server-runtime.js";
 import { APP_VERSION } from "../../src/version.js";
 import { loadMasterSecret } from "../../src/credential-vault.js";
 import { DATABASE_SCHEMA_VERSION, Database, readDatabaseSchemaVersion } from "../../src/database.js";
@@ -61,6 +68,14 @@ describe("本地服务运行时", () => {
     expect(isDevelopmentServer({ NODE_ENV: "production", npm_lifecycle_event: "start" })).toBe(false);
     expect(isDevelopmentServer({ NODE_ENV: "development" })).toBe(true);
     expect(isDevelopmentServer({ npm_lifecycle_event: "dev" })).toBe(true);
+  });
+
+  it("解析迁移备份保留数量并限制最低值", () => {
+    expect(resolvePreMigrationBackupRetention({})).toBe(5);
+    expect(resolvePreMigrationBackupRetention({ [PRE_MIGRATION_BACKUP_RETENTION_ENV]: "1" })).toBe(2);
+    expect(resolvePreMigrationBackupRetention({ [PRE_MIGRATION_BACKUP_RETENTION_ENV]: "2.9" })).toBe(2);
+    expect(resolvePreMigrationBackupRetention({ [PRE_MIGRATION_BACKUP_RETENTION_ENV]: "8.9" })).toBe(8);
+    expect(resolvePreMigrationBackupRetention({ [PRE_MIGRATION_BACKUP_RETENTION_ENV]: "invalid" })).toBe(5);
   });
 
   it("开发免登录仅允许绑定回环地址", async () => {
@@ -148,6 +163,42 @@ describe("本地服务运行时", () => {
       toSchemaVersion: DATABASE_SCHEMA_VERSION,
       databaseFile: "novel.db"
     });
+    expect(running.runtime.database.get("SELECT MAX(version) AS version FROM schema_migrations")).toEqual({ version: DATABASE_SCHEMA_VERSION });
+  });
+
+  it("启动时清理超出配置数量的最旧迁移备份", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-migration-backup-retention-"));
+    roots.push(root);
+    const databasePath = join(root, "novel.db");
+    const legacy = new Database(databasePath);
+    legacy.raw.exec("DROP TABLE attachment_cleanup_queue; DROP TABLE attachment_access_modules; DELETE FROM schema_migrations WHERE version >= 58");
+    legacy.close();
+
+    const backupsDirectory = join(root, "backups");
+    const baseTime = Date.parse("2026-01-01T00:00:00.000Z");
+    const backupNames = Array.from({ length: 4 }, (_, index) => `pre-migration-v57-to-v${DATABASE_SCHEMA_VERSION}-2026-01-01T00-00-0${index}.000Z`);
+    for (const [index, backupName] of backupNames.entries()) {
+      const backupDirectory = join(backupsDirectory, backupName);
+      mkdirSync(backupDirectory, { recursive: true });
+      writeFileSync(join(backupDirectory, "backup.json"), JSON.stringify({ fromSchemaVersion: 57 }));
+      const modifiedAt = new Date(baseTime + index * 1000);
+      utimesSync(backupDirectory, modifiedAt, modifiedAt);
+    }
+
+    const running = await startLocalServer({
+      host: "127.0.0.1",
+      port: 0,
+      dataDirectory: root,
+      databasePath,
+      env: { NODE_ENV: "test", [PRE_MIGRATION_BACKUP_RETENTION_ENV]: "3" }
+    });
+    runningServers.push(running);
+
+    const retainedNames = readdirSync(backupsDirectory).filter((name) => name.startsWith("pre-migration-v"));
+    expect(retainedNames).toHaveLength(3);
+    expect(retainedNames).not.toContain(backupNames[0]);
+    expect(retainedNames).not.toContain(backupNames[1]);
+    expect(retainedNames).toEqual(expect.arrayContaining([backupNames[2], backupNames[3]]));
     expect(running.runtime.database.get("SELECT MAX(version) AS version FROM schema_migrations")).toEqual({ version: DATABASE_SCHEMA_VERSION });
   });
 

--- a/tests/unit/database-disk-space.test.ts
+++ b/tests/unit/database-disk-space.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isSqliteDiskIoError, logSqliteDiskIoError, readAvailableDiskSpace, SQLITE_IOERR_SHMSIZE } from "../../src/database.js";
+import { logger } from "../../src/logger.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("SQLite 磁盘空间错误提示", () => {
+  it("识别 SQLITE_IOERR_SHMSIZE 而不误判约束错误", () => {
+    const diskIoError = Object.assign(new Error("disk I/O error"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: SQLITE_IOERR_SHMSIZE,
+      errstr: "disk I/O error"
+    });
+    const constraintError = Object.assign(new Error("constraint failed"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 1555,
+      errstr: "constraint failed"
+    });
+
+    expect(isSqliteDiskIoError(diskIoError)).toBe(true);
+    expect(isSqliteDiskIoError(constraintError)).toBe(false);
+  });
+
+  it("读取数据库目录所在文件系统的可用空间", () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-disk-space-"));
+    roots.push(root);
+
+    const available = readAvailableDiskSpace(root);
+
+    expect(available?.availableBytes).toBeGreaterThan(0);
+    expect(available?.availableMiB).toBeGreaterThan(0);
+  });
+
+  it("检测到 SQLite 磁盘错误时连续输出空间和处理提示", () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-disk-space-log-"));
+    roots.push(root);
+    const records: Array<{ event: string; fields?: Record<string, unknown> }> = [];
+    const error = Object.assign(new Error("disk I/O error"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: SQLITE_IOERR_SHMSIZE,
+      errstr: "disk I/O error"
+    });
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation((event, fields) => {
+      records.push({ event, fields });
+    });
+
+    try {
+      logSqliteDiskIoError(join(root, "novel.db"), error);
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      event: "database.disk_io_error.space_check",
+      fields: {
+        spaceCheck: "completed",
+        availableBytes: expect.any(Number),
+        availableMiB: expect.any(Number)
+      }
+    });
+    expect(records[1]).toMatchObject({
+      event: "database.disk_io_error.guidance",
+      fields: {
+        message: expect.stringContaining("Check the host disk's available space")
+      }
+    });
+  });
+});


### PR DESCRIPTION
## 变更

- 增加 `SCRIVERSE_PRE_MIGRATION_BACKUP_RETENTION`，默认保留 5 个完整迁移备份，最低 2 个。
- 增加 `SCRIVERSE_STARTUP_RETRY_LIMIT`，默认允许连续失败启动 2 次；达到上限后阻断初始化、备份和迁移重试。
- 在 SQLite `4874` 磁盘 I/O 错误时打印文件系统剩余空间，并提示检查宿主机硬盘和数据库目录写权限。
- 服务成功监听后清理 `.startup-retry.json`。

## 本地异常场景验证

- 在临时目录构造 schema 57 旧数据库。
- 连续模拟两次启动异常，确认生成 2 份备份后第三次启动被阻断。
- 确认计数文件记录 `attempts: 2`，第三次不会再生成备份。
- 另行验证修复启动条件后正常监听会自动清理计数文件。

## 验证

- `npm run check` 通过：133 个测试文件、682 个测试通过，类型检查和构建通过。