### PR TITLE
MUXUE-2: fill expanded relationship graph viewport

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-<link rel="stylesheet" href="/styles.css?v=20260809-galaxy-label-stability-v1">
+<link rel="stylesheet" href="/styles.css?v=20260810-relationship-preview-fullscreen-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1963,7 +1963,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .mind-edge-detail { position: absolute; z-index: 5; left: 16px; right: 16px; bottom: 14px; display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 10px; align-items: start; padding: 10px 12px; border: 1px solid var(--line); border-radius: 5px; background: var(--surface-strong); box-shadow: var(--shadow); font-size: 11px; }
 .mind-edge-detail b { white-space: nowrap; }.mind-edge-detail span { color: var(--muted); line-height: 1.55; }
 .relationship-empty-note { margin-top: -12px; padding: 12px 14px; border: 1px dashed var(--line); color: var(--muted); font-size: 11px; }
-.relationship-map-dialog { position: relative; width: min(1400px, 96vw); max-width: none; height: min(900px, 92vh); max-height: none; padding: 0; border: 1px solid var(--line); border-radius: 7px; background: var(--panel); box-shadow: var(--shadow); }
+.relationship-map-dialog { position: fixed; inset: 0; width: 100vw; max-width: none; height: 100dvh; max-height: none; margin: 0; padding: 0; overflow: hidden; border: 0; border-radius: 0; background: var(--panel); box-shadow: none; }
 .relationship-map-dialog::backdrop { background: rgba(34,30,25,.52); backdrop-filter: blur(3px); }
 .relationship-map-floating-close { position: absolute; z-index: 12; top: 25px; right: 25px; width: 34px; height: 34px; border: 1px solid var(--line); border-radius: 50%; background: var(--surface-strong); color: var(--ink); font-size: 20px; }
 .relationship-map-expanded-host { height: 100%; padding: 18px; }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -322,7 +322,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
     expect(page.text).toContain('/app.js?v=20260809-galaxy-size-threshold-v1');
-    expect(page.text).toContain('/styles.css?v=20260809-galaxy-label-stability-v1');
+    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260809-galaxy-label-stability-v1');
+    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
     expect(page.text).toContain('/app.js?v=20260809-galaxy-size-threshold-v1');
   });
 });

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260809-galaxy-label-stability-v1');
+    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
     expect(page.text).toContain('/app.js?v=20260809-galaxy-size-threshold-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260809-galaxy-size-threshold-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,7 +23,7 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260809-galaxy-label-stability-v1');
+    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
     expect(page.text).toContain('/app.js?v=20260809-galaxy-size-threshold-v1');
     expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');
@@ -35,5 +35,7 @@ describe("人物关系图搜索界面", () => {
     expect(styles.text).toContain('.relationship-node-search-results');
     expect(styles.text).toContain('.relationship-node-search.is-galaxy');
     expect(styles.text).toContain('.relationship-node-search:not(.is-galaxy)');
+    expect(styles.text).toContain('.relationship-map-dialog { position: fixed; inset: 0; width: 100vw; max-width: none; height: 100dvh;');
+    expect(styles.text).not.toContain('width: min(1400px, 96vw);');
   });
 });

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -31,7 +31,7 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260809-galaxy-label-stability-v1');
+    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
     expect(page.text).toContain('/app.js?v=20260809-galaxy-size-threshold-v1');
 
     expect(application.text).toContain('/s3-backup-ui.js?v=20260804-s3-backup-v1');


### PR DESCRIPTION
Closes MUXUE-2

## 变更

- 移除放大人物关系图的 `1400×900` 尺寸上限，改为铺满当前视口。
- 保留现有桌面与窄屏工具栏布局、关闭行为和关系图交互。
- 更新静态样式缓存版本，并增加全屏布局回归断言。

## 验证

- `npm run typecheck`
- `npm test`：136 个测试文件、697 项测试通过
- `npm run build`
- 内置浏览器：`1920×1080`、`1280×720`、`390×844`
- 健康检查与 SQLite 完整性、外键检查通过
