### PR TITLE
MUXUE-23: enforce bounded graceful shutdown

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -683,8 +683,10 @@ export type Runtime = {
   auth: UserAuthService;
   attachmentStorage: AttachmentStorage;
   cleanupAttachments: () => Promise<void>;
-  close: () => void;
+  close: () => Promise<void>;
 };
+
+export const RUNTIME_BACKUP_IDLE_TIMEOUT_MS = 9_000;
 
 function data(response: Response, value: unknown, status = 200): void {
   response.status(status).json({ data: value });
@@ -2725,12 +2727,33 @@ export function createRuntime(options: RuntimeOptions): Runtime {
 
   backups.startScheduler();
   logger.info("runtime.ready", { serveUi: options.serveUi ?? true });
-  return { app, database, store, ai, backups, auth, attachmentStorage, cleanupAttachments, close: () => {
-    logger.info("runtime.closing");
-    backups.dispose();
-    ai.dispose();
-    database.close();
-    if (temporaryAttachmentRoot) rmSync(temporaryAttachmentRoot, { recursive: true, force: true });
-    logger.info("runtime.closed");
-  } };
+  let closePromise: Promise<void> | null = null;
+  let stopping = false;
+  let closed = false;
+  const close = (): Promise<void> => {
+    if (closed) return Promise.resolve();
+    if (closePromise) return closePromise;
+    if (!stopping) {
+      stopping = true;
+      logger.info("runtime.closing");
+      backups.dispose();
+      ai.dispose();
+    }
+    closePromise = (async () => {
+      try {
+        await backups.waitForIdle(RUNTIME_BACKUP_IDLE_TIMEOUT_MS);
+        database.close();
+        if (temporaryAttachmentRoot) rmSync(temporaryAttachmentRoot, { recursive: true, force: true });
+        closed = true;
+        logger.info("runtime.closed");
+      } catch (error) {
+        logger.error("runtime.close_failed", { error: sanitizeError(error) });
+        throw error;
+      } finally {
+        if (!closed) closePromise = null;
+      }
+    })();
+    return closePromise;
+  };
+  return { app, database, store, ai, backups, auth, attachmentStorage, cleanupAttachments, close };
 }

--- a/src/s3-backup.ts
+++ b/src/s3-backup.ts
@@ -514,8 +514,29 @@ export class S3BackupManager {
     this.schedulerTimer.unref();
   }
 
-  async waitForIdle(): Promise<void> {
-    await this.executionChain;
+  async waitForIdle(timeoutMs?: number): Promise<void> {
+    const executionChain = this.executionChain;
+    if (timeoutMs === undefined) {
+      await executionChain;
+      return;
+    }
+    const normalizedTimeoutMs = Math.floor(timeoutMs);
+    if (!Number.isFinite(timeoutMs) || normalizedTimeoutMs < 1) {
+      throw new RangeError("S3 backup idle timeout must be a positive finite number");
+    }
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new AppError(
+        504,
+        "BACKUP_IDLE_TIMEOUT",
+        `等待 S3 备份执行链结束超时（${normalizedTimeoutMs} 毫秒）`
+      )), normalizedTimeoutMs);
+    });
+    try {
+      await Promise.race([executionChain, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   dispose(): void {

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -36,6 +36,7 @@ export const MIN_PRE_MIGRATION_BACKUP_RETENTION = 2;
 export const STARTUP_RETRY_LIMIT_ENV = "SCRIVERSE_STARTUP_RETRY_LIMIT";
 export const DEFAULT_STARTUP_RETRY_LIMIT = 2;
 export const STARTUP_RETRY_STATE_FILENAME = ".startup-retry.json";
+export const SERVER_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 export function isDevelopmentServer(environment: NodeJS.ProcessEnv): boolean {
   return environment.NODE_ENV === "development" || environment.npm_lifecycle_event === "dev";
@@ -237,7 +238,9 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
     const server = runtime.app.listen(options.port, options.host);
     const handleStartupError = (error: Error): void => {
       logger.error("server.start_failed", { host: options.host, port: options.port, error: sanitizeError(error) });
-      runtime.close();
+      void runtime.close().catch((closeError: unknown) => {
+        logger.error("server.runtime_close_failed", { error: sanitizeError(closeError) });
+      });
       rejectStart(error);
     };
     server.once("error", handleStartupError);
@@ -246,27 +249,32 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
       const address = server.address();
       if (!address || typeof address === "string") {
         server.close();
-        runtime.close();
+        void runtime.close().catch((closeError: unknown) => {
+          logger.error("server.runtime_close_failed", { error: sanitizeError(closeError) });
+        });
         rejectStart(new Error("Scriverse server did not expose a TCP port"));
         return;
       }
       const port = address.port;
       const displayHost = options.host.includes(":") ? `[${options.host}]` : options.host;
       clearStartupRetryState(options.dataDirectory);
-      let closed = false;
-      const close = async (): Promise<void> => {
-        if (closed) return;
-        closed = true;
-        logger.info("server.stopping", { host: options.host, port });
-        server.closeAllConnections();
-        try {
-          await new Promise<void>((resolveClose, rejectClose) => {
+      let closePromise: Promise<void> | null = null;
+      const close = (): Promise<void> => {
+        if (closePromise) return closePromise;
+        closePromise = (async () => {
+          logger.info("server.stopping", { host: options.host, port });
+          const serverClose = new Promise<void>((resolveClose, rejectClose) => {
             server.close((error) => error ? rejectClose(error) : resolveClose());
           });
-        } finally {
-          runtime.close();
-          logger.info("server.stopped", { host: options.host, port });
-        }
+          server.closeAllConnections();
+          try {
+            await serverClose;
+          } finally {
+            await runtime.close();
+            logger.info("server.stopped", { host: options.host, port });
+          }
+        })();
+        return closePromise;
       };
       resolveStart({
         server,
@@ -289,8 +297,16 @@ export function installServerShutdownHandlers(running: RunningLocalServer): void
     if (shuttingDown) return;
     shuttingDown = true;
     logger.info("server.shutdown_signal_received", { signal });
+    const forceExitTimer = setTimeout(() => {
+      logger.error("server.shutdown_timeout", { signal, timeoutMs: SERVER_SHUTDOWN_TIMEOUT_MS });
+      process.exit(1);
+    }, SERVER_SHUTDOWN_TIMEOUT_MS);
+    forceExitTimer.unref();
     void running.close().then(
-      () => { process.exitCode = 0; },
+      () => {
+        clearTimeout(forceExitTimer);
+        process.exitCode = 0;
+      },
       (error: unknown) => {
         logger.error("server.stop_failed", { signal, error: sanitizeError(error) });
         process.exitCode = 1;

--- a/tests/e2e/browser-ai-fixture.ts
+++ b/tests/e2e/browser-ai-fixture.ts
@@ -313,7 +313,7 @@ async function shutdown(): Promise<void> {
   server.close();
   mockAi.closeAllConnections();
   mockAi.close();
-  runtime.close();
+  await runtime.close();
   await rm(isolatedDirectory, { recursive: true, force: true });
   process.exit(0);
 }

--- a/tests/e2e/cli-server-fixture.ts
+++ b/tests/e2e/cli-server-fixture.ts
@@ -19,13 +19,18 @@ const server = runtime.app.listen(0, "127.0.0.1", () => {
   console.log(JSON.stringify({ baseUrl: `http://127.0.0.1:${address.port}` }));
 });
 
-function shutdown(): void {
-  server.closeAllConnections();
-  server.close(() => {
-    runtime.close();
-    process.exit(0);
+let shuttingDown = false;
+async function shutdown(): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  const serverClose = new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
   });
+  server.closeAllConnections();
+  await serverClose;
+  await runtime.close();
+  process.exit(0);
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
+process.on("SIGINT", () => { void shutdown(); });
+process.on("SIGTERM", () => { void shutdown(); });

--- a/tests/e2e/real-ai-agent-tools.ts
+++ b/tests/e2e/real-ai-agent-tools.ts
@@ -403,7 +403,7 @@ try {
     appServer.close();
     await once(appServer, "close");
   }
-  runtime?.close();
+  await runtime?.close();
   mockAi.close();
   if (mockAi.listening) await once(mockAi, "close");
   await rm(isolatedDirectory, { recursive: true, force: true });

--- a/tests/e2e/real-collaboration-refresh.ts
+++ b/tests/e2e/real-collaboration-refresh.ts
@@ -205,7 +205,7 @@ try {
 
     server.closeAllConnections();
     server.close();
-    runtime.close();
+    await runtime.close();
     await rm(isolatedDirectory, { recursive: true, force: true });
     process.exit(0);
   }
@@ -215,7 +215,7 @@ try {
   console.error(error);
   server.closeAllConnections();
   server.close();
-  runtime.close();
+  await runtime.close();
   await rm(isolatedDirectory, { recursive: true, force: true });
   process.exit(1);
 }
@@ -223,7 +223,7 @@ try {
 async function shutdown(): Promise<void> {
   server.closeAllConnections();
   server.close();
-  runtime.close();
+  await runtime.close();
   await rm(isolatedDirectory, { recursive: true, force: true });
   process.exit(0);
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,10 +14,18 @@ export function createTestRuntime(fetchImpl?: typeof fetch): Runtime {
   return {
     ...runtime,
     app: server as unknown as Runtime["app"],
-    close: () => {
-      server.closeAllConnections();
-      server.close();
-      runtime.close();
+    close: async () => {
+      try {
+        if (server.listening) {
+          const serverClose = new Promise<void>((resolve, reject) => {
+            server.close((error) => error ? reject(error) : resolve());
+          });
+          server.closeAllConnections();
+          await serverClose;
+        }
+      } finally {
+        await runtime.close();
+      }
     }
   };
 }

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -44,9 +44,9 @@ describe("AI 供应商、模型与建议 API", () => {
     chapterId = chapter.body.data.id;
     await request(runtime.app).post(`/api/works/${workId}/settings`).send({ title: "跃迁限制", category: "世界规则", content: "跃迁后必须冷却十二小时。", locked: true, status: "confirmed" });
   });
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
-    runtime.close();
+    await runtime.close();
   });
 
   async function configureAi(): Promise<{ providerId: string; modelId: string }> {

--- a/tests/integration/ai-prompt-cache-stability.test.ts
+++ b/tests/integration/ai-prompt-cache-stability.test.ts
@@ -112,9 +112,9 @@ describe("AI 多轮 prompt cache 稳定性", () => {
     }).expect(200);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
-    runtime.close();
+    await runtime.close();
   });
 
   async function streamTurn(instruction: string, scope: Record<string, unknown>, conversationId?: string): Promise<string> {

--- a/tests/integration/ai-usage-api.test.ts
+++ b/tests/integration/ai-usage-api.test.ts
@@ -10,9 +10,9 @@ describe("AI Token 用量统计 API", () => {
     runtime = createTestRuntime();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.unstubAllEnvs();
-    runtime.close();
+    await runtime.close();
   });
 
   it("按项目、作品和本地日期聚合 token 与缓存命中率", async () => {

--- a/tests/integration/analysis-task-model.test.ts
+++ b/tests/integration/analysis-task-model.test.ts
@@ -6,8 +6,8 @@ import { createTestRuntime } from "../helpers.js";
 describe("AI 分析任务模型", () => {
   let runtime: Runtime | null = null;
 
-  afterEach(() => {
-    runtime?.close();
+  afterEach(async () => {
+    await runtime?.close();
     runtime = null;
   });
 

--- a/tests/integration/analysis-task-trace.test.ts
+++ b/tests/integration/analysis-task-trace.test.ts
@@ -6,8 +6,8 @@ import { createTestRuntime } from "../helpers.js";
 describe("AI 分析全流程追踪", () => {
   let runtime: Runtime | null = null;
 
-  afterEach(() => {
-    runtime?.close();
+  afterEach(async () => {
+    await runtime?.close();
     runtime = null;
   });
 

--- a/tests/integration/anthropic-messages-api.test.ts
+++ b/tests/integration/anthropic-messages-api.test.ts
@@ -139,8 +139,8 @@ describe("Anthropic Messages 供应商", () => {
     expect(tested.body.data).toMatchObject({ ok: true, availableModels: ["LongCat-2.0"] });
   });
 
-  afterEach(() => {
-    runtime.close();
+  afterEach(async () => {
+    await runtime.close();
   });
 
   it("通过 LongCat Messages 格式完成工具调用与普通响应", async () => {

--- a/tests/integration/character-markdown-attachments.test.ts
+++ b/tests/integration/character-markdown-attachments.test.ts
@@ -8,7 +8,7 @@ describe("人物 Markdown 章节与附件", () => {
   let runtime: ReturnType<typeof createTestRuntime>;
 
   beforeEach(() => { runtime = createTestRuntime(); });
-  afterEach(() => { runtime.close(); });
+  afterEach(() => runtime.close());
 
   it("将上传图片转为更小的无损 WebP 并按内容去重", async () => {
     const work = await createWork(runtime);

--- a/tests/integration/google-vertex-api.test.ts
+++ b/tests/integration/google-vertex-api.test.ts
@@ -84,8 +84,8 @@ describe("Google Vertex 供应商 API", () => {
     chapterId = chapter.body.data.id;
   });
 
-  afterEach(() => {
-    runtime.close();
+  afterEach(async () => {
+    await runtime.close();
   });
 
   it("拒绝非法服务账号 JSON，并在合法配置下换票后完成探测与调用", async () => {

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -6,8 +6,8 @@ import { createTestRuntime, seedChapter } from "../helpers.js";
 describe("作品混合检索", () => {
   let runtime: Runtime | null = null;
 
-  afterEach(() => {
-    runtime?.close();
+  afterEach(async () => {
+    await runtime?.close();
     runtime = null;
   });
 

--- a/tests/integration/longcat-multiturn.test.ts
+++ b/tests/integration/longcat-multiturn.test.ts
@@ -73,8 +73,8 @@ describe("LongCat OpenAI 多轮推理兼容", () => {
     await request(runtime.app).post(`/api/providers/${provider.body.data.id}/test`).send({}).expect(200);
   });
 
-  afterEach(() => {
-    runtime.close();
+  afterEach(async () => {
+    await runtime.close();
   });
 
   it("在下一轮恢复流式响应中的 reasoning_content", async () => {
@@ -193,8 +193,8 @@ describe("LongCat Anthropic 多轮思考兼容", () => {
     await request(runtime.app).post(`/api/providers/${provider.body.data.id}/test`).send({}).expect(200);
   });
 
-  afterEach(() => {
-    runtime.close();
+  afterEach(async () => {
+    await runtime.close();
   });
 
   it("在下一轮恢复流式响应中的 thinking 和 signature", async () => {

--- a/tests/integration/multimodal-image-tool.test.ts
+++ b/tests/integration/multimodal-image-tool.test.ts
@@ -6,8 +6,8 @@ import { createTestRuntime } from "../helpers.js";
 describe("Agent 多模态图片工具", () => {
   let runtime: Runtime | undefined;
 
-  afterEach(() => {
-    runtime?.close();
+  afterEach(async () => {
+    await runtime?.close();
     runtime = undefined;
   });
 

--- a/tests/integration/pagination-api.test.ts
+++ b/tests/integration/pagination-api.test.ts
@@ -21,7 +21,7 @@ describe("列表 API 分页", () => {
       expect(secondPage.body.data).toMatchObject({ page: 2, limit: 2, hasMore: false, nextPage: null });
       expect(secondPage.body.data.items).toHaveLength(1);
     } finally {
-      runtime.close();
+      await runtime.close();
     }
   });
 
@@ -38,7 +38,7 @@ describe("列表 API 分页", () => {
       expect(page.body.data).toMatchObject({ page: 2, limit: 2, hasMore: false, nextPage: null, total: 3 });
       expect(page.body.data.items).toHaveLength(1);
     } finally {
-      runtime.close();
+      await runtime.close();
     }
   });
 
@@ -49,7 +49,7 @@ describe("列表 API 分页", () => {
       await request(runtime.app).get("/api/works?page=0").expect(400);
       await request(runtime.app).get("/api/works?page=1&page=2").expect(400);
     } finally {
-      runtime.close();
+      await runtime.close();
     }
   });
 });

--- a/tests/integration/relationship-search-index.test.ts
+++ b/tests/integration/relationship-search-index.test.ts
@@ -7,8 +7,8 @@ import { createTestRuntime, seedChapter } from "../helpers.js";
 describe("人物关系来源增量索引", () => {
   let runtime: Runtime | null = null;
 
-  afterEach(() => {
-    runtime?.close();
+  afterEach(async () => {
+    await runtime?.close();
     runtime = null;
   });
 

--- a/tests/integration/s3-backup-config.test.ts
+++ b/tests/integration/s3-backup-config.test.ts
@@ -26,8 +26,8 @@ async function register(runtime: Runtime, username: string): Promise<{
 describe("S3 备份目标配置 API", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    for (const runtime of runtimes.splice(0)) runtime.close();
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.close();
   });
 
   it("保存多个目标并加密凭据、规范化目录及保留未更新的凭据", async () => {

--- a/tests/integration/s3-backup-execution.test.ts
+++ b/tests/integration/s3-backup-execution.test.ts
@@ -1,4 +1,8 @@
 import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { createRuntime, type Runtime } from "../../src/app.js";
 import { createLogger, type LogRecord } from "../../src/logger.js";
@@ -54,11 +58,12 @@ class FakeS3Client implements S3ObjectClient {
 
 function testRuntime(options: {
   clientFactory: (connection: S3BackupConnection) => S3ObjectClient;
+  databasePath?: string;
   loggerRecords?: LogRecord[];
   requestTimeoutMs?: number;
 }): Runtime {
   return createRuntime({
-    databasePath: ":memory:",
+    databasePath: options.databasePath ?? ":memory:",
     masterSecret: "s3-execution-test-master-secret-with-enough-length",
     disableUserAuth: true,
     serveUi: false,
@@ -78,9 +83,11 @@ function testRuntime(options: {
 
 describe("S3 数据库与图片备份执行", () => {
   const runtimes: Runtime[] = [];
+  const roots: string[] = [];
 
-  afterEach(() => {
-    for (const runtime of runtimes.splice(0)) runtime.close();
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.close();
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
   it("上传时间戳数据库、跳过已有图片并只清理最老数据库", async () => {
@@ -303,5 +310,75 @@ describe("S3 数据库与图片备份执行", () => {
     expect(run.status).toBe("failed");
     expect(run.errorMessage).toContain("上传 CredentialVault 恢复密钥超时");
     expect(closed).toBe(true);
+  });
+
+  it("关闭运行时前限时等待执行中的备份完成并落盘最终状态", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-backup-shutdown-"));
+    roots.push(root);
+    const databasePath = join(root, "novel.db");
+    let releaseUpload = (): void => {
+      throw new Error("Upload gate was not initialized");
+    };
+    const uploadGate = new Promise<void>((resolve) => {
+      releaseUpload = resolve;
+    });
+    let notifyUploadStarted = (): void => {
+      throw new Error("Upload start notifier was not initialized");
+    };
+    const uploadStarted = new Promise<void>((resolve) => {
+      notifyUploadStarted = resolve;
+    });
+    let uploadCount = 0;
+    const client: S3ObjectClient = {
+      objectExists: async () => false,
+      putObject: async () => {
+        uploadCount += 1;
+        if (uploadCount !== 1) return;
+        notifyUploadStarted();
+        await uploadGate;
+      },
+      listObjects: async () => [],
+      deleteObjects: async () => undefined,
+      close: () => undefined
+    };
+    const runtime = testRuntime({ databasePath, clientFactory: () => client });
+    runtimes.push(runtime);
+    const target = runtime.backups.createTarget({
+      name: "关闭等待目标",
+      endpoint: "https://shutdown.example.com",
+      bucket: "backup-bucket",
+      accessKeyId: "access-shutdown",
+      secretAccessKey: "secret-shutdown",
+      enabled: true,
+      backupImages: false
+    });
+    runtime.backups.enqueueTargets([target.id], "manual");
+    await uploadStarted;
+
+    await expect(runtime.backups.waitForIdle(10)).rejects.toMatchObject({ code: "BACKUP_IDLE_TIMEOUT" });
+    expect(runtime.backups.listRuns().items).toEqual([
+      expect.objectContaining({ targetId: target.id, status: "running", finishedAt: null })
+    ]);
+
+    let closeSettled = false;
+    const closePromise = runtime.close().finally(() => {
+      closeSettled = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeSettled).toBe(false);
+    expect(() => runtime.backups.enqueueTargets([target.id], "manual")).toThrow("S3 备份服务正在停止");
+
+    releaseUpload();
+    await closePromise;
+    const database = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(database.prepare("SELECT COUNT(*) AS count FROM s3_backup_runs WHERE status = 'running'").get()).toEqual({ count: 0 });
+      expect(database.prepare("SELECT status, finished_at FROM s3_backup_runs WHERE target_id = ?").get(target.id)).toMatchObject({
+        status: "succeeded",
+        finished_at: expect.any(String)
+      });
+    } finally {
+      database.close();
+    }
   });
 });

--- a/tests/integration/s3-backup-scheduler.test.ts
+++ b/tests/integration/s3-backup-scheduler.test.ts
@@ -34,8 +34,8 @@ class SchedulerS3Client implements S3ObjectClient {
 describe("S3 备份调度与运行事件 API", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    for (const runtime of runtimes.splice(0)) runtime.close();
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.close();
   });
 
   it("按服务器本地时间补跑当天任务、避免重复并保持目标串行", async () => {

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -1,14 +1,17 @@
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { Agent, request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { isDevelopmentAuthBypassEnabled, resolveRuntimeSecurity } from "../../src/security.js";
 import {
   isDevelopmentServer,
   isLoopbackHost,
   PRE_MIGRATION_BACKUP_RETENTION_ENV,
+  SERVER_SHUTDOWN_TIMEOUT_MS,
   STARTUP_RETRY_LIMIT_ENV,
   STARTUP_RETRY_STATE_FILENAME,
+  installServerShutdownHandlers,
   resolvePreMigrationBackupRetention,
   resolveStartupRetryLimit,
   startLocalServer,
@@ -211,6 +214,72 @@ describe("本地服务运行时", () => {
     chmodSync(masterKeyPath, 0o644);
     expect(loadMasterSecret(masterKeyPath)).toHaveLength(43);
     expect(statSync(masterKeyPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("关闭服务时主动清理 keep-alive 连接并完成运行时关闭", async () => {
+    const root = mkdtempSync(join(tmpdir(), "scriverse-keep-alive-close-"));
+    roots.push(root);
+    const running = await startLocalServer({
+      host: "127.0.0.1",
+      port: 0,
+      dataDirectory: root,
+      databasePath: join(root, "novel.db"),
+      env: { NODE_ENV: "test" }
+    });
+    runningServers.push(running);
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const request = httpRequest(`${running.url}/api/health`, { agent }, (response) => {
+          response.resume();
+          response.once("end", resolve);
+        });
+        request.once("error", reject);
+        request.end();
+      });
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const closeTimeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("Server close did not finish with an idle keep-alive connection")), 1_000);
+        timer.unref();
+      });
+      try {
+        await Promise.race([running.close(), closeTimeout]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  it("收到关闭信号后十秒未结束则强制退出", async () => {
+    vi.useFakeTimers();
+    const originalSigintListeners = new Set(process.listeners("SIGINT"));
+    const originalSigtermListeners = new Set(process.listeners("SIGTERM"));
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    let sigintListener: NodeJS.SignalsListener | undefined;
+    let sigtermListener: NodeJS.SignalsListener | undefined;
+    try {
+      installServerShutdownHandlers({
+        close: () => new Promise<void>(() => undefined)
+      } as RunningLocalServer);
+      sigintListener = process.listeners("SIGINT").find((listener) => !originalSigintListeners.has(listener));
+      sigtermListener = process.listeners("SIGTERM").find((listener) => !originalSigtermListeners.has(listener));
+      expect(sigintListener).toBeTypeOf("function");
+      expect(sigtermListener).toBeTypeOf("function");
+
+      sigtermListener?.("SIGTERM");
+      await vi.advanceTimersByTimeAsync(SERVER_SHUTDOWN_TIMEOUT_MS - 1);
+      expect(exit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(exit).toHaveBeenCalledOnce();
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      if (sigintListener) process.removeListener("SIGINT", sigintListener);
+      if (sigtermListener) process.removeListener("SIGTERM", sigtermListener);
+      exit.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("升级数据库前完整备份数据库、主密钥和附件", async () => {

--- a/tests/integration/task-auto-run.test.ts
+++ b/tests/integration/task-auto-run.test.ts
@@ -89,8 +89,8 @@ async function setupWork(fetchMock: typeof fetch): Promise<{
 describe("分析任务自动运行", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("校验自动运行设置并返回任务范围摘要", async () => {

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -63,9 +63,9 @@ function createUserAuthTestRuntime(allowRegistration = true): Runtime {
   return {
     ...runtime,
     app: authTestServer as unknown as Runtime["app"],
-    close: () => {
+    close: async () => {
       if (activeRuntimeApp === runtime.app) activeRuntimeApp = null;
-      runtime.close();
+      await runtime.close();
     }
   };
 }
@@ -368,7 +368,7 @@ describe("用户、作品权限与操作者追踪 API", () => {
       });
       const user = await register(firstRuntime, "restart_user");
       await user.agent.get("/api/auth/session").expect(200);
-      firstRuntime.close();
+      await firstRuntime.close();
       firstRuntime = null;
 
       restartedRuntime = createRuntime({
@@ -392,8 +392,8 @@ describe("用户、作品权限与操作者追踪 API", () => {
         ...captcha
       }).expect(200);
     } finally {
-      restartedRuntime?.close();
-      firstRuntime?.close();
+      await restartedRuntime?.close();
+      await firstRuntime?.close();
       rmSync(root, { recursive: true, force: true });
     }
   });
@@ -2252,7 +2252,7 @@ describe("用户、作品权限与操作者追踪 API", () => {
   });
 
   it("未显式开启注册时连首位管理员注册也会被拒绝", async () => {
-    runtime.close();
+    await runtime.close();
     runtime = createUserAuthTestRuntime(false);
     const closedSession = await request(runtime.app).get("/api/auth/session").expect(200);
     expect(closedSession.body.data).toMatchObject({ setupRequired: true, registrationOpen: false });

--- a/tests/integration/zhipu-anthropic-multiturn.test.ts
+++ b/tests/integration/zhipu-anthropic-multiturn.test.ts
@@ -82,8 +82,8 @@ describe("智谱 Anthropic 多轮思考兼容", () => {
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
   });
 
-  afterEach(() => {
-    runtime.close();
+  afterEach(async () => {
+    await runtime.close();
   });
 
   it("在下一轮恢复流式响应中的 thinking 和 signature", async () => {

--- a/tests/system/ai-history-dialog.test.ts
+++ b/tests/system/ai-history-dialog.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("AI 对话历史弹窗", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("将历史列表放入独立弹窗并保留会话切换交互", async () => {

--- a/tests/system/ai-mention-chips.test.ts
+++ b/tests/system/ai-mention-chips.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("AI 输入框引用气泡", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("将引用放入可编辑输入框并移除上方引用区", async () => {

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -62,7 +62,7 @@ describe("作者完整创作流程", () => {
   });
 
   afterAll(async () => {
-    runtime.close();
+    await runtime.close();
     mockServer.close();
     await once(mockServer, "close");
   });

--- a/tests/system/book-summary-reference.test.ts
+++ b/tests/system/book-summary-reference.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("全书概要上下文引用", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("默认不引用上下文并保留显式的章节与全书范围", async () => {

--- a/tests/system/editor-toolbar-layout.test.ts
+++ b/tests/system/editor-toolbar-layout.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("编辑器工具栏布局", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("让章节路径独占首行，并统一侧栏工具按钮尺寸", async () => {

--- a/tests/system/global-replace-ui.test.ts
+++ b/tests/system/global-replace-ui.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("全局替换界面", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("提供正文默认范围、设定库范围和正文加设定库范围", async () => {

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("知识模块布局切换", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("设定、角色、种族、组织、伏笔与审核保留卡片并支持列表切换", async () => {

--- a/tests/system/product-footer.test.ts
+++ b/tests/system/product-footer.test.ts
@@ -78,7 +78,7 @@ describe("产品信息页脚", () => {
       expect(update.body.data.checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/u);
       expect(update.body.data.nextCheckAt).toMatch(/^\d{4}-\d{2}-\d{2}T/u);
     } finally {
-      releaseRuntime.close();
+      await releaseRuntime.close();
     }
   });
 

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -5,8 +5,8 @@ import { createRuntime, type Runtime } from "../../src/app.js";
 describe("人物关系图搜索界面", () => {
   const runtimes: Runtime[] = [];
 
-  afterEach(() => {
-    while (runtimes.length) runtimes.pop()?.close();
+  afterEach(async () => {
+    while (runtimes.length) await runtimes.pop()?.close();
   });
 
   it("在普通图、放大图和银河图提供可访问的人物搜索与定位入口", async () => {

--- a/tests/system/system-restart-dialog.test.ts
+++ b/tests/system/system-restart-dialog.test.ts
@@ -32,7 +32,7 @@ describe("系统重启认证清理", () => {
       expect(second.body.data.bootId).toMatch(/^[0-9a-f-]{36}$/u);
       expect(second.body.data.bootId).not.toBe(first.body.data.bootId);
     } finally {
-      secondRuntime.close();
+      await secondRuntime.close();
     }
   });
 

--- a/tests/unit/ai-conversation-system-clock.test.ts
+++ b/tests/unit/ai-conversation-system-clock.test.ts
@@ -3,7 +3,9 @@ import { createTestRuntime, seedChapter } from "../helpers.js";
 
 describe("AI 对话 system 时钟冻结", () => {
   const runtimes: ReturnType<typeof createTestRuntime>[] = [];
-  afterEach(() => runtimes.splice(0).forEach((runtime) => runtime.close()));
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.close();
+  });
 
   it("首轮写入后禁止更新，分支对话继承原时钟", async () => {
     const runtime = createTestRuntime();

--- a/tests/unit/context-builder.test.ts
+++ b/tests/unit/context-builder.test.ts
@@ -4,7 +4,9 @@ import { createTestRuntime, seedChapter } from "../helpers.js";
 
 describe("AI 上下文组装", () => {
   const runtimes: ReturnType<typeof createTestRuntime>[] = [];
-  afterEach(() => runtimes.splice(0).forEach((runtime) => runtime.close()));
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.close();
+  });
 
   it("正文范围默认注入轻量组织/种族与锁定设定，不含组织设定正文", async () => {
     const runtime = createTestRuntime();

--- a/tests/unit/keyword-entity-inject.test.ts
+++ b/tests/unit/keyword-entity-inject.test.ts
@@ -4,7 +4,9 @@ import { createTestRuntime, seedChapter } from "../helpers.js";
 
 describe("AI 关键词实体注入", () => {
   const runtimes: ReturnType<typeof createTestRuntime>[] = [];
-  afterEach(() => runtimes.splice(0).forEach((runtime) => runtime.close()));
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) await runtime.close();
+  });
 
   it("按主名与别名最长匹配角色，并匹配种族与组织名", async () => {
     const runtime = createTestRuntime();


### PR DESCRIPTION
## 变更摘要

- 停止 S3 备份调度后，限时等待现有执行链完成，再关闭数据库。
- 调整 HTTP 服务关闭顺序，并在信号关闭超过 10 秒时强制退出。
- 将 `Runtime.close()` 调整为异步接口，并同步等待所有现有调用方。
- 覆盖 keep-alive 连接、S3 上传执行中关闭和强制退出兜底。

## 验证

- `npx vitest run tests/integration/s3-backup-execution.test.ts tests/integration/s3-backup-scheduler.test.ts tests/integration/server-runtime.test.ts --maxWorkers=1`（23 项通过）
- `npm run typecheck`
- `npm test`（136 个测试文件、700 项测试通过）
- `npm run build`

关联 MUXUE-23。
