### PR TITLE
MUXUE-3: reject unsupported analysis task types

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,4 +1,11 @@
-import type { AiInjectedEntities, AiMessage, ContextScope, TaskType } from "./domain.js";
+import {
+  ANALYSIS_TASK_TYPES,
+  type AiInjectedEntities,
+  type AiMessage,
+  type AnalysisTaskType,
+  type ContextScope,
+  type TaskType
+} from "./domain.js";
 import {
   buildCompletionRequestBody,
   isAiProviderProtocol,
@@ -112,6 +119,16 @@ const AUTO_RUN_MAX_ATTEMPTS = 3;
 const AUTO_RUN_RETRY_DELAYS_MS = [5_000, 30_000] as const;
 const AI_INTERACTIVE_TIMEOUT_MS = 60_000;
 const AI_LONG_RUNNING_TIMEOUT_MS = 300_000;
+const analysisTaskTypes = new Set<string>(ANALYSIS_TASK_TYPES);
+
+function isAnalysisTaskType(value: string): value is AnalysisTaskType {
+  return analysisTaskTypes.has(value);
+}
+
+function unsupportedTaskType(taskType: string): AppError {
+  return new AppError(400, "UNSUPPORTED_TASK_TYPE", `不支持的任务类型：${taskType}`);
+}
+
 // A small but non-transparent 128x128 PNG. The model test must exercise an actual image_url
 // payload, while keeping the request cheap and avoiding any user data in the probe.
 const MULTIMODAL_TEST_IMAGE_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAPoAAAD6AG1e1JrAAACfklEQVR4nO2cwY3EQBACJ8LOglRJyw4DJOpR/xOUuF17Zp91H9xsBi/9B8AhABIcC4AEx78AJDg+AyDB8SEQCY5vAUhwfA1EguM5ABIcD4KQ4HgSiATHo2AkON4FIMHxMggJjreBSHC8DkaC4zwAEhwHQpDgOBGEBMeRMCQ4zgQiwXEoFAmOU8FIcBwLR4LjXgASHBdDkOC4GYQEx9UwJDjuBiLBcTkUCY7bwUhwXA8319P5fQCPS8APRChfAgIUBOFRWADlS0CAgiA8CgugfAkIUBCER2EBlC8BAQqC8CgsgPIlIEBBEB6FBVC+BAQoCMKjsADKl4AABUF4FBZA+RIQoCAIj8ICKF8CAhQE4VFYAOVLQICCIDwKC6B8CQhQEIRHYQGULwEBCoLwKCyA8iUgQEEQHoUFUL4EBCgIwqOwAMqXgAAFQXgUFkD5EhCgIAiPwgIoXwICFAThUVgA5UtAgIIgPAoLoHwJCFAQhEdhAZQvAQEKgvAoLIDyJSBAQRAehQVQvgQEKAjCo7AAypeAAAVBeBQWQPkSEKAgCI/CAihfAgIUBOFRWADlS0CAgiA8CgugfAkIUBCER2EBlC8BAQqC8CgsgPIlIEBBEB6FBVC+BAQoCMKjsADKl4AABUF4FBZA+RIQoCAIj8ICKF8CAhQE4VFYAOVLQICCIDwKC6B8CQhQEIRHYQGULwEBCoLwKCyA8iUgQEEQHoUFUL4EBCgIwqOwAMqXgAAFQXgUFkD5EhCgIAiPwgIoXwICFAThUVgA5UtAgIIgPAoLoHwJCFAQhEdhAZQvAQEKgvAoLIDyJSBAQRAehQVQvgQEKAjCo7AAypeAAAVBeJQfFY4JQ620WGEAAAAASUVORK5CYII=";
@@ -2426,7 +2443,7 @@ export class AiManager {
         failures: [{ message, ...(error instanceof AppError ? { code: error.code } : {}) }]
       });
     }
-    if (current.status !== "partial") return;
+    if (current.status !== "partial" && current.status !== "failed") return;
     const disposition = autoRunFailureDisposition(error, Number(current.attemptCount));
     const settings = this.store.recordAutoRunFailure(workId, message, disposition.pauseImmediately);
     logger.warn("ai.auto_run.task_failed", {
@@ -3191,7 +3208,7 @@ export class AiManager {
 
   rerunTask(taskId: string, modelOverrideId?: string): Record<string, unknown> {
     const original = this.store.getTask(taskId);
-    const rerunnableStatuses = new Set(["review", "completed", "partial", "expired", "cancelled"]);
+    const rerunnableStatuses = new Set(["review", "completed", "partial", "failed", "expired", "cancelled"]);
     if (!rerunnableStatuses.has(String(original.status))) {
       throw new AppError(409, "TASK_NOT_RERUNNABLE", "只有已结束的分析任务可以按原配置重跑");
     }
@@ -3686,7 +3703,9 @@ export class AiManager {
     const taskController = new AbortController();
     this.taskControllers.set(taskId, taskController);
     try {
-      const taskType = String(task.taskType);
+      const taskTypeValue = String(task.taskType);
+      if (!isAnalysisTaskType(taskTypeValue)) throw unsupportedTaskType(taskTypeValue);
+      const taskType = taskTypeValue;
       const scope = task.scope as ContextScope;
       let result: Record<string, unknown>;
       if (taskType === "chapter-analysis") {
@@ -3705,17 +3724,19 @@ export class AiManager {
         result = await this.runSettingExtraction(workId, scope, selectedModelId, taskId);
       } else if (taskType === "consistency-check") {
         result = await this.runConsistencyCheck(workId, scope, selectedModelId, taskId);
-      } else {
+      } else if (taskType === "book-analysis") {
         const generated = await this.generate({
           workId,
           taskId,
-          taskType: taskType === "book-analysis" ? "book-analysis" : "chapter-analysis",
+          taskType: "book-analysis",
           instruction: "请基于上下文完成分析，给出有原文依据的中文结论。",
           scope,
           signal: taskController.signal,
           ...(selectedModelId ? { modelId: selectedModelId } : {})
         });
         result = { content: generated.content, callId: generated.callId };
+      } else {
+        throw unsupportedTaskType(taskType);
       }
       if (!this.taskCanCommit(taskId)) {
         logger.warn("ai.task.result_discarded", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000 });
@@ -3746,7 +3767,8 @@ export class AiManager {
           throw error;
         }
       }
-      this.store.updateTask(taskId, { status: "partial", progress: 100, failures: [failure] });
+      const failedStatus = error instanceof AppError && error.code === "UNSUPPORTED_TASK_TYPE" ? "failed" : "partial";
+      this.store.updateTask(taskId, { status: failedStatus, progress: 100, failures: [failure] });
       logger.error("ai.task.failed", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000, error: aiErrorForLog(error) });
       throw error;
     } finally {

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ import { resolveMaxAgentToolCallLimit } from "./ai-tool-results.js";
 import { CredentialVault } from "./credential-vault.js";
 import { Database } from "./database.js";
 import { assertSafeDocxArchive } from "./docx-security.js";
-import { DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
+import { ANALYSIS_TASK_TYPES, DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
 import { AppError } from "./errors.js";
 import { isOfficialGoogleVertexBaseUrl, parseGoogleServiceAccount } from "./google-vertex-auth.js";
 import { HYBRID_SEARCH_TYPES } from "./hybrid-search.js";
@@ -581,7 +581,7 @@ const contextSchema = z.object({
   includeSettingInfo: z.boolean().optional()
 });
 
-const analysisTaskTypeSchema = z.enum(["structure", "chapter-analysis", "character-extraction", "character-summary", "character-identity-audit", "timeline-analysis", "worldview-analysis", "setting-extraction", "consistency-check", "report-update", "book-analysis"]);
+export const analysisTaskTypeSchema = z.enum(ANALYSIS_TASK_TYPES);
 const relationshipSourceRefSchema = z.object({
   sourceType: z.string().trim().min(1).max(50).regex(/^[a-z][a-z-]*$/u),
   sourceId: identifier,

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ import { resolveMaxAgentToolCallLimit } from "./ai-tool-results.js";
 import { CredentialVault } from "./credential-vault.js";
 import { Database } from "./database.js";
 import { assertSafeDocxArchive } from "./docx-security.js";
-import { ANALYSIS_TASK_TYPES, DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
+import { CREATABLE_ANALYSIS_TASK_TYPES, DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
 import { AppError } from "./errors.js";
 import { isOfficialGoogleVertexBaseUrl, parseGoogleServiceAccount } from "./google-vertex-auth.js";
 import { HYBRID_SEARCH_TYPES } from "./hybrid-search.js";
@@ -581,7 +581,8 @@ const contextSchema = z.object({
   includeSettingInfo: z.boolean().optional()
 });
 
-export const analysisTaskTypeSchema = z.enum(ANALYSIS_TASK_TYPES);
+/** 创建任务 API 的分析类型校验：仅允许可新建类型，历史类型在运行层保留防御性拒绝。 */
+export const creatableAnalysisTaskTypeSchema = z.enum(CREATABLE_ANALYSIS_TASK_TYPES);
 const relationshipSourceRefSchema = z.object({
   sourceType: z.string().trim().min(1).max(50).regex(/^[a-z][a-z-]*$/u),
   sourceId: identifier,
@@ -625,7 +626,7 @@ const relationshipAnalysisScopeSchema = z.object({
 });
 const analysisTaskSchema = z.union([
   z.object({ taskType: z.literal("relationship-analysis"), scope: relationshipAnalysisScopeSchema.optional(), modelId: identifier.optional() }).strict(),
-  z.object({ taskType: analysisTaskTypeSchema, scope: jsonObject.optional(), modelId: identifier.optional() }).strict().superRefine((input, context) => {
+  z.object({ taskType: creatableAnalysisTaskTypeSchema, scope: jsonObject.optional(), modelId: identifier.optional() }).strict().superRefine((input, context) => {
     if (input.scope?.includeAllSettings !== undefined) {
       context.addIssue({ code: z.ZodIssueCode.custom, path: ["scope", "includeAllSettings"], message: "包含所有设定仅支持人物关系分析" });
     }

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -24,8 +24,8 @@ export const TASK_TYPES = [
 ] as const;
 export type TaskType = (typeof TASK_TYPES)[number];
 
-export const ANALYSIS_TASK_TYPES = [
-  "structure",
+/** 创建任务 API 允许新建的分析任务类型（运行层已实现对应执行路径）。 */
+export const CREATABLE_ANALYSIS_TASK_TYPES = [
   "chapter-analysis",
   "character-extraction",
   "character-summary",
@@ -35,9 +35,15 @@ export const ANALYSIS_TASK_TYPES = [
   "worldview-analysis",
   "setting-extraction",
   "consistency-check",
-  "report-update",
   "book-analysis"
 ] as const;
+export type CreatableAnalysisTaskType = (typeof CREATABLE_ANALYSIS_TASK_TYPES)[number];
+
+/** 仅可读取的历史分析任务类型：创建 API 不允许新建，运行层保留防御性拒绝。 */
+export const HISTORICAL_ANALYSIS_TASK_TYPES = ["structure", "report-update"] as const;
+
+/** 全量分析任务类型（可新建 + 历史）：单一来源，供运行层白名单与历史任务读取。 */
+export const ANALYSIS_TASK_TYPES = [...CREATABLE_ANALYSIS_TASK_TYPES, ...HISTORICAL_ANALYSIS_TASK_TYPES] as const;
 export type AnalysisTaskType = (typeof ANALYSIS_TASK_TYPES)[number];
 
 export const ANALYSIS_STATUSES = [

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -24,11 +24,28 @@ export const TASK_TYPES = [
 ] as const;
 export type TaskType = (typeof TASK_TYPES)[number];
 
+export const ANALYSIS_TASK_TYPES = [
+  "structure",
+  "chapter-analysis",
+  "character-extraction",
+  "character-summary",
+  "character-identity-audit",
+  "timeline-analysis",
+  "relationship-analysis",
+  "worldview-analysis",
+  "setting-extraction",
+  "consistency-check",
+  "report-update",
+  "book-analysis"
+] as const;
+export type AnalysisTaskType = (typeof ANALYSIS_TASK_TYPES)[number];
+
 export const ANALYSIS_STATUSES = [
   "pending",
   "running",
   "completed",
   "partial",
+  "failed",
   "review",
   "expired",
   "cancelled"

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -54,7 +54,7 @@ import {
   normalizeTimelineSortDirection,
   timelineTrackColorIndex
 } from "/timeline-view.js?v=20260801-timeline-sort-actions-v1";
-import { backgroundTaskActivityCount, backgroundTaskPollDelay, collectBackgroundTaskTransitions } from "/background-task-center.js?v=20260726-background-task-center-v1";
+import { backgroundTaskActivityCount, backgroundTaskPollDelay, collectBackgroundTaskTransitions } from "/background-task-center.js?v=20260810-analysis-task-failed-v1";
 import { createModuleRequestCache } from "/module-request-cache.js?v=20260730-module-request-cache-v1";
 import { systemStatusPresentation } from "/system-status.js?v=20260801-system-health-v1";
 import { collectS3BackupRunTransitions, s3BackupFailureToast, s3BackupRootPrefix, s3BackupStatusLabel } from "/s3-backup-ui.js?v=20260804-s3-backup-v1";
@@ -248,18 +248,19 @@ function analysisTaskStatusLabel(status) {
     review: "已完成",
     completed: "已完成",
     partial: "部分失败",
+    failed: "失败",
     expired: "已过期",
     cancelled: "已取消"
   })[String(status)] ?? "未知状态";
 }
 
 function canRerunAnalysisTask(task) {
-  return ["review", "completed", "partial", "expired", "cancelled"].includes(String(task?.status ?? ""));
+  return ["review", "completed", "partial", "failed", "expired", "cancelled"].includes(String(task?.status ?? ""));
 }
 
 function normalizedAnalysisTaskStatus(status) {
   const value = String(status);
-  return ["pending", "running", "review", "completed", "partial", "expired", "cancelled"].includes(value)
+  return ["pending", "running", "review", "completed", "partial", "failed", "expired", "cancelled"].includes(value)
     ? value
     : "unknown";
 }
@@ -7576,6 +7577,7 @@ function backgroundProductUpdateMarkup() {
 
 function backgroundTaskTransitionMessage(transition) {
   const label = analysisTaskTypeLabel(transition.task.taskType);
+  if (transition.status === "failed") return { message: `${label}失败，请打开任务详情查看`, type: "error" };
   if (transition.status === "partial") return { message: `${label}部分失败，请打开任务详情查看`, type: "error" };
   if (transition.status === "expired") return { message: `${label}已过期，正文可能已发生变化`, type: "error" };
   if (transition.status === "cancelled") return { message: `${label}已取消`, type: "info" };

--- a/src/public/background-task-center.js
+++ b/src/public/background-task-center.js
@@ -1,5 +1,5 @@
 const activeTaskStatuses = new Set(["pending", "running"]);
-const terminalTaskStatuses = new Set(["review", "completed", "partial", "expired", "cancelled"]);
+const terminalTaskStatuses = new Set(["review", "completed", "partial", "failed", "expired", "cancelled"]);
 
 export function backgroundTaskActivityCount(taskPage, relationshipIndex) {
   const pendingCount = Number(taskPage?.stats?.pendingCount ?? 0);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-<link rel="stylesheet" href="/styles.css?v=20260810-relationship-preview-fullscreen-v1">
+<link rel="stylesheet" href="/styles.css?v=20260810-analysis-task-failed-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
@@ -1026,6 +1026,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260810-review-status-feedback-v1"></script>
+    <script type="module" src="/app.js?v=20260810-analysis-task-failed-review-status-v1"></script>
   </body>
 </html>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1615,13 +1615,13 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 }
 .task-status-badge.is-running .task-status-indicator::after { animation: task-status-running-ripple 1.8s ease-out infinite; }
 .task-status-badge.is-review, .task-status-badge.is-completed { --task-status-color: var(--green); }
-.task-status-badge.is-partial { --task-status-color: var(--accent); }
+.task-status-badge.is-partial, .task-status-badge.is-failed { --task-status-color: var(--accent); }
 .task-status-badge.is-expired { --task-status-color: color-mix(in srgb, var(--muted) 72%, var(--accent)); border-style: dashed; }
 .task-status-badge.is-cancelled, .task-status-badge.is-unknown { --task-status-color: var(--muted); }
 .task-status-badge.is-cancelled .task-status-indicator, .task-status-badge.is-unknown .task-status-indicator { background: transparent; border: 1px solid currentColor; box-shadow: none; }
 .task-status-badge.is-state-change { animation: task-status-enter .42s cubic-bezier(.22, .8, .32, 1) both; }
 .task-status-badge.is-running.is-state-change { animation: task-status-enter .42s cubic-bezier(.22, .8, .32, 1) both, task-status-running-breathe 1.8s ease-in-out .42s infinite; }
-.task-status-badge.is-partial.is-state-change { animation: task-status-attention .46s ease-out both; }
+.task-status-badge.is-partial.is-state-change, .task-status-badge.is-failed.is-state-change { animation: task-status-attention .46s ease-out both; }
 .task-progress-cell { width: 128px; }
 .task-progress { display: grid; grid-template-columns: 36px minmax(58px, 1fr); align-items: center; gap: 8px; min-width: 102px; }
 .task-progress-value { color: var(--ink); font-family: var(--font-latin), monospace; font-size: 11px; font-variant-numeric: tabular-nums; font-weight: 600; }
@@ -1629,7 +1629,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .task-progress-fill { position: relative; display: block; width: var(--task-progress); height: 100%; overflow: hidden; border-radius: inherit; background: var(--muted); transition: width .35s ease; }
 .task-progress.is-running .task-progress-fill { background: var(--task-running); }
 .task-progress.is-review .task-progress-fill, .task-progress.is-completed .task-progress-fill { background: var(--green); }
-.task-progress.is-partial .task-progress-fill { background: var(--accent); }
+.task-progress.is-partial .task-progress-fill, .task-progress.is-failed .task-progress-fill { background: var(--accent); }
 .task-progress.is-running .task-progress-fill::after {
   content: "";
   position: absolute;

--- a/src/store.ts
+++ b/src/store.ts
@@ -7375,7 +7375,7 @@ export class Store {
 
   updateTask(taskId: string, input: { status: string; progress?: number; result?: unknown; failures?: unknown[] }): Record<string, unknown> {
     const current = this.getTask(taskId);
-    const terminal = ["completed", "partial", "review", "expired", "cancelled"];
+    const terminal = ["completed", "partial", "failed", "review", "expired", "cancelled"];
     if (terminal.includes(String(current.status)) && input.status !== current.status) {
       throw new AppError(409, "INVALID_TASK_TRANSITION", "终态任务不能再变更状态");
     }

--- a/tests/integration/analysis-task-model.test.ts
+++ b/tests/integration/analysis-task-model.test.ts
@@ -81,7 +81,12 @@ describe("AI 分析任务模型", () => {
     }).expect(201);
     expect(overriddenTask.body.data.model.id).toBe(modelA.body.data.id);
 
-    await request(runtime.app).post(`/api/tasks/${defaultTask.body.data.id}/run`).send({}).expect(200);
+    const completed = await request(runtime.app).post(`/api/tasks/${defaultTask.body.data.id}/run`).send({}).expect(200);
+    expect(completed.body.data).toMatchObject({
+      taskType: "book-analysis",
+      status: "review",
+      result: { content: "已完成全书综合分析。", callId: expect.stringMatching(/^call_/u) }
+    });
     expect(requestedModels).toEqual(["analysis-model-a"]);
     const storedTask = runtime.database.get<Record<string, unknown>>(
       "SELECT model_id FROM analysis_tasks WHERE id = ?",

--- a/tests/integration/task-auto-run.test.ts
+++ b/tests/integration/task-auto-run.test.ts
@@ -268,6 +268,33 @@ describe("分析任务自动运行", () => {
     expect(secondPage.body.data.items).toHaveLength(25);
   });
 
+  it.each(["structure", "report-update", "future-analysis"])("不支持的任务类型 %s 明确失败且自动运行不重试", async (taskType) => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      throw new Error("不支持的任务不应调用 AI 供应商");
+    });
+    const runtime = createTestRuntime(fetchMock);
+    runtimes.push(runtime);
+    const work = runtime.store.createWork({ title: "不支持的任务类型测试" });
+    const task = runtime.store.createTask(String(work.id), {
+      taskType,
+      scope: { type: "book" }
+    });
+
+    await expect(runtime.ai.runTask(String(task.id), undefined, undefined, { autoRun: true })).rejects.toMatchObject({
+      status: 400,
+      code: "UNSUPPORTED_TASK_TYPE",
+      message: `不支持的任务类型：${taskType}`
+    });
+    expect(runtime.store.getTask(String(task.id))).toMatchObject({
+      status: "failed",
+      progress: 100,
+      attemptCount: 1,
+      nextAttemptAt: null,
+      failures: [{ message: `不支持的任务类型：${taskType}`, code: "UNSUPPORTED_TASK_TYPE" }]
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("以事务原子认领待执行任务并遵守运行上限", () => {
     const runtime = createTestRuntime();
     runtimes.push(runtime);

--- a/tests/integration/task-creation-api.test.ts
+++ b/tests/integration/task-creation-api.test.ts
@@ -1,0 +1,43 @@
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import { createTestRuntime } from "../helpers.js";
+
+describe("分析任务创建 API 类型白名单", () => {
+  let runtime: Runtime | null = null;
+
+  afterEach(() => {
+    runtime?.close();
+    runtime = null;
+  });
+
+  async function setupWork(): Promise<string> {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: "ok" } }]
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    runtime = createTestRuntime(fetchMock);
+    const work = await request(runtime.app).post("/api/works").send({ title: "创建类型白名单测试" }).expect(201);
+    return String(work.body.data.id);
+  }
+
+  it("拒绝运行时不支持的历史分析类型（structure/report-update）且不落库", async () => {
+    const workId = await setupWork();
+    for (const taskType of ["structure", "report-update"]) {
+      await request(runtime!.app).post(`/api/works/${workId}/tasks`).send({
+        taskType,
+        scope: { type: "book" }
+      }).expect(400);
+    }
+    const tasks = await request(runtime!.app).get(`/api/works/${workId}/tasks`).expect(200);
+    expect(tasks.body.data.items).toEqual([]);
+  });
+
+  it("仍接受可新建的分析类型并创建为 pending 任务", async () => {
+    const workId = await setupWork();
+    const task = await request(runtime!.app).post(`/api/works/${workId}/tasks`).send({
+      taskType: "chapter-analysis",
+      scope: { type: "book" }
+    }).expect(201);
+    expect(task.body.data).toMatchObject({ taskType: "chapter-analysis", status: "pending" });
+  });
+});

--- a/tests/system/analysis-task-rerun-ui.test.ts
+++ b/tests/system/analysis-task-rerun-ui.test.ts
@@ -11,7 +11,7 @@ describe("AI 分析任务重跑界面", () => {
     ]);
 
     expect(application).toContain("function canRerunAnalysisTask(task)");
-    expect(application).toContain('"review", "completed", "partial", "expired", "cancelled"');
+    expect(application).toContain('"review", "completed", "partial", "failed", "expired", "cancelled"');
     expect(application).not.toContain('data-rerun-task="${esc(item.id)}"');
     expect(application).toContain('data-rerun-task-detail="${esc(task.id)}"');
     expect(application).toContain('data-rerun-task-model="${esc(task.id)}"');

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -321,9 +321,8 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/index.css?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
-    expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
+expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');
+    expect(page.text).toContain('/styles.css?v=20260810-analysis-task-failed-v1');    expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
     expect(application.text).toContain('/ai-settings/usage?timezoneOffset=');
     expect(application.text).toContain('class="form-field model-multimodal-fields"');
@@ -430,10 +429,14 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".analysis-type-description");
     expect(page.text).toContain('id="setting-editor-confirm"');
     expect(application.text).toContain('review: "已完成"');
+    expect(application.text).toContain('failed: "失败"');
+    expect(application.text).toContain('/background-task-center.js?v=20260810-analysis-task-failed-v1');
+    expect(application.text).toContain('if (transition.status === "failed") return { message: `${label}失败，请打开任务详情查看`, type: "error" };');
     expect(application.text).not.toContain('review: "待审核"');
     expect(application.text).toContain('"分析已完成"');
     expect(application.text).not.toContain("结果进入审核状态");
     expect(styles.text).toContain("--toast-bg:");
+    expect(styles.text).toContain(".task-status-badge.is-partial, .task-status-badge.is-failed");
     expect(styles.text).toContain(":root[data-theme=\"dark\"]");
     expect(styles.text).toContain("--relationship-network-surface: #eef2f7");
     expect(styles.text).toContain("--relationship-network-surface: #12121a");

--- a/tests/system/book-summary-reference.test.ts
+++ b/tests/system/book-summary-reference.test.ts
@@ -28,8 +28,7 @@ describe("全书概要上下文引用", () => {
     expect(page.text).not.toContain('id="ai-include-setting-info"');
     expect(page.text).not.toContain('<option value="selection">选中文本</option>');
     expect(page.text).not.toContain('id="ai-book-summary-reference"');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-    expect(application.text).toContain('id="save-agent-tools"');
+expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');    expect(application.text).toContain('id="save-agent-tools"');
     expect(application.text).toContain('class="book-summary-context-percent-field"');
     expect(application.text).toContain('class="config-inline-save"');
     expect(application.text).toContain('class="ghost-button config-save-button"');

--- a/tests/system/drafts-ui.test.ts
+++ b/tests/system/drafts-ui.test.ts
@@ -19,8 +19,7 @@ describe("想法模块界面", () => {
 
     expect(page.text).toContain('data-module="drafts"');
     expect(page.text).toContain(">想法</button>");
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-    expect(application.text).toContain('drafts: ["临时想法", "创作想法"');
+expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');    expect(application.text).toContain('drafts: ["临时想法", "创作想法"');
     expect(application.text).toContain('[["prose", "正文想法"], ["setting", "设定想法"]]');
     expect(application.text).toContain('field("volumeId", "绑定分卷"');
     expect(application.text).toContain('field("settingModule", "绑定设定模块"');

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,6 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-  });
+expect(page.text).toContain('/styles.css?v=20260810-analysis-task-failed-v1');
+    expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');  });
 });

--- a/tests/system/global-replace-ui.test.ts
+++ b/tests/system/global-replace-ui.test.ts
@@ -29,8 +29,7 @@ describe("全局替换界面", () => {
     expect(page.text).toContain('name="replaceScope" value="prose" checked');
     expect(page.text).toContain('name="replaceScope" value="settings"');
     expect(page.text).toContain('name="replaceScope" value="prose-and-settings"');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-    expect(application.text).toContain("function submitGlobalReplace(");
+expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');    expect(application.text).toContain("function submitGlobalReplace(");
     expect(application.text).toContain("function syncGlobalReplaceScopeOptions(");
     expect(application.text).toContain('/replace`');
     expect(styles.text).toContain(".replace-dialog-body");

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,10 +23,9 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260810-review-status-feedback-v1"></script>');
-    expect(page.text).toContain('id="setting-editor-readonly-badge"');
+expect(page.text).toContain('/styles.css?v=20260810-analysis-task-failed-v1');
+    expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260810-analysis-task-failed-review-status-v1');    expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');
     expect(styles.text).toContain('.entity-editor-readonly-badge');

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,9 +23,8 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-    expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
+expect(page.text).toContain('/styles.css?v=20260810-analysis-task-failed-v1');
+    expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');    expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');
     expect(graph.text).toContain('testId: "relationship-node-search"');
     expect(graph.text).toContain('testId: "galaxy-node-search"');

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -31,9 +31,8 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260810-relationship-preview-fullscreen-v1');
-    expect(page.text).toContain('/app.js?v=20260810-review-status-feedback-v1');
-
+expect(page.text).toContain('/styles.css?v=20260810-analysis-task-failed-v1');
+    expect(page.text).toContain('/app.js?v=20260810-analysis-task-failed-review-status-v1');
     expect(application.text).toContain('/s3-backup-ui.js?v=20260804-s3-backup-v1');
     expect(application.text).toContain('api("/api/platform/backups/targets")');
     expect(application.text).toContain('api("/api/platform/backups/runs?limit=100")');

--- a/tests/unit/ai-auto-run.test.ts
+++ b/tests/unit/ai-auto-run.test.ts
@@ -39,4 +39,13 @@ describe("AI 分析队列失败策略", () => {
       pauseImmediately: true
     });
   });
+
+  it("对不支持的任务类型直接失败且不重试", () => {
+    const unsupported = new AppError(400, "UNSUPPORTED_TASK_TYPE", "不支持的任务类型：structure");
+    expect(autoRunFailureDisposition(unsupported, 1)).toEqual({
+      retry: false,
+      retryDelayMs: 0,
+      pauseImmediately: false
+    });
+  });
 });

--- a/tests/unit/background-task-center.test.ts
+++ b/tests/unit/background-task-center.test.ts
@@ -38,6 +38,15 @@ describe("全局后台任务中心", () => {
     expect(unchanged.transitions).toEqual([]);
   });
 
+  it("把明确失败识别为终态变化", () => {
+    const initial = collectBackgroundTaskTransitions(new Map([["failed-task", "running"]]), [
+      { id: "failed-task", status: "failed" }
+    ], true);
+    expect(initial.transitions).toEqual([
+      expect.objectContaining({ previousStatus: "running", status: "failed" })
+    ]);
+  });
+
   it("活动任务或打开弹窗时采用更短轮询间隔", () => {
     expect(backgroundTaskPollDelay(1, false)).toBe(5_000);
     expect(backgroundTaskPollDelay(0, true)).toBe(5_000);

--- a/tests/unit/domain.test.ts
+++ b/tests/unit/domain.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { analysisTaskTypeSchema } from "../../src/app.js";
+import { ANALYSIS_TASK_TYPES } from "../../src/domain.js";
+
+describe("分析任务类型定义", () => {
+  it("API 校验与领域常量使用相同选项", () => {
+    expect(analysisTaskTypeSchema.options).toEqual([...ANALYSIS_TASK_TYPES]);
+  });
+});

--- a/tests/unit/domain.test.ts
+++ b/tests/unit/domain.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { analysisTaskTypeSchema } from "../../src/app.js";
-import { ANALYSIS_TASK_TYPES } from "../../src/domain.js";
+import { creatableAnalysisTaskTypeSchema } from "../../src/app.js";
+import { ANALYSIS_TASK_TYPES, CREATABLE_ANALYSIS_TASK_TYPES, HISTORICAL_ANALYSIS_TASK_TYPES } from "../../src/domain.js";
 
 describe("分析任务类型定义", () => {
-  it("API 校验与领域常量使用相同选项", () => {
-    expect(analysisTaskTypeSchema.options).toEqual([...ANALYSIS_TASK_TYPES]);
+  it("创建 API 校验与可新建类型常量使用相同选项", () => {
+    expect(creatableAnalysisTaskTypeSchema.options).toEqual([...CREATABLE_ANALYSIS_TASK_TYPES]);
+  });
+
+  it("全量类型为可新建类型与历史类型的并集（单一来源）", () => {
+    expect([...CREATABLE_ANALYSIS_TASK_TYPES, ...HISTORICAL_ANALYSIS_TASK_TYPES]).toEqual([...ANALYSIS_TASK_TYPES]);
+    expect(ANALYSIS_TASK_TYPES).toContain("structure");
+    expect(ANALYSIS_TASK_TYPES).toContain("report-update");
+    expect(CREATABLE_ANALYSIS_TASK_TYPES).not.toContain("structure");
+    expect(CREATABLE_ANALYSIS_TASK_TYPES).not.toContain("report-update");
   });
 });


### PR DESCRIPTION
## 变更

- 统一分析任务类型定义，API 校验与运行时白名单共用 `ANALYSIS_TASK_TYPES`
- 对 `structure`、`report-update` 和未知任务类型抛出 `UNSUPPORTED_TASK_TYPE`，记录为 `failed` 且不进入自动重试
- 保留 `book-analysis` 的原有生成路径，并补齐失败状态的终态、重跑和界面展示支持

## 验证

- `npm run typecheck`
- `npm test`（137 个测试文件，703 条测试）
- `npm run build`
- 浏览器：桌面 1280×720、窄屏 390×844 的任务列表与详情状态验收

Closes MUXUE-3
