### PR TITLE
MUXUE-13: add missing list query indexes

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -6,7 +6,7 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-export const DATABASE_SCHEMA_VERSION = 80;
+export const DATABASE_SCHEMA_VERSION = 81;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -726,6 +726,8 @@ export class Database {
       CREATE INDEX IF NOT EXISTS idx_volumes_work ON volumes(work_id, sort_order);
       CREATE INDEX IF NOT EXISTS idx_chapters_work ON chapters(work_id, volume_id, sort_order);
       CREATE INDEX IF NOT EXISTS idx_versions_chapter ON chapter_versions(chapter_id, version_no DESC);
+      CREATE INDEX IF NOT EXISTS idx_file_versions_work ON file_versions(work_id, created_at DESC, id DESC);
+      CREATE INDEX IF NOT EXISTS idx_chapter_insights_chapter ON chapter_insights(chapter_id, chapter_version DESC, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_settings_work ON settings(work_id, category);
       CREATE INDEX IF NOT EXISTS idx_drafts_work ON drafts(work_id, draft_type, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_characters_work ON characters(work_id, name);
@@ -736,6 +738,7 @@ export class Database {
       CREATE INDEX IF NOT EXISTS idx_character_merges_work ON character_merges(work_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_tasks_work ON analysis_tasks(work_id, status);
       CREATE INDEX IF NOT EXISTS idx_calls_work ON ai_calls(work_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_ai_suggestions_work ON ai_suggestions(work_id, status, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_ai_conversations_work ON ai_conversations(work_id, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_ai_conversation_messages ON ai_conversation_messages(conversation_id, created_at);
       CREATE INDEX IF NOT EXISTS idx_audit_logs_work_created ON audit_logs(work_id, created_at DESC);
@@ -3217,6 +3220,20 @@ export class Database {
       this.transaction(() => {
         this.run("CREATE INDEX IF NOT EXISTS idx_audit_logs_work_created ON audit_logs(work_id, created_at DESC)");
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (80, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    if (!applied.has(81)) {
+      this.transaction(() => {
+        this.run("CREATE INDEX IF NOT EXISTS idx_ai_suggestions_work ON ai_suggestions(work_id, status, created_at DESC)");
+        this.run("CREATE INDEX IF NOT EXISTS idx_file_versions_work ON file_versions(work_id, created_at DESC, id DESC)");
+        this.run("CREATE INDEX IF NOT EXISTS idx_chapter_insights_chapter ON chapter_insights(chapter_id, chapter_version DESC, created_at DESC)");
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (81, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -3233,14 +3233,14 @@ export class Database {
         this.run("CREATE INDEX IF NOT EXISTS idx_ai_suggestions_work ON ai_suggestions(work_id, status, created_at DESC)");
         this.run("CREATE INDEX IF NOT EXISTS idx_file_versions_work ON file_versions(work_id, created_at DESC, id DESC)");
         this.run("CREATE INDEX IF NOT EXISTS idx_chapter_insights_chapter ON chapter_insights(chapter_id, chapter_version DESC, created_at DESC)");
+        const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+        if (integrity.some((row) => row.integrity_check !== "ok")) {
+          throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+        }
+        const foreignKeys = this.all("PRAGMA foreign_key_check");
+        if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (81, ?)", new Date().toISOString());
       });
-      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
-      if (integrity.some((row) => row.integrity_check !== "ok")) {
-        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
-      }
-      const foreignKeys = this.all("PRAGMA foreign_key_check");
-      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
     }
   }
 

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -596,6 +596,34 @@ describe("数据库版本化迁移", () => {
     restarted.close();
   });
 
+  it("迁移 81 的外键检查失败时不登记版本并连续阻断启动", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-list-index-invalid-"));
+    roots.push(root);
+    const filename = join(root, "list-index-invalid.db");
+    const current = new Database(filename);
+    current.run("DROP INDEX idx_ai_suggestions_work");
+    current.run("DROP INDEX idx_file_versions_work");
+    current.run("DROP INDEX idx_chapter_insights_chapter");
+    current.run("DELETE FROM schema_migrations WHERE version = 81");
+    current.close();
+
+    const invalid = new DatabaseSync(filename);
+    invalid.exec("PRAGMA foreign_keys = OFF");
+    invalid.prepare(
+      `INSERT INTO file_versions (id, work_id, file_name, file_type, word_count, paragraph_count, snapshot_json, created_at)
+       VALUES ('file-version-invalid-work', 'work-missing', 'invalid.txt', 'txt', 0, 0, '{}', '2026-08-10T00:00:00.000Z')`
+    ).run();
+    invalid.close();
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(() => new Database(filename)).toThrow("数据库外键检查失败：发现 1 条异常记录");
+      const inspected = new DatabaseSync(filename);
+      expect(inspected.prepare("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 81").get()?.count).toBe(0);
+      expect(inspected.prepare("PRAGMA foreign_key_check").all()).toHaveLength(1);
+      inspected.close();
+    }
+  });
+
   it("迁移 53 只重排可重建索引并保留领域数据", () => {
     const filename = createLegacyDatabase();
     const current = new Database(filename);

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -302,7 +302,7 @@ describe("数据库版本化迁移", () => {
     second.close();
   });
 
-  it("从已有迁移 74 平滑升级到 80 并重建 AI 历史短词索引", () => {
+  it("从已有迁移 74 平滑升级到 81 并重建 AI 历史短词索引", () => {
     const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-74-upgrade-"));
     roots.push(root);
     const filename = join(root, "migration-74.db");
@@ -320,7 +320,7 @@ describe("数据库版本化迁移", () => {
       VALUES ('conversation-migration-74', 'work-migration-74', '旧对话', '重复重复', '2025-01-01', '2025-01-01');
       DROP TABLE s3_backup_runs;
       DROP TABLE s3_backup_targets;
-      DELETE FROM schema_migrations WHERE version IN (75, 76, 77, 78, 79, 80);
+      DELETE FROM schema_migrations WHERE version IN (75, 76, 77, 78, 79, 80, 81);
     `);
     const searchRow = legacy.prepare(
       "SELECT id FROM ai_history_search WHERE source_type = 'conversation' AND source_id = 'conversation-migration-74'"
@@ -366,7 +366,7 @@ describe("数据库版本化迁移", () => {
       );
       INSERT INTO platform_ui_settings (id, toast_position, page_sizes_json, galaxy_frame_rate, updated_at)
       VALUES (1, 'top-right', '{"characters":25}', 60, '2026-08-09T00:00:00.000Z');
-      DELETE FROM schema_migrations WHERE version IN (78, 79, 80);
+      DELETE FROM schema_migrations WHERE version IN (78, 79, 80, 81);
     `);
     legacy.close();
 
@@ -403,7 +403,7 @@ describe("数据库版本化迁移", () => {
       );
       INSERT INTO platform_ui_settings (id, toast_position, page_sizes_json, galaxy_frame_rate, updated_at)
       VALUES (1, 'top-right', '{"characters":25}', 120, '2026-08-09T00:00:00.000Z');
-      DELETE FROM schema_migrations WHERE version IN (79, 80);
+      DELETE FROM schema_migrations WHERE version IN (79, 80, 81);
     `);
     legacy.close();
 
@@ -475,6 +475,122 @@ describe("数据库版本化迁移", () => {
     const restarted = new Database(filename);
     expect(restarted.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 80")).toEqual({ count: 1 });
     expect(restarted.all("PRAGMA index_list(audit_logs)").filter((index) => index.name === "idx_audit_logs_work_created")).toHaveLength(1);
+    expect(restarted.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(restarted.all("PRAGMA foreign_key_check")).toEqual([]);
+    restarted.close();
+  });
+
+  it("迁移 81 为既有库补建列表索引并保留领域数据", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-list-index-existing-"));
+    roots.push(root);
+    const filename = join(root, "list-index-existing.db");
+    const current = new Database(filename);
+    const timestamp = "2026-08-10T00:00:00.000Z";
+    current.run(
+      `INSERT INTO works (id, title, created_at, updated_at)
+       VALUES ('work-list-index', '列表索引迁移', ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO volumes (id, work_id, title, sort_order, created_at, updated_at)
+       VALUES ('volume-list-index', 'work-list-index', '第一卷', 0, ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO chapters (id, work_id, volume_id, title, sort_order, created_at, updated_at)
+       VALUES ('chapter-list-index', 'work-list-index', 'volume-list-index', '第一章', 0, ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO ai_calls (id, work_id, task_type, provider_id, model_id, context_scope_json, status, created_at)
+       VALUES ('call-list-index', 'work-list-index', 'chat', 'provider-list-index', 'model-list-index', '{}', 'succeeded', ?)`,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO ai_suggestions (id, call_id, work_id, chapter_id, chapter_version, task_type, instruction, content, status, created_at)
+       VALUES ('suggestion-before-index', 'call-list-index', 'work-list-index', 'chapter-list-index', 1, 'chat', '迁移', '保留建议', 'pending', ?)`,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO file_versions (id, work_id, file_name, file_type, word_count, paragraph_count, snapshot_json, created_at)
+       VALUES ('file-version-before-index', 'work-list-index', 'before.txt', 'txt', 4, 1, '{}', ?)`,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO chapter_insights (id, chapter_id, chapter_version, summary, created_at)
+       VALUES ('insight-before-index', 'chapter-list-index', 1, '保留洞察', ?)`,
+      timestamp
+    );
+    current.run("DROP INDEX idx_ai_suggestions_work");
+    current.run("DROP INDEX idx_file_versions_work");
+    current.run("DROP INDEX idx_chapter_insights_chapter");
+    current.run("DELETE FROM schema_migrations WHERE version = 81");
+    current.close();
+
+    const migrated = new Database(filename);
+    expect(migrated.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 81")).toEqual({ count: 1 });
+    expect(migrated.all("PRAGMA index_xinfo('idx_ai_suggestions_work')")
+      .filter((column) => column.key === 1)
+      .map((column) => ({ name: column.name, desc: column.desc }))).toEqual([
+      { name: "work_id", desc: 0 },
+      { name: "status", desc: 0 },
+      { name: "created_at", desc: 1 }
+    ]);
+    expect(migrated.all("PRAGMA index_xinfo('idx_file_versions_work')")
+      .filter((column) => column.key === 1)
+      .map((column) => ({ name: column.name, desc: column.desc }))).toEqual([
+      { name: "work_id", desc: 0 },
+      { name: "created_at", desc: 1 },
+      { name: "id", desc: 1 }
+    ]);
+    expect(migrated.all("PRAGMA index_xinfo('idx_chapter_insights_chapter')")
+      .filter((column) => column.key === 1)
+      .map((column) => ({ name: column.name, desc: column.desc }))).toEqual([
+      { name: "chapter_id", desc: 0 },
+      { name: "chapter_version", desc: 1 },
+      { name: "created_at", desc: 1 }
+    ]);
+    expect(migrated.get("SELECT id FROM ai_suggestions WHERE id = 'suggestion-before-index'")).toEqual({ id: "suggestion-before-index" });
+    expect(migrated.get("SELECT id FROM file_versions WHERE id = 'file-version-before-index'")).toEqual({ id: "file-version-before-index" });
+    expect(migrated.get("SELECT id FROM chapter_insights WHERE id = 'insight-before-index'")).toEqual({ id: "insight-before-index" });
+    expect(migrated.all(
+      "EXPLAIN QUERY PLAN SELECT * FROM ai_suggestions WHERE work_id = ? AND status = ? ORDER BY created_at DESC",
+      "work-list-index",
+      "pending"
+    ).some((step) => String(step.detail).includes("USING INDEX idx_ai_suggestions_work"))).toBe(true);
+    expect(migrated.all(
+      "EXPLAIN QUERY PLAN SELECT * FROM file_versions WHERE work_id = ? ORDER BY created_at DESC, id DESC",
+      "work-list-index"
+    ).some((step) => String(step.detail).includes("USING INDEX idx_file_versions_work"))).toBe(true);
+    expect(migrated.all(
+      "EXPLAIN QUERY PLAN SELECT * FROM chapter_insights WHERE chapter_id = ? ORDER BY chapter_version DESC, created_at DESC",
+      "chapter-list-index"
+    ).some((step) => String(step.detail).includes("USING INDEX idx_chapter_insights_chapter"))).toBe(true);
+    expect(migrated.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
+    migrated.close();
+  });
+
+  it("迁移 81 在全新库预建三个列表索引后可幂等登记并重启", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-list-index-fresh-"));
+    roots.push(root);
+    const filename = join(root, "list-index-fresh.db");
+
+    const first = new Database(filename);
+    expect(first.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 81")).toEqual({ count: 1 });
+    expect(first.all("PRAGMA index_list(ai_suggestions)").filter((index) => index.name === "idx_ai_suggestions_work")).toHaveLength(1);
+    expect(first.all("PRAGMA index_list(file_versions)").filter((index) => index.name === "idx_file_versions_work")).toHaveLength(1);
+    expect(first.all("PRAGMA index_list(chapter_insights)").filter((index) => index.name === "idx_chapter_insights_chapter")).toHaveLength(1);
+    first.close();
+
+    const restarted = new Database(filename);
+    expect(restarted.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 81")).toEqual({ count: 1 });
+    expect(restarted.all("PRAGMA index_list(ai_suggestions)").filter((index) => index.name === "idx_ai_suggestions_work")).toHaveLength(1);
+    expect(restarted.all("PRAGMA index_list(file_versions)").filter((index) => index.name === "idx_file_versions_work")).toHaveLength(1);
+    expect(restarted.all("PRAGMA index_list(chapter_insights)").filter((index) => index.name === "idx_chapter_insights_chapter")).toHaveLength(1);
     expect(restarted.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
     expect(restarted.all("PRAGMA foreign_key_check")).toEqual([]);
     restarted.close();


### PR DESCRIPTION
## Summary

- add schema migration 81 for the three missing list query indexes
- precreate the indexes for fresh databases and keep upgrades idempotent
- keep index creation, integrity and foreign-key checks, and version registration in one failure-atomic transaction
- cover legacy data preservation, index shape, query plans, restart behavior, and two consecutive blocked starts for an invalid database

## Validation

- `npm run typecheck`
- `npx vitest run tests/unit/database-migration.test.ts tests/integration/database-upgrade-fixture.test.ts --maxWorkers=1` (2 files, 21 tests)
- `npx vitest run tests/integration/ai-api.test.ts tests/integration/work-chapter-api.test.ts --maxWorkers=1` (2 files, 79 tests)
- `npm test` (136 files, 702 tests)
- `npm run build`

Closes MUXUE-13
