### PR TITLE
MUXUE-9: index audit log listing

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -6,7 +6,7 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-export const DATABASE_SCHEMA_VERSION = 79;
+export const DATABASE_SCHEMA_VERSION = 80;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -738,6 +738,7 @@ export class Database {
       CREATE INDEX IF NOT EXISTS idx_calls_work ON ai_calls(work_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_ai_conversations_work ON ai_conversations(work_id, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_ai_conversation_messages ON ai_conversation_messages(conversation_id, created_at);
+      CREATE INDEX IF NOT EXISTS idx_audit_logs_work_created ON audit_logs(work_id, created_at DESC);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_character_names_primary ON character_names(character_id) WHERE kind = 'primary';
       CREATE INDEX IF NOT EXISTS idx_character_names_character ON character_names(character_id, sort_order);
       CREATE INDEX IF NOT EXISTS idx_character_versions_character ON character_versions(character_id, version_no DESC);
@@ -3204,6 +3205,18 @@ export class Database {
         this.run("DROP TABLE platform_ui_settings");
         this.run("ALTER TABLE platform_ui_settings_v79 RENAME TO platform_ui_settings");
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (79, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    if (!applied.has(80)) {
+      this.transaction(() => {
+        this.run("CREATE INDEX IF NOT EXISTS idx_audit_logs_work_created ON audit_logs(work_id, created_at DESC)");
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (80, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -302,7 +302,7 @@ describe("数据库版本化迁移", () => {
     second.close();
   });
 
-  it("从已有迁移 74 平滑升级到 79 并重建 AI 历史短词索引", () => {
+  it("从已有迁移 74 平滑升级到 80 并重建 AI 历史短词索引", () => {
     const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-74-upgrade-"));
     roots.push(root);
     const filename = join(root, "migration-74.db");
@@ -320,7 +320,7 @@ describe("数据库版本化迁移", () => {
       VALUES ('conversation-migration-74', 'work-migration-74', '旧对话', '重复重复', '2025-01-01', '2025-01-01');
       DROP TABLE s3_backup_runs;
       DROP TABLE s3_backup_targets;
-      DELETE FROM schema_migrations WHERE version IN (75, 76, 77, 78, 79);
+      DELETE FROM schema_migrations WHERE version IN (75, 76, 77, 78, 79, 80);
     `);
     const searchRow = legacy.prepare(
       "SELECT id FROM ai_history_search WHERE source_type = 'conversation' AND source_id = 'conversation-migration-74'"
@@ -366,7 +366,7 @@ describe("数据库版本化迁移", () => {
       );
       INSERT INTO platform_ui_settings (id, toast_position, page_sizes_json, galaxy_frame_rate, updated_at)
       VALUES (1, 'top-right', '{"characters":25}', 60, '2026-08-09T00:00:00.000Z');
-      DELETE FROM schema_migrations WHERE version IN (78, 79);
+      DELETE FROM schema_migrations WHERE version IN (78, 79, 80);
     `);
     legacy.close();
 
@@ -403,7 +403,7 @@ describe("数据库版本化迁移", () => {
       );
       INSERT INTO platform_ui_settings (id, toast_position, page_sizes_json, galaxy_frame_rate, updated_at)
       VALUES (1, 'top-right', '{"characters":25}', 120, '2026-08-09T00:00:00.000Z');
-      DELETE FROM schema_migrations WHERE version = 79;
+      DELETE FROM schema_migrations WHERE version IN (79, 80);
     `);
     legacy.close();
 
@@ -419,6 +419,65 @@ describe("数据库版本化迁移", () => {
     expect(migrated.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
     expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
     migrated.close();
+  });
+
+  it("迁移 80 为既有库补建审计列表索引并保留日志", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-audit-index-existing-"));
+    roots.push(root);
+    const filename = join(root, "audit-index-existing.db");
+    const current = new Database(filename);
+    const timestamp = "2026-08-10T00:00:00.000Z";
+    current.run(
+      `INSERT INTO works (id, title, created_at, updated_at)
+       VALUES ('work-audit-index', '审计索引迁移', ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO audit_logs (id, work_id, action, entity_type, actor, detail_json, created_at)
+       VALUES ('audit-before-index', 'work-audit-index', 'work.updated', 'work', 'owner', '{}', ?)`,
+      timestamp
+    );
+    current.run("DROP INDEX idx_audit_logs_work_created");
+    current.run("DELETE FROM schema_migrations WHERE version = 80");
+    current.close();
+
+    const migrated = new Database(filename);
+    expect(migrated.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 80")).toEqual({ count: 1 });
+    expect(migrated.all("PRAGMA index_xinfo('idx_audit_logs_work_created')")
+      .filter((column) => column.key === 1)
+      .map((column) => ({ name: column.name, desc: column.desc }))).toEqual([
+      { name: "work_id", desc: 0 },
+      { name: "created_at", desc: 1 }
+    ]);
+    expect(migrated.get("SELECT id FROM audit_logs WHERE id = 'audit-before-index'")).toEqual({ id: "audit-before-index" });
+    expect(migrated.all(
+      `EXPLAIN QUERY PLAN SELECT log.*, user.display_name AS actor_display_name, user.username AS actor_username
+       FROM audit_logs log LEFT JOIN users user ON user.id = log.user_id
+       WHERE log.work_id = ? ORDER BY log.created_at DESC LIMIT 200`,
+      "work-audit-index"
+    ).some((step) => String(step.detail).includes("USING INDEX idx_audit_logs_work_created"))).toBe(true);
+    expect(migrated.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
+    migrated.close();
+  });
+
+  it("迁移 80 在全新库预建索引后可幂等登记并重启", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-audit-index-fresh-"));
+    roots.push(root);
+    const filename = join(root, "audit-index-fresh.db");
+
+    const first = new Database(filename);
+    expect(first.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 80")).toEqual({ count: 1 });
+    expect(first.all("PRAGMA index_list(audit_logs)").filter((index) => index.name === "idx_audit_logs_work_created")).toHaveLength(1);
+    first.close();
+
+    const restarted = new Database(filename);
+    expect(restarted.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 80")).toEqual({ count: 1 });
+    expect(restarted.all("PRAGMA index_list(audit_logs)").filter((index) => index.name === "idx_audit_logs_work_created")).toHaveLength(1);
+    expect(restarted.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(restarted.all("PRAGMA foreign_key_check")).toEqual([]);
+    restarted.close();
   });
 
   it("迁移 53 只重排可重建索引并保留领域数据", () => {


### PR DESCRIPTION
## 变更

- 新增数据库迁移 80，为 `audit_logs(work_id, created_at DESC)` 建立幂等复合索引。
- 将同一索引加入全新库基线建表清单，并保留既有库升级路径。
- 分别覆盖既有库与全新库迁移，验证索引结构、查询计划、日志保留和重启幂等性。

## 验证

- `npm exec vitest -- run tests/unit/database-migration.test.ts --maxWorkers=1`：17 项通过
- `npm exec vitest -- run tests/integration/user-auth-api.test.ts --maxWorkers=1`：29 项通过
- `npm run typecheck`：通过
- `npm test`：136 个文件、699 项测试通过
- `npm run build`：通过
- 隔离数据库健康检查、`PRAGMA integrity_check` 与 `PRAGMA foreign_key_check`：通过

Closes MUXUE-9
