### PR TITLE
build(release): bump version to 0.6.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.11";
+export const APP_VERSION = "0.6.12";


### PR DESCRIPTION
## 变更内容

- 将 `package.json`、`package-lock.json` 和 `src/version.ts` 的应用版本从 `0.6.11` 更新为 `0.6.12`。

## 验证

- `npm run test:unit -- tests/unit/version.test.ts`：71 个单元测试文件、359 个测试通过。
- `git diff --check` 通过。