### PR TITLE
build(release): bump version to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.1";
+export const APP_VERSION = "0.7.2";


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 顶层版本和根包版本、`src/version.ts` 统一更新为 `0.7.2`。
- 已审计 `develop` 相对 `main` 的 CLI 影响：本次仅扩展现有管理员界面设置和银河图渲染，不改变 CLI 契约，因此无需 CLI 适配。

## 验证

- `npx vitest run tests/unit/version.test.ts --maxWorkers=1`
- `npm run typecheck`
- `git diff --check`