### PR TITLE
build(release): bump version to 0.6.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.6.12";
+export const APP_VERSION = "0.6.13";


### PR DESCRIPTION
## 变更说明

- 将 `package.json`、`package-lock.json` 根包元数据和 `src/version.ts` 的应用版本统一更新为 `0.6.13`。
- 本提交仅包含补丁版本号更新。

## 验证

- `npm test -- tests/unit/version.test.ts`