### PR TITLE
MUXUE-8: complete streamed tool execution

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -3283,11 +3283,7 @@ export class AiManager {
       && titleModelId
       && (conversationBefore?.title === "新对话" || conversationBefore?.title === defaultTitle)
     );
-    const chatTools = this.enabledAgentTools(input.workId, "chat", input.agentToolIds, input.conversationId);
-    const generated = chatTools.length
-      ? await this.generate({ ...input, taskType: "chat" })
-      : await this.generateStream({ ...input, taskType: "chat" }, onDelta);
-    if (chatTools.length) onDelta(generated.content);
+    const generated = await this.generate({ ...input, taskType: "chat" }, onDelta);
     const chapter = input.scope.chapterId ? this.store.getChapter(input.scope.chapterId) : null;
     const suggestionId = id("suggestion");
     this.store.db.run(
@@ -4948,7 +4944,7 @@ export class AiManager {
     });
   }
 
-  async generate(input: GenerateInput): Promise<GenerateResult> {
+  async generate(input: GenerateInput, onDelta?: (delta: string) => void): Promise<GenerateResult> {
     const generationRoleplayCharacterId = this.roleplayCharacterId(input.workId, input.conversationId);
     const { model, provider } = this.resolveModel(input.workId, input.taskType, input.modelId);
     const preset = safeJsonObject(stringValue(model, "preset_json"));
@@ -5041,7 +5037,7 @@ export class AiManager {
       providerId: stringValue(provider, "id"),
       modelId: stringValue(model, "id"),
       protocol,
-      streaming: false,
+      streaming: Boolean(onDelta),
       contextChars: context.length,
       instructionChars: input.instruction.length,
       toolCount: tools.length
@@ -5072,11 +5068,14 @@ export class AiManager {
         ? AI_LONG_RUNNING_TIMEOUT_MS
         : AI_INTERACTIVE_TIMEOUT_MS;
       const maximumAttempts = Math.round(clamp(input.maxAttempts ?? 3, 1, 5));
-      type CompletionChoice = NonNullable<CompletionPayload["choices"]>[number];
       let completionRequestCount = 0;
       let cacheUsageComplete = true;
       let totalInputTokens = 0;
       let totalCachedInputTokens = 0;
+      const processSteps: AiProcessStep[] = [];
+      const completionDelivery = new WeakMap<CompletionPayload, "json" | "sse">();
+      let streamedContent = "";
+      let streamingGenerationRound = 0;
       type CompletionRequestOptions = {
         messages?: CompletionMessage[];
         parameters?: Record<string, unknown>;
@@ -5090,6 +5089,9 @@ export class AiManager {
         const requestParameters = options.parameters ?? parameters;
         const purpose = options.purpose ?? "generation";
         const requestTools = toolChoice === "auto" ? tools : [];
+        const streamResponse = Boolean(onDelta) && purpose === "generation";
+        const processRound = streamResponse ? streamingGenerationRound + 1 : 0;
+        if (streamResponse) streamingGenerationRound = processRound;
         const roundParameters = this.constrainParametersForDailyTokenQuota(
           input.workId,
           requestMessages,
@@ -5113,9 +5115,17 @@ export class AiManager {
         };
         traceRounds.push(traceRound);
         saveTrace();
+        let streamedThinkingStep: {
+          id: string;
+          type: "thinking";
+          round: number;
+          content: string;
+          createdAt: string;
+        } | null = null;
         let lastFailure: unknown = null;
         for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
           let retryable = true;
+          let attemptEmitted = false;
           const attemptStartedAt = process.hrtime.bigint();
           const traceAttempt: AiCallTraceAttempt = {
             attempt,
@@ -5135,18 +5145,62 @@ export class AiManager {
               try {
                 const response = await this.outboundFetch(endpoint, {
                   method: "POST",
-                  headers: providerRequestHeaders(protocol, accessToken, "application/json"),
+                  headers: providerRequestHeaders(protocol, accessToken, streamResponse ? "text/event-stream" : "application/json"),
                   body: JSON.stringify(buildCompletionRequestBody({
-                  protocol,
-                  model: stringValue(model, "model_id"),
-                  messages: requestMessages,
-                  parameters: roundParameters,
-                  tools: requestTools,
-                  toolChoice
-                })),
+                    protocol,
+                    model: stringValue(model, "model_id"),
+                    messages: requestMessages,
+                    parameters: roundParameters,
+                    tools: requestTools,
+                    toolChoice,
+                    ...(streamResponse ? { stream: true } : {})
+                  })),
                   signal: controller.signal
                 });
-                return { ok: response.ok, status: response.status, body: await readResponseTextLimited(response) };
+                if (!response.ok) {
+                  return { ok: false as const, status: response.status, body: await readResponseTextLimited(response) };
+                }
+                const isEventStream = response.headers.get("content-type")?.toLowerCase().includes("text/event-stream") ?? false;
+                if (!streamResponse || !isEventStream) {
+                  const body = await readResponseTextLimited(response);
+                  try {
+                    const payload = parseCompletionPayload(protocol, redactProviderSecrets(JSON.parse(body), activeSecrets));
+                    return { ok: true as const, status: response.status, payload, delivery: "json" as const };
+                  } catch {
+                    throw new Error(`${providerProtocolLabelText(protocol)} returned invalid JSON: ${body.slice(0, 500)}`);
+                  }
+                }
+                const payload = await this.readCompletionStream(
+                  response,
+                  protocol,
+                  activeSecrets,
+                  (delta) => {
+                    attemptEmitted = true;
+                    streamedContent += delta;
+                    onDelta?.(delta);
+                  },
+                  (delta) => {
+                    attemptEmitted = true;
+                    if (!streamedThinkingStep) {
+                      streamedThinkingStep = {
+                        id: id("process"),
+                        type: "thinking",
+                        round: processRound,
+                        content: "",
+                        createdAt: now()
+                      };
+                      processSteps.push(streamedThinkingStep);
+                    }
+                    streamedThinkingStep.content += delta;
+                    input.onProcessStep?.({ ...streamedThinkingStep, content: delta, append: true });
+                  }
+                );
+                return {
+                  ok: true as const,
+                  status: response.status,
+                  payload: redactProviderSecrets(payload, activeSecrets) as CompletionPayload,
+                  delivery: "sse" as const
+                };
               } finally {
                 clearTimeout(timeout);
                 input.signal?.removeEventListener("abort", forwardAbort);
@@ -5157,33 +5211,31 @@ export class AiManager {
               attempt,
               status: candidate.status,
               ok: candidate.ok,
-              durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000
+              durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
+              streaming: streamResponse
             });
             if (candidate.ok) {
-              try {
-                const parsed = parseCompletionPayload(protocol, redactProviderSecrets(JSON.parse(candidate.body), activeSecrets));
-                traceAttempt.completedAt = now();
-                traceAttempt.status = "completed";
-                traceAttempt.httpStatus = candidate.status;
-                traceAttempt.response = sanitizeCompletionTraceResponse(parsed);
-                saveTrace();
-                completionRequestCount += 1;
-                const cacheUsage = resolveInputCacheUsage(parsed.usage);
-                if (!cacheUsage) cacheUsageComplete = false;
-                else {
-                  totalInputTokens += cacheUsage.inputTokens;
-                  totalCachedInputTokens += cacheUsage.cachedInputTokens;
-                }
-                const outputText = completionPayloadOutputText(parsed);
-                trackUsage(resolveAiTokenUsage(
-                  parsed.usage,
-                  estimateAiTokens(JSON.stringify(requestMessages)),
-                  outputText ? estimateAiTokens(outputText) : 0
-                ));
-                return parsed;
-              } catch {
-                throw new Error(`${providerProtocolLabelText(protocol)} returned invalid JSON: ${candidate.body.slice(0, 500)}`);
+              const parsed = candidate.payload;
+              completionDelivery.set(parsed, candidate.delivery);
+              traceAttempt.completedAt = now();
+              traceAttempt.status = "completed";
+              traceAttempt.httpStatus = candidate.status;
+              traceAttempt.response = sanitizeCompletionTraceResponse(parsed);
+              saveTrace();
+              completionRequestCount += 1;
+              const cacheUsage = resolveInputCacheUsage(parsed.usage);
+              if (!cacheUsage) cacheUsageComplete = false;
+              else {
+                totalInputTokens += cacheUsage.inputTokens;
+                totalCachedInputTokens += cacheUsage.cachedInputTokens;
               }
+              const outputText = completionPayloadOutputText(parsed);
+              trackUsage(resolveAiTokenUsage(
+                parsed.usage,
+                estimateAiTokens(JSON.stringify(requestMessages)),
+                outputText ? estimateAiTokens(outputText) : 0
+              ));
+              return parsed;
             }
             lastFailure = new Error(`HTTP ${candidate.status}: ${candidate.body.slice(0, 500)}`);
             traceAttempt.completedAt = now();
@@ -5208,18 +5260,18 @@ export class AiManager {
             logger.warn("ai.call.attempt_failed", {
               callId,
               attempt,
-              retryable: retryable && attempt < maximumAttempts && !input.signal?.aborted,
+              retryable: retryable && !attemptEmitted && attempt < maximumAttempts && !input.signal?.aborted,
               durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
+              streaming: streamResponse,
               error: aiErrorForLog(error)
             });
-            if (input.signal?.aborted) throw error;
+            if (input.signal?.aborted || attemptEmitted) throw error;
             if (!retryable || attempt >= maximumAttempts) throw error;
           }
           if (attempt < maximumAttempts) await new Promise((resolve) => setTimeout(resolve, attempt * 1200));
         }
         throw lastFailure instanceof Error ? lastFailure : new Error("AI request failed after all retries.");
       };
-      const processSteps: AiProcessStep[] = [];
       const baseMessageCount = messages.length;
       const firstUserMessageIndex = messages.findIndex((message) => message.role !== "system");
       const compactedMessageIndex = firstUserMessageIndex < 0 ? messages.length : firstUserMessageIndex;
@@ -5351,15 +5403,17 @@ export class AiManager {
       let payload = await requestCompletion("auto");
       let choice = payload.choices?.[0];
       const executedToolCalls: AgentToolCallResult[] = [];
-      const recordChoiceProcess = (currentChoice: CompletionChoice | undefined, round: number, includeIntermediate: boolean): void => {
+      const recordChoiceProcess = (currentPayload: CompletionPayload, round: number, includeIntermediate: boolean): void => {
+        const currentChoice = currentPayload.choices?.[0];
+        const deliveredAsSse = completionDelivery.get(currentPayload) === "sse";
         const reasoning = currentChoice?.message?.reasoning_content;
-        if (reasoning?.trim()) {
+        if (!deliveredAsSse && reasoning?.trim()) {
           const step: AiProcessStep = { id: id("process"), type: "thinking", round, content: reasoning, createdAt: now() };
           processSteps.push(step);
           input.onProcessStep?.(step);
         }
         const intermediate = currentChoice?.message?.content;
-        if (includeIntermediate && intermediate?.trim()) {
+        if (!deliveredAsSse && includeIntermediate && intermediate?.trim()) {
           const step: AiProcessStep = { id: id("process"), type: "intermediate", round, content: intermediate, createdAt: now() };
           processSteps.push(step);
           input.onProcessStep?.(step);
@@ -5368,7 +5422,7 @@ export class AiManager {
       let toolRound = 0;
       while (choice?.message?.tool_calls?.length) {
         const round = toolRound + 1;
-        recordChoiceProcess(choice, round, true);
+        recordChoiceProcess(payload, round, true);
         const toolCalls = choice.message.tool_calls;
         if (shouldRejectGlobalToolCalls(globalToolCallUsed, toolCalls.length, globalToolCallLimit)) {
           logger.warn("ai.tool_call.global_limit_reached", {
@@ -5447,16 +5501,21 @@ export class AiManager {
         payload = await requestCompletion("auto");
         choice = payload.choices?.[0];
       }
-      recordChoiceProcess(choice, toolRound + 1, false);
-      const content = choice?.message?.content;
-      if (!content?.trim()) {
+      recordChoiceProcess(payload, toolRound + 1, false);
+      const finalContent = choice?.message?.content;
+      if (!finalContent?.trim()) {
         const reasoningLength = choice?.message?.reasoning_content?.length ?? 0;
         const suffix = choice?.finish_reason === "length" || reasoningLength > 0
           ? `；模型已生成 ${reasoningLength} 个推理字符，请提高 max_tokens 输出预算`
           : "";
         throw new Error(`${providerProtocolLabelText(protocol)} 响应缺少可用正文，finish_reason=${choice?.finish_reason ?? "unknown"}${suffix}`);
       }
-      const outputTokens = resolveOutputTokens(payload.usage, content);
+      if (onDelta && completionDelivery.get(payload) !== "sse") {
+        streamedContent += finalContent;
+        onDelta(finalContent);
+      }
+      const content = onDelta ? streamedContent : finalContent;
+      const outputTokens = resolveOutputTokens(payload.usage, finalContent);
       const cacheHitPercent = cacheUsageComplete && completionRequestCount > 0 && totalInputTokens > 0
         ? Math.round(totalCachedInputTokens / totalInputTokens * 1_000) / 10
         : undefined;
@@ -5480,12 +5539,19 @@ export class AiManager {
         callId,
         workId: input.workId,
         taskType: input.taskType,
-        streaming: false,
+        streaming: Boolean(onDelta),
         durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
         outputChars: content.length,
         outputTokens,
         toolCallCount: executedToolCalls.length
       });
+      const finalAnthropicContent = choice?.message?.anthropic_content;
+      const replayAnthropicContent = onDelta && finalAnthropicContent?.length && content !== finalContent
+        ? [
+          ...finalAnthropicContent.filter((block) => block.type !== "text" && block.type !== "tool_use"),
+          { type: "text", text: content }
+        ]
+        : finalAnthropicContent;
       return {
         callId,
         content,
@@ -5494,7 +5560,7 @@ export class AiManager {
           ? { reasoningContent: choice.message.reasoning_content }
           : {}),
         ...(cacheHitPercent === undefined ? {} : { cacheHitPercent }),
-        ...(choice?.message?.anthropic_content?.length ? { anthropicContent: choice.message.anthropic_content } : {}),
+        ...(replayAnthropicContent?.length ? { anthropicContent: replayAnthropicContent } : {}),
         provider: this.mapProvider(provider),
         model: this.mapModel(model),
         context,
@@ -5525,7 +5591,7 @@ export class AiManager {
         callId,
         workId: input.workId,
         taskType: input.taskType,
-        streaming: false,
+        streaming: Boolean(onDelta),
         durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
         error: aiErrorForLog(error)
       });
@@ -5540,215 +5606,13 @@ export class AiManager {
     }
   }
 
-  private async generateStream(input: GenerateInput, onDelta: (delta: string) => void): Promise<GenerateResult> {
-    const { model, provider } = this.resolveModel(input.workId, input.taskType, input.modelId);
-    const context = this.buildContext(input, model);
-    const preset = safeJsonObject(stringValue(model, "preset_json"));
-    const messages = this.buildMessages(input, context);
-    let parameters: Record<string, unknown>;
-    try {
-      parameters = this.constrainParametersForContext(model, messages, {
-        ...this.sanitizeParameters({ ...preset, ...(input.parameters ?? {}) }, stringValue(model, "model_id")),
-        ...thinkingParameters(provider, model)
-      });
-    } catch (error) {
-      if (!(error instanceof AppError) || error.code !== "CONTEXT_WINDOW_EXCEEDED") throw error;
-      throw initialContextWindowError(error, provider, model);
-    }
-    parameters = this.constrainParametersForDailyTokenQuota(input.workId, messages, parameters);
-    const callId = id("call");
-    this.store.db.run(
-      `INSERT INTO ai_calls (id, work_id, task_type, provider_id, model_id, context_scope_json, parameters_json,
-       status, input_chars, created_at, created_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)`,
-      callId,
-      input.workId,
-      input.taskType,
-      stringValue(provider, "id"),
-      stringValue(model, "id"),
-      JSON.stringify(input.scope),
-      JSON.stringify(parameters),
-      context.length + input.instruction.length,
-      now(),
-      currentRequestActor()?.userId ?? null
-    );
-    const callStartedAt = process.hrtime.bigint();
-    const protocol = providerProtocol(provider);
-    logger.info("ai.call.started", {
-      callId,
-      workId: input.workId,
-      taskType: input.taskType,
-      providerId: stringValue(provider, "id"),
-      modelId: stringValue(model, "id"),
-      protocol,
-      streaming: true,
-      contextChars: context.length,
-      instructionChars: input.instruction.length
-    });
-    let activeSecrets: string[] = [];
-    try {
-      const { accessToken, credentialSecret } = await this.resolveProviderAccessToken(provider);
-      activeSecrets = [credentialSecret, accessToken];
-      const endpoint = providerCompletionEndpoint(stringValue(provider, "base_url"), protocol);
-      const maximumAttempts = Math.round(clamp(input.maxAttempts ?? 3, 1, 5));
-      let streamedResult: {
-        content: string;
-        reasoning: string;
-        outputTokens: number;
-        cacheHitPercent?: number;
-        anthropicContent?: Record<string, unknown>[];
-        tokenUsage: ResolvedAiTokenUsage;
-      } | null = null;
-      let lastFailure: unknown = null;
-      let emitted = false;
-      const thinkingStepId = id("process");
-      const thinkingCreatedAt = now();
-      for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
-        const attemptStartedAt = process.hrtime.bigint();
-        logger.info("ai.call.attempt_started", { callId, attempt, maximumAttempts, streaming: true });
-        try {
-          const candidate = await this.scheduleProviderRequest(provider, input.signal, async () => {
-            const controller = new AbortController();
-            const forwardAbort = (): void => controller.abort(input.signal?.reason);
-            if (input.signal?.aborted) forwardAbort();
-            else input.signal?.addEventListener("abort", forwardAbort, { once: true });
-            const timeout = setTimeout(() => controller.abort(new Error(`AI 请求超时（${Math.round(AI_INTERACTIVE_TIMEOUT_MS / 1_000)} 秒）`)), AI_INTERACTIVE_TIMEOUT_MS);
-            try {
-              const response = await this.outboundFetch(endpoint, {
-                method: "POST",
-                headers: providerRequestHeaders(protocol, accessToken, "text/event-stream"),
-                body: JSON.stringify(buildCompletionRequestBody({
-                  protocol,
-                  model: stringValue(model, "model_id"),
-                  messages,
-                  parameters,
-                  stream: true
-                })),
-                signal: controller.signal
-              });
-              if (!response.ok) return { ok: false as const, status: response.status, body: await readResponseTextLimited(response) };
-              const streamed = await this.readCompletionStream(
-                response,
-                protocol,
-                estimateAiTokens(JSON.stringify(messages)),
-                activeSecrets,
-                (delta) => {
-                  emitted = true;
-                  onDelta(delta);
-                },
-                (delta) => {
-                  emitted = true;
-                  input.onProcessStep?.({ id: thinkingStepId, type: "thinking", round: 1, content: delta, createdAt: thinkingCreatedAt, append: true });
-                }
-              );
-              return { ok: true as const, status: response.status, result: streamed };
-            } finally {
-              clearTimeout(timeout);
-              input.signal?.removeEventListener("abort", forwardAbort);
-            }
-          });
-          logger.info("ai.call.attempt_completed", {
-            callId,
-            attempt,
-            status: candidate.status,
-            ok: candidate.ok,
-            durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
-            streaming: true
-          });
-          if (candidate.ok) {
-            streamedResult = candidate.result;
-            break;
-          }
-          lastFailure = new Error(`HTTP ${candidate.status}: ${candidate.body.slice(0, 500)}`);
-          if (candidate.status !== 429 && candidate.status < 500) attempt = maximumAttempts;
-        } catch (error) {
-          lastFailure = error;
-          logger.warn("ai.call.attempt_failed", {
-            callId,
-            attempt,
-            retryable: !input.signal?.aborted && !emitted && attempt < maximumAttempts,
-            durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
-            streaming: true,
-            error: aiErrorForLog(error)
-          });
-          if (input.signal?.aborted || emitted || attempt >= maximumAttempts) throw error;
-        }
-        if (attempt < maximumAttempts) await new Promise((resolve) => setTimeout(resolve, attempt * 1200));
-      }
-      if (streamedResult === null) throw lastFailure instanceof Error ? lastFailure : new Error("AI 流式请求重试后仍未返回响应");
-      const { content, reasoning, outputTokens, cacheHitPercent, anthropicContent, tokenUsage } = streamedResult;
-      const processSteps: AiProcessStep[] = reasoning.trim()
-        ? [{ id: thinkingStepId, type: "thinking", round: 1, content: reasoning, createdAt: thinkingCreatedAt }]
-        : [];
-      this.store.db.run(
-        `UPDATE ai_calls
-         SET status = 'completed', output_chars = ?, input_tokens = ?, output_tokens = ?,
-             cached_input_tokens = ?, cache_eligible_input_tokens = ?, cache_usage_available = ?,
-             token_usage_source = ?, completed_at = ?
-         WHERE id = ?`,
-        content.length,
-        tokenUsage.inputTokens,
-        tokenUsage.outputTokens,
-        tokenUsage.cachedInputTokens,
-        tokenUsage.cacheEligibleInputTokens,
-        tokenUsage.cacheEligibleInputTokens > 0 ? 1 : 0,
-        tokenUsage.source,
-        now(),
-        callId
-      );
-      logger.info("ai.call.completed", {
-        callId,
-        workId: input.workId,
-        taskType: input.taskType,
-        streaming: true,
-        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
-        outputChars: content.length,
-        outputTokens
-      });
-      return {
-        callId,
-        content,
-        outputTokens,
-        ...(reasoning.length > 0 ? { reasoningContent: reasoning } : {}),
-        ...(cacheHitPercent === undefined ? {} : { cacheHitPercent }),
-        ...(anthropicContent?.length ? { anthropicContent } : {}),
-        provider: this.mapProvider(provider),
-        model: this.mapModel(model),
-        context,
-        toolCalls: [],
-        processSteps,
-        contextUsage: this.completionContextUsage(input, model, messages, [])
-      };
-    } catch (error) {
-      const message = error instanceof Error ? redactProviderSecretsText(error.message, ...activeSecrets) : "AI 流式调用失败";
-      const failureTarget = aiFailureTargetDetails(provider, model);
-      this.store.db.run("UPDATE ai_calls SET status = 'failed', failure = ?, completed_at = ? WHERE id = ?", message, now(), callId);
-      logger.error("ai.call.failed", {
-        callId,
-        workId: input.workId,
-        taskType: input.taskType,
-        streaming: true,
-        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
-        error: aiErrorForLog(error)
-      });
-      throw new AppError(502, "AI_CALL_FAILED", "AI 调用失败", { callId, failure: message, ...failureTarget });
-    }
-  }
-
   private async readCompletionStream(
     response: Response,
     protocol: AiProviderProtocol,
-    estimatedInputTokens: number,
     apiKey: string | string[],
     onDelta: (delta: string) => void,
     onThinkingDelta: (delta: string) => void
-  ): Promise<{
-    content: string;
-    reasoning: string;
-    outputTokens: number;
-    cacheHitPercent?: number;
-    anthropicContent?: Record<string, unknown>[];
-    tokenUsage: ResolvedAiTokenUsage;
-  }> {
+  ): Promise<CompletionPayload> {
     const protocolLabel = providerProtocolLabelText(protocol);
     if (!response.body) throw new Error(`${protocolLabel} 流式响应缺少正文`);
     const reader = response.body.getReader();
@@ -5775,6 +5639,7 @@ export class AiManager {
     };
     const anthropicBlocks = new Map<number, Record<string, unknown>>();
     const anthropicToolInputJson = new Map<number, string>();
+    const openAiToolCalls = new Map<number, CompletionToolCall>();
     const eventIndex = (payload: Record<string, unknown>): number | null => {
       const index = payload.index;
       return typeof index === "number" && Number.isInteger(index) && index >= 0 ? index : null;
@@ -5828,6 +5693,12 @@ export class AiManager {
             if (contentBlock.type === "thinking" && typeof contentBlock.thinking !== "string") contentBlock.thinking = "";
             if (contentBlock.type === "tool_use" && !contentBlock.input) contentBlock.input = {};
             anthropicBlocks.set(index, contentBlock);
+            if (contentBlock.type === "text" && typeof contentBlock.text === "string" && contentBlock.text.length > 0) {
+              appendContent(contentBlock.text);
+            }
+            if (contentBlock.type === "thinking" && typeof contentBlock.thinking === "string" && contentBlock.thinking.length > 0) {
+              appendReasoning(contentBlock.thinking);
+            }
           }
         }
         const eventUsage = payload.usage && typeof payload.usage === "object" && !Array.isArray(payload.usage)
@@ -5883,6 +5754,27 @@ export class AiManager {
       const deltaRecord = choice?.delta && typeof choice.delta === "object" && !Array.isArray(choice.delta)
         ? choice.delta as Record<string, unknown>
         : {};
+      const toolCallDeltas = Array.isArray(deltaRecord.tool_calls) ? deltaRecord.tool_calls : [];
+      for (const [position, value] of toolCallDeltas.entries()) {
+        const toolCallDelta = value && typeof value === "object" && !Array.isArray(value)
+          ? value as Record<string, unknown>
+          : {};
+        const index = typeof toolCallDelta.index === "number" && Number.isInteger(toolCallDelta.index) && toolCallDelta.index >= 0
+          ? toolCallDelta.index
+          : position;
+        const current = openAiToolCalls.get(index) ?? {
+          id: "",
+          type: "function" as const,
+          function: { name: "", arguments: "" }
+        };
+        if (typeof toolCallDelta.id === "string") current.id += toolCallDelta.id;
+        const fn = toolCallDelta.function && typeof toolCallDelta.function === "object" && !Array.isArray(toolCallDelta.function)
+          ? toolCallDelta.function as Record<string, unknown>
+          : {};
+        if (typeof fn.name === "string") current.function.name += fn.name;
+        if (typeof fn.arguments === "string") current.function.arguments = `${String(current.function.arguments)}${fn.arguments}`;
+        openAiToolCalls.set(index, current);
+      }
       const thinkingDelta = deltaRecord.reasoning_content;
       if (typeof thinkingDelta === "string" && thinkingDelta.length > 0) {
         appendReasoning(thinkingDelta);
@@ -5927,9 +5819,6 @@ export class AiManager {
       reasoning += finalReasoning;
       onThinkingDelta(finalReasoning);
     }
-    if (!content.trim()) throw new Error(`${protocolLabel} 流式响应缺少可用正文，finish_reason=${finishReason}`);
-    const cacheHitPercent = resolveCacheHitPercent(usage);
-    const outputTokens = resolveOutputTokens(usage, content);
     const anthropicContent = protocol === "anthropic-messages"
       ? [...anthropicBlocks.entries()]
         .sort(([left], [right]) => left - right)
@@ -5938,14 +5827,32 @@ export class AiManager {
           return redactProviderSecrets(block, apiKey) as Record<string, unknown>;
         })
       : undefined;
-    return {
-      content,
-      reasoning,
-      outputTokens,
-      ...(cacheHitPercent === undefined ? {} : { cacheHitPercent }),
-      ...(anthropicContent?.length ? { anthropicContent } : {}),
-      tokenUsage: resolveAiTokenUsage(usage, estimatedInputTokens, outputTokens)
-    };
+    const usageRecord = usage && typeof usage === "object" && !Array.isArray(usage)
+      ? usage as Record<string, unknown>
+      : undefined;
+    const payload = protocol === "anthropic-messages"
+      ? parseCompletionPayload(protocol, {
+        ...(usageRecord ? { usage: usageRecord } : {}),
+        stop_reason: finishReason === "unknown" ? null : finishReason,
+        content: anthropicContent ?? []
+      })
+      : {
+        ...(usageRecord ? { usage: usageRecord } : {}),
+        choices: [{
+          finish_reason: finishReason === "unknown" ? null : finishReason,
+          message: {
+            content: content || null,
+            reasoning_content: reasoning || null,
+            tool_calls: [...openAiToolCalls.entries()]
+              .sort(([left], [right]) => left - right)
+              .map(([, toolCall]) => toolCall)
+          }
+        }]
+      } satisfies CompletionPayload;
+    if (!content.trim() && !(payload.choices?.[0]?.message?.tool_calls?.length)) {
+      throw new Error(`${protocolLabel} 流式响应缺少可用正文，finish_reason=${finishReason}`);
+    }
+    return payload;
   }
 
   private async runChapterAnalysis(workId: string, scope: ContextScope, modelId?: string, taskId?: string): Promise<Record<string, unknown>> {

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -3283,13 +3283,7 @@ export class AiManager {
       && titleModelId
       && (conversationBefore?.title === "新对话" || conversationBefore?.title === defaultTitle)
     );
-    const chatTools = this.enabledAgentTools(input.workId, "chat", input.agentToolIds, input.conversationId);
-    const chatProtocol = providerProtocol(this.resolveModel(input.workId, "chat", input.modelId).provider);
-    const useLegacyAnthropicToolFlow = chatTools.length > 0 && chatProtocol === "anthropic-messages";
-    const generated = useLegacyAnthropicToolFlow
-      ? await this.generate({ ...input, taskType: "chat" })
-      : await this.generateStream({ ...input, taskType: "chat" }, onDelta);
-    if (useLegacyAnthropicToolFlow) onDelta(generated.content);
+    const generated = await this.generateStream({ ...input, taskType: "chat" }, onDelta);
     const chapter = input.scope.chapterId ? this.store.getChapter(input.scope.chapterId) : null;
     const suggestionId = id("suggestion");
     this.store.db.run(
@@ -5648,6 +5642,7 @@ export class AiManager {
     };
     const anthropicBlocks = new Map<number, Record<string, unknown>>();
     const anthropicToolInputJson = new Map<number, string>();
+    const finalizedAnthropicToolInputs = new Map<number, string>();
     const openAiToolCalls = new Map<number, { id: string; name: string; arguments: string }>();
     let openAiToolCallsFinalized = false;
     const eventIndex = (payload: Record<string, unknown>): number | null => {
@@ -5666,13 +5661,15 @@ export class AiManager {
     const finalizeAnthropicToolInput = (index: number): void => {
       const block = anthropicBlocks.get(index);
       const inputJson = anthropicToolInputJson.get(index);
-      if (!block || block.type !== "tool_use" || inputJson === undefined) return;
+      if (!block || block.type !== "tool_use") return;
+      const completeInputJson = inputJson ?? JSON.stringify(block.input ?? {});
       try {
-        const parsed = JSON.parse(inputJson) as unknown;
+        const parsed = JSON.parse(completeInputJson) as unknown;
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) block.input = parsed;
       } catch {
         block.input = {};
       }
+      finalizedAnthropicToolInputs.set(index, completeInputJson);
       anthropicToolInputJson.delete(index);
     };
     const consumeEvent = (eventText: string): void => {
@@ -5821,25 +5818,50 @@ export class AiManager {
       reasoning += finalReasoning;
       onThinkingDelta(finalReasoning);
     }
-    const toolCalls: CompletionToolCall[] = openAiToolCallsFinalized
-      ? [...openAiToolCalls.entries()]
-        .sort(([left], [right]) => left - right)
-        .flatMap(([, toolCall]) => toolCall.id && toolCall.name ? [{
+    const sortedOpenAiToolCalls = [...openAiToolCalls.entries()].sort(([left], [right]) => left - right);
+    const openAiToolCallsComplete = openAiToolCallsFinalized
+      && sortedOpenAiToolCalls.length > 0
+      && sortedOpenAiToolCalls.every(([, toolCall]) => Boolean(toolCall.id && toolCall.name));
+    const anthropicToolBlocks = [...anthropicBlocks.entries()]
+      .filter(([, block]) => block.type === "tool_use")
+      .sort(([left], [right]) => left - right);
+    const anthropicToolCallsComplete = finishReason === "tool_use"
+      && anthropicToolBlocks.length > 0
+      && anthropicToolBlocks.every(([index, block]) => (
+        finalizedAnthropicToolInputs.has(index)
+        && typeof block.id === "string"
+        && block.id.length > 0
+        && typeof block.name === "string"
+        && block.name.length > 0
+      ));
+    const toolCalls: CompletionToolCall[] = protocol === "anthropic-messages"
+      ? anthropicToolCallsComplete
+        ? anthropicToolBlocks.map(([index, block]) => ({
+          id: String(block.id),
+          type: "function" as const,
+          function: {
+            name: String(block.name),
+            arguments: finalizedAnthropicToolInputs.get(index) ?? "{}"
+          }
+        }))
+        : []
+      : openAiToolCallsComplete
+        ? sortedOpenAiToolCalls.map(([, toolCall]) => ({
           id: toolCall.id,
           type: "function" as const,
           function: { name: toolCall.name, arguments: toolCall.arguments }
-        }] : [])
-      : [];
+        }))
+        : [];
+    if ((finishReason === "tool_calls" || finishReason === "tool_use") && toolCalls.length === 0) {
+      throw new Error(`${protocolLabel} 流式工具调用不完整，finish_reason=${finishReason}`);
+    }
     if (!content.trim() && toolCalls.length === 0) {
       throw new Error(`${protocolLabel} 流式响应缺少可用正文，finish_reason=${finishReason}`);
     }
     const anthropicContent = protocol === "anthropic-messages"
       ? [...anthropicBlocks.entries()]
         .sort(([left], [right]) => left - right)
-        .map(([index, block]) => {
-          finalizeAnthropicToolInput(index);
-          return redactProviderSecrets(block, apiKey) as Record<string, unknown>;
-        })
+        .map(([, block]) => redactProviderSecrets(block, apiKey) as Record<string, unknown>)
       : undefined;
     return redactProviderSecrets({
       ...(usage && typeof usage === "object" && !Array.isArray(usage) ? { usage } : {}),

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -3284,10 +3284,12 @@ export class AiManager {
       && (conversationBefore?.title === "新对话" || conversationBefore?.title === defaultTitle)
     );
     const chatTools = this.enabledAgentTools(input.workId, "chat", input.agentToolIds, input.conversationId);
-    const generated = chatTools.length
+    const chatProtocol = providerProtocol(this.resolveModel(input.workId, "chat", input.modelId).provider);
+    const useLegacyAnthropicToolFlow = chatTools.length > 0 && chatProtocol === "anthropic-messages";
+    const generated = useLegacyAnthropicToolFlow
       ? await this.generate({ ...input, taskType: "chat" })
       : await this.generateStream({ ...input, taskType: "chat" }, onDelta);
-    if (chatTools.length) onDelta(generated.content);
+    if (useLegacyAnthropicToolFlow) onDelta(generated.content);
     const chapter = input.scope.chapterId ? this.store.getChapter(input.scope.chapterId) : null;
     const suggestionId = id("suggestion");
     this.store.db.run(
@@ -4949,6 +4951,14 @@ export class AiManager {
   }
 
   async generate(input: GenerateInput): Promise<GenerateResult> {
+    return this.generateCompletion(input);
+  }
+
+  private async generateCompletion(
+    input: GenerateInput,
+    onDelta?: (delta: string) => void
+  ): Promise<GenerateResult> {
+    const streaming = onDelta !== undefined;
     const generationRoleplayCharacterId = this.roleplayCharacterId(input.workId, input.conversationId);
     const { model, provider } = this.resolveModel(input.workId, input.taskType, input.modelId);
     const preset = safeJsonObject(stringValue(model, "preset_json"));
@@ -5041,7 +5051,7 @@ export class AiManager {
       providerId: stringValue(provider, "id"),
       modelId: stringValue(model, "id"),
       protocol,
-      streaming: false,
+      streaming,
       contextChars: context.length,
       instructionChars: input.instruction.length,
       toolCount: tools.length
@@ -5077,6 +5087,9 @@ export class AiManager {
       let cacheUsageComplete = true;
       let totalInputTokens = 0;
       let totalCachedInputTokens = 0;
+      let streamedContent = "";
+      let generationRequestCount = 0;
+      const streamingThinkingSteps = new Map<number, { id: string; createdAt: string }>();
       type CompletionRequestOptions = {
         messages?: CompletionMessage[];
         parameters?: Record<string, unknown>;
@@ -5090,6 +5103,13 @@ export class AiManager {
         const requestParameters = options.parameters ?? parameters;
         const purpose = options.purpose ?? "generation";
         const requestTools = toolChoice === "auto" ? tools : [];
+        const useStreamingResponse = streaming && purpose === "generation";
+        const generationRound = useStreamingResponse ? generationRequestCount + 1 : null;
+        const thinkingStep = generationRound === null ? null : {
+          id: id("process"),
+          createdAt: now()
+        };
+        if (generationRound !== null && thinkingStep) streamingThinkingSteps.set(generationRound, thinkingStep);
         const roundParameters = this.constrainParametersForDailyTokenQuota(
           input.workId,
           requestMessages,
@@ -5116,6 +5136,24 @@ export class AiManager {
         let lastFailure: unknown = null;
         for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
           let retryable = true;
+          let attemptEmitted = false;
+          const emitContent = (delta: string): void => {
+            attemptEmitted = true;
+            streamedContent += delta;
+            onDelta?.(delta);
+          };
+          const emitThinking = (delta: string): void => {
+            if (generationRound === null || !thinkingStep) return;
+            attemptEmitted = true;
+            input.onProcessStep?.({
+              id: thinkingStep.id,
+              type: "thinking",
+              round: generationRound,
+              content: delta,
+              createdAt: thinkingStep.createdAt,
+              append: true
+            });
+          };
           const attemptStartedAt = process.hrtime.bigint();
           const traceAttempt: AiCallTraceAttempt = {
             attempt,
@@ -5135,18 +5173,29 @@ export class AiManager {
               try {
                 const response = await this.outboundFetch(endpoint, {
                   method: "POST",
-                  headers: providerRequestHeaders(protocol, accessToken, "application/json"),
+                  headers: providerRequestHeaders(protocol, accessToken, useStreamingResponse ? "text/event-stream" : "application/json"),
                   body: JSON.stringify(buildCompletionRequestBody({
-                  protocol,
-                  model: stringValue(model, "model_id"),
-                  messages: requestMessages,
-                  parameters: roundParameters,
-                  tools: requestTools,
-                  toolChoice
-                })),
+                    protocol,
+                    model: stringValue(model, "model_id"),
+                    messages: requestMessages,
+                    parameters: roundParameters,
+                    tools: requestTools,
+                    toolChoice,
+                    ...(useStreamingResponse ? { stream: true } : {})
+                  })),
                   signal: controller.signal
                 });
-                return { ok: response.ok, status: response.status, body: await readResponseTextLimited(response) };
+                if (!response.ok) {
+                  return { ok: false as const, status: response.status, body: await readResponseTextLimited(response) };
+                }
+                if (useStreamingResponse && response.headers.get("Content-Type")?.toLowerCase().includes("text/event-stream")) {
+                  return {
+                    ok: true as const,
+                    status: response.status,
+                    payload: await this.readCompletionStream(response, protocol, activeSecrets, emitContent, emitThinking)
+                  };
+                }
+                return { ok: true as const, status: response.status, body: await readResponseTextLimited(response) };
               } finally {
                 clearTimeout(timeout);
                 input.signal?.removeEventListener("abort", forwardAbort);
@@ -5160,30 +5209,41 @@ export class AiManager {
               durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000
             });
             if (candidate.ok) {
-              try {
-                const parsed = parseCompletionPayload(protocol, redactProviderSecrets(JSON.parse(candidate.body), activeSecrets));
-                traceAttempt.completedAt = now();
-                traceAttempt.status = "completed";
-                traceAttempt.httpStatus = candidate.status;
-                traceAttempt.response = sanitizeCompletionTraceResponse(parsed);
-                saveTrace();
-                completionRequestCount += 1;
-                const cacheUsage = resolveInputCacheUsage(parsed.usage);
-                if (!cacheUsage) cacheUsageComplete = false;
-                else {
-                  totalInputTokens += cacheUsage.inputTokens;
-                  totalCachedInputTokens += cacheUsage.cachedInputTokens;
+              let parsed: CompletionPayload;
+              if ("payload" in candidate && candidate.payload) {
+                parsed = candidate.payload;
+              } else {
+                try {
+                  parsed = parseCompletionPayload(protocol, redactProviderSecrets(JSON.parse(candidate.body), activeSecrets));
+                } catch {
+                  throw new Error(`${providerProtocolLabelText(protocol)} returned invalid JSON: ${candidate.body.slice(0, 500)}`);
                 }
-                const outputText = completionPayloadOutputText(parsed);
-                trackUsage(resolveAiTokenUsage(
-                  parsed.usage,
-                  estimateAiTokens(JSON.stringify(requestMessages)),
-                  outputText ? estimateAiTokens(outputText) : 0
-                ));
-                return parsed;
-              } catch {
-                throw new Error(`${providerProtocolLabelText(protocol)} returned invalid JSON: ${candidate.body.slice(0, 500)}`);
+                if (useStreamingResponse) {
+                  const streamedChoice = parsed.choices?.[0];
+                  if (streamedChoice?.message?.reasoning_content) emitThinking(streamedChoice.message.reasoning_content);
+                  if (streamedChoice?.message?.content) emitContent(streamedChoice.message.content);
+                }
               }
+              traceAttempt.completedAt = now();
+              traceAttempt.status = "completed";
+              traceAttempt.httpStatus = candidate.status;
+              traceAttempt.response = sanitizeCompletionTraceResponse(parsed);
+              saveTrace();
+              completionRequestCount += 1;
+              if (useStreamingResponse) generationRequestCount += 1;
+              const cacheUsage = resolveInputCacheUsage(parsed.usage);
+              if (!cacheUsage) cacheUsageComplete = false;
+              else {
+                totalInputTokens += cacheUsage.inputTokens;
+                totalCachedInputTokens += cacheUsage.cachedInputTokens;
+              }
+              const outputText = completionPayloadOutputText(parsed);
+              trackUsage(resolveAiTokenUsage(
+                parsed.usage,
+                estimateAiTokens(JSON.stringify(requestMessages)),
+                outputText ? estimateAiTokens(outputText) : 0
+              ));
+              return parsed;
             }
             lastFailure = new Error(`HTTP ${candidate.status}: ${candidate.body.slice(0, 500)}`);
             traceAttempt.completedAt = now();
@@ -5197,6 +5257,7 @@ export class AiManager {
             }
           } catch (error) {
             lastFailure = error;
+            if (attemptEmitted) retryable = false;
             if (traceAttempt.status === "running") {
               traceAttempt.completedAt = now();
               traceAttempt.status = "failed";
@@ -5354,9 +5415,16 @@ export class AiManager {
       const recordChoiceProcess = (currentChoice: CompletionChoice | undefined, round: number, includeIntermediate: boolean): void => {
         const reasoning = currentChoice?.message?.reasoning_content;
         if (reasoning?.trim()) {
-          const step: AiProcessStep = { id: id("process"), type: "thinking", round, content: reasoning, createdAt: now() };
+          const streamingStep = streamingThinkingSteps.get(round);
+          const step: AiProcessStep = {
+            id: streamingStep?.id ?? id("process"),
+            type: "thinking",
+            round,
+            content: reasoning,
+            createdAt: streamingStep?.createdAt ?? now()
+          };
           processSteps.push(step);
-          input.onProcessStep?.(step);
+          if (!streaming) input.onProcessStep?.(step);
         }
         const intermediate = currentChoice?.message?.content;
         if (includeIntermediate && intermediate?.trim()) {
@@ -5448,15 +5516,16 @@ export class AiManager {
         choice = payload.choices?.[0];
       }
       recordChoiceProcess(choice, toolRound + 1, false);
-      const content = choice?.message?.content;
-      if (!content?.trim()) {
+      const finalContent = choice?.message?.content;
+      if (!finalContent?.trim()) {
         const reasoningLength = choice?.message?.reasoning_content?.length ?? 0;
         const suffix = choice?.finish_reason === "length" || reasoningLength > 0
           ? `；模型已生成 ${reasoningLength} 个推理字符，请提高 max_tokens 输出预算`
           : "";
         throw new Error(`${providerProtocolLabelText(protocol)} 响应缺少可用正文，finish_reason=${choice?.finish_reason ?? "unknown"}${suffix}`);
       }
-      const outputTokens = resolveOutputTokens(payload.usage, content);
+      const content = streaming ? streamedContent : finalContent;
+      const outputTokens = resolveOutputTokens(payload.usage, finalContent);
       const cacheHitPercent = cacheUsageComplete && completionRequestCount > 0 && totalInputTokens > 0
         ? Math.round(totalCachedInputTokens / totalInputTokens * 1_000) / 10
         : undefined;
@@ -5480,7 +5549,7 @@ export class AiManager {
         callId,
         workId: input.workId,
         taskType: input.taskType,
-        streaming: false,
+        streaming,
         durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
         outputChars: content.length,
         outputTokens,
@@ -5503,7 +5572,9 @@ export class AiManager {
         contextUsage: this.completionContextUsage(effectiveInput, model, completionMessages, tools)
       };
     } catch (error) {
-      const message = error instanceof Error ? redactProviderSecretsText(error.message, ...activeSecrets) : "AI 调用失败";
+      const message = error instanceof Error
+        ? redactProviderSecretsText(error.message, ...activeSecrets)
+        : streaming ? "AI 流式调用失败" : "AI 调用失败";
       const failureTarget = aiFailureTargetDetails(provider, model);
       this.store.db.run(
         `UPDATE ai_calls
@@ -5525,7 +5596,7 @@ export class AiManager {
         callId,
         workId: input.workId,
         taskType: input.taskType,
-        streaming: false,
+        streaming,
         durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
         error: aiErrorForLog(error)
       });
@@ -5541,214 +5612,16 @@ export class AiManager {
   }
 
   private async generateStream(input: GenerateInput, onDelta: (delta: string) => void): Promise<GenerateResult> {
-    const { model, provider } = this.resolveModel(input.workId, input.taskType, input.modelId);
-    const context = this.buildContext(input, model);
-    const preset = safeJsonObject(stringValue(model, "preset_json"));
-    const messages = this.buildMessages(input, context);
-    let parameters: Record<string, unknown>;
-    try {
-      parameters = this.constrainParametersForContext(model, messages, {
-        ...this.sanitizeParameters({ ...preset, ...(input.parameters ?? {}) }, stringValue(model, "model_id")),
-        ...thinkingParameters(provider, model)
-      });
-    } catch (error) {
-      if (!(error instanceof AppError) || error.code !== "CONTEXT_WINDOW_EXCEEDED") throw error;
-      throw initialContextWindowError(error, provider, model);
-    }
-    parameters = this.constrainParametersForDailyTokenQuota(input.workId, messages, parameters);
-    const callId = id("call");
-    this.store.db.run(
-      `INSERT INTO ai_calls (id, work_id, task_type, provider_id, model_id, context_scope_json, parameters_json,
-       status, input_chars, created_at, created_by_user_id) VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)`,
-      callId,
-      input.workId,
-      input.taskType,
-      stringValue(provider, "id"),
-      stringValue(model, "id"),
-      JSON.stringify(input.scope),
-      JSON.stringify(parameters),
-      context.length + input.instruction.length,
-      now(),
-      currentRequestActor()?.userId ?? null
-    );
-    const callStartedAt = process.hrtime.bigint();
-    const protocol = providerProtocol(provider);
-    logger.info("ai.call.started", {
-      callId,
-      workId: input.workId,
-      taskType: input.taskType,
-      providerId: stringValue(provider, "id"),
-      modelId: stringValue(model, "id"),
-      protocol,
-      streaming: true,
-      contextChars: context.length,
-      instructionChars: input.instruction.length
-    });
-    let activeSecrets: string[] = [];
-    try {
-      const { accessToken, credentialSecret } = await this.resolveProviderAccessToken(provider);
-      activeSecrets = [credentialSecret, accessToken];
-      const endpoint = providerCompletionEndpoint(stringValue(provider, "base_url"), protocol);
-      const maximumAttempts = Math.round(clamp(input.maxAttempts ?? 3, 1, 5));
-      let streamedResult: {
-        content: string;
-        reasoning: string;
-        outputTokens: number;
-        cacheHitPercent?: number;
-        anthropicContent?: Record<string, unknown>[];
-        tokenUsage: ResolvedAiTokenUsage;
-      } | null = null;
-      let lastFailure: unknown = null;
-      let emitted = false;
-      const thinkingStepId = id("process");
-      const thinkingCreatedAt = now();
-      for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
-        const attemptStartedAt = process.hrtime.bigint();
-        logger.info("ai.call.attempt_started", { callId, attempt, maximumAttempts, streaming: true });
-        try {
-          const candidate = await this.scheduleProviderRequest(provider, input.signal, async () => {
-            const controller = new AbortController();
-            const forwardAbort = (): void => controller.abort(input.signal?.reason);
-            if (input.signal?.aborted) forwardAbort();
-            else input.signal?.addEventListener("abort", forwardAbort, { once: true });
-            const timeout = setTimeout(() => controller.abort(new Error(`AI 请求超时（${Math.round(AI_INTERACTIVE_TIMEOUT_MS / 1_000)} 秒）`)), AI_INTERACTIVE_TIMEOUT_MS);
-            try {
-              const response = await this.outboundFetch(endpoint, {
-                method: "POST",
-                headers: providerRequestHeaders(protocol, accessToken, "text/event-stream"),
-                body: JSON.stringify(buildCompletionRequestBody({
-                  protocol,
-                  model: stringValue(model, "model_id"),
-                  messages,
-                  parameters,
-                  stream: true
-                })),
-                signal: controller.signal
-              });
-              if (!response.ok) return { ok: false as const, status: response.status, body: await readResponseTextLimited(response) };
-              const streamed = await this.readCompletionStream(
-                response,
-                protocol,
-                estimateAiTokens(JSON.stringify(messages)),
-                activeSecrets,
-                (delta) => {
-                  emitted = true;
-                  onDelta(delta);
-                },
-                (delta) => {
-                  emitted = true;
-                  input.onProcessStep?.({ id: thinkingStepId, type: "thinking", round: 1, content: delta, createdAt: thinkingCreatedAt, append: true });
-                }
-              );
-              return { ok: true as const, status: response.status, result: streamed };
-            } finally {
-              clearTimeout(timeout);
-              input.signal?.removeEventListener("abort", forwardAbort);
-            }
-          });
-          logger.info("ai.call.attempt_completed", {
-            callId,
-            attempt,
-            status: candidate.status,
-            ok: candidate.ok,
-            durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
-            streaming: true
-          });
-          if (candidate.ok) {
-            streamedResult = candidate.result;
-            break;
-          }
-          lastFailure = new Error(`HTTP ${candidate.status}: ${candidate.body.slice(0, 500)}`);
-          if (candidate.status !== 429 && candidate.status < 500) attempt = maximumAttempts;
-        } catch (error) {
-          lastFailure = error;
-          logger.warn("ai.call.attempt_failed", {
-            callId,
-            attempt,
-            retryable: !input.signal?.aborted && !emitted && attempt < maximumAttempts,
-            durationMs: Number(process.hrtime.bigint() - attemptStartedAt) / 1_000_000,
-            streaming: true,
-            error: aiErrorForLog(error)
-          });
-          if (input.signal?.aborted || emitted || attempt >= maximumAttempts) throw error;
-        }
-        if (attempt < maximumAttempts) await new Promise((resolve) => setTimeout(resolve, attempt * 1200));
-      }
-      if (streamedResult === null) throw lastFailure instanceof Error ? lastFailure : new Error("AI 流式请求重试后仍未返回响应");
-      const { content, reasoning, outputTokens, cacheHitPercent, anthropicContent, tokenUsage } = streamedResult;
-      const processSteps: AiProcessStep[] = reasoning.trim()
-        ? [{ id: thinkingStepId, type: "thinking", round: 1, content: reasoning, createdAt: thinkingCreatedAt }]
-        : [];
-      this.store.db.run(
-        `UPDATE ai_calls
-         SET status = 'completed', output_chars = ?, input_tokens = ?, output_tokens = ?,
-             cached_input_tokens = ?, cache_eligible_input_tokens = ?, cache_usage_available = ?,
-             token_usage_source = ?, completed_at = ?
-         WHERE id = ?`,
-        content.length,
-        tokenUsage.inputTokens,
-        tokenUsage.outputTokens,
-        tokenUsage.cachedInputTokens,
-        tokenUsage.cacheEligibleInputTokens,
-        tokenUsage.cacheEligibleInputTokens > 0 ? 1 : 0,
-        tokenUsage.source,
-        now(),
-        callId
-      );
-      logger.info("ai.call.completed", {
-        callId,
-        workId: input.workId,
-        taskType: input.taskType,
-        streaming: true,
-        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
-        outputChars: content.length,
-        outputTokens
-      });
-      return {
-        callId,
-        content,
-        outputTokens,
-        ...(reasoning.length > 0 ? { reasoningContent: reasoning } : {}),
-        ...(cacheHitPercent === undefined ? {} : { cacheHitPercent }),
-        ...(anthropicContent?.length ? { anthropicContent } : {}),
-        provider: this.mapProvider(provider),
-        model: this.mapModel(model),
-        context,
-        toolCalls: [],
-        processSteps,
-        contextUsage: this.completionContextUsage(input, model, messages, [])
-      };
-    } catch (error) {
-      const message = error instanceof Error ? redactProviderSecretsText(error.message, ...activeSecrets) : "AI 流式调用失败";
-      const failureTarget = aiFailureTargetDetails(provider, model);
-      this.store.db.run("UPDATE ai_calls SET status = 'failed', failure = ?, completed_at = ? WHERE id = ?", message, now(), callId);
-      logger.error("ai.call.failed", {
-        callId,
-        workId: input.workId,
-        taskType: input.taskType,
-        streaming: true,
-        durationMs: Number(process.hrtime.bigint() - callStartedAt) / 1_000_000,
-        error: aiErrorForLog(error)
-      });
-      throw new AppError(502, "AI_CALL_FAILED", "AI 调用失败", { callId, failure: message, ...failureTarget });
-    }
+    return this.generateCompletion(input, onDelta);
   }
 
   private async readCompletionStream(
     response: Response,
     protocol: AiProviderProtocol,
-    estimatedInputTokens: number,
     apiKey: string | string[],
     onDelta: (delta: string) => void,
     onThinkingDelta: (delta: string) => void
-  ): Promise<{
-    content: string;
-    reasoning: string;
-    outputTokens: number;
-    cacheHitPercent?: number;
-    anthropicContent?: Record<string, unknown>[];
-    tokenUsage: ResolvedAiTokenUsage;
-  }> {
+  ): Promise<CompletionPayload> {
     const protocolLabel = providerProtocolLabelText(protocol);
     if (!response.body) throw new Error(`${protocolLabel} 流式响应缺少正文`);
     const reader = response.body.getReader();
@@ -5775,6 +5648,8 @@ export class AiManager {
     };
     const anthropicBlocks = new Map<number, Record<string, unknown>>();
     const anthropicToolInputJson = new Map<number, string>();
+    const openAiToolCalls = new Map<number, { id: string; name: string; arguments: string }>();
+    let openAiToolCallsFinalized = false;
     const eventIndex = (payload: Record<string, unknown>): number | null => {
       const index = payload.index;
       return typeof index === "number" && Number.isInteger(index) && index >= 0 ? index : null;
@@ -5869,6 +5744,7 @@ export class AiManager {
         if (eventDelta.type === "text_delta" && typeof eventDelta.text === "string" && eventDelta.text.length > 0) {
           appendContent(eventDelta.text);
         }
+        if (type === "message_stop") upstreamDone = true;
         return;
       }
       const streamUsage = payload.usage && typeof payload.usage === "object" && !Array.isArray(payload.usage)
@@ -5879,10 +5755,28 @@ export class AiManager {
       const choice = choices[0] && typeof choices[0] === "object" && !Array.isArray(choices[0])
         ? choices[0] as Record<string, unknown>
         : null;
-      if (typeof choice?.finish_reason === "string") finishReason = choice.finish_reason;
+      if (typeof choice?.finish_reason === "string") {
+        finishReason = choice.finish_reason;
+        if (finishReason === "tool_calls") openAiToolCallsFinalized = true;
+      }
       const deltaRecord = choice?.delta && typeof choice.delta === "object" && !Array.isArray(choice.delta)
         ? choice.delta as Record<string, unknown>
         : {};
+      const streamedToolCalls = Array.isArray(deltaRecord.tool_calls) ? deltaRecord.tool_calls : [];
+      for (const value of streamedToolCalls) {
+        if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+        const toolCallDelta = value as Record<string, unknown>;
+        const index = toolCallDelta.index;
+        if (typeof index !== "number" || !Number.isInteger(index) || index < 0) continue;
+        const current = openAiToolCalls.get(index) ?? { id: "", name: "", arguments: "" };
+        if (!current.id && typeof toolCallDelta.id === "string") current.id = toolCallDelta.id;
+        const fn = toolCallDelta.function && typeof toolCallDelta.function === "object" && !Array.isArray(toolCallDelta.function)
+          ? toolCallDelta.function as Record<string, unknown>
+          : {};
+        if (typeof fn.name === "string") current.name += fn.name;
+        if (typeof fn.arguments === "string") current.arguments += fn.arguments;
+        openAiToolCalls.set(index, current);
+      }
       const thinkingDelta = deltaRecord.reasoning_content;
       if (typeof thinkingDelta === "string" && thinkingDelta.length > 0) {
         appendReasoning(thinkingDelta);
@@ -5927,9 +5821,18 @@ export class AiManager {
       reasoning += finalReasoning;
       onThinkingDelta(finalReasoning);
     }
-    if (!content.trim()) throw new Error(`${protocolLabel} 流式响应缺少可用正文，finish_reason=${finishReason}`);
-    const cacheHitPercent = resolveCacheHitPercent(usage);
-    const outputTokens = resolveOutputTokens(usage, content);
+    const toolCalls: CompletionToolCall[] = openAiToolCallsFinalized
+      ? [...openAiToolCalls.entries()]
+        .sort(([left], [right]) => left - right)
+        .flatMap(([, toolCall]) => toolCall.id && toolCall.name ? [{
+          id: toolCall.id,
+          type: "function" as const,
+          function: { name: toolCall.name, arguments: toolCall.arguments }
+        }] : [])
+      : [];
+    if (!content.trim() && toolCalls.length === 0) {
+      throw new Error(`${protocolLabel} 流式响应缺少可用正文，finish_reason=${finishReason}`);
+    }
     const anthropicContent = protocol === "anthropic-messages"
       ? [...anthropicBlocks.entries()]
         .sort(([left], [right]) => left - right)
@@ -5938,14 +5841,18 @@ export class AiManager {
           return redactProviderSecrets(block, apiKey) as Record<string, unknown>;
         })
       : undefined;
-    return {
-      content,
-      reasoning,
-      outputTokens,
-      ...(cacheHitPercent === undefined ? {} : { cacheHitPercent }),
-      ...(anthropicContent?.length ? { anthropicContent } : {}),
-      tokenUsage: resolveAiTokenUsage(usage, estimatedInputTokens, outputTokens)
-    };
+    return redactProviderSecrets({
+      ...(usage && typeof usage === "object" && !Array.isArray(usage) ? { usage } : {}),
+      choices: [{
+        finish_reason: finishReason,
+        message: {
+          content: content || null,
+          reasoning_content: reasoning || null,
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+          ...(anthropicContent?.length ? { anthropic_content: anthropicContent } : {})
+        }
+      }]
+    }, apiKey) as CompletionPayload;
   }
 
   private async runChapterAnalysis(workId: string, scope: ContextScope, modelId?: string, taskId?: string): Promise<Record<string, unknown>> {

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1576,6 +1576,55 @@ describe("AI 供应商、模型与建议 API", () => {
     });
   });
 
+  it("工具定义开启时在上游响应结束前推送首个正文 delta", async () => {
+    const { providerId, modelId } = await configureAi();
+    await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    let upstreamFinished = false;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) {
+        return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      }
+      const body = JSON.parse(String(init?.body)) as {
+        stream?: boolean;
+        tools?: Array<{ function?: { name?: string } }>;
+      };
+      expect(body.stream).toBe(true);
+      expect(body.tools).toEqual(expect.arrayContaining([
+        expect.objectContaining({ function: expect.objectContaining({ name: "story_index" }) })
+      ]));
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          const encoder = new TextEncoder();
+          controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"首个"}}]}\n\n'));
+          setTimeout(() => {
+            upstreamFinished = true;
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"增量"},"finish_reason":"stop"}]}\n\n'));
+            controller.enqueue(encoder.encode('data: {"choices":[],"usage":{"prompt_tokens":20,"completion_tokens":4}}\n\n'));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          }, 20);
+        }
+      }), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    });
+
+    const deltas: string[] = [];
+    const firstDeltaBeforeUpstreamFinished: boolean[] = [];
+    const generated = await runtime.ai.createStreamingChat({
+      workId,
+      instruction: "不调用工具，直接回答。",
+      scope: { type: "chapter", chapterId },
+      modelId,
+      maxAttempts: 1
+    }, (delta) => {
+      if (deltas.length === 0) firstDeltaBeforeUpstreamFinished.push(!upstreamFinished);
+      deltas.push(delta);
+    });
+
+    expect(firstDeltaBeforeUpstreamFinished).toEqual([true]);
+    expect(deltas).toEqual(["首个", "增量"]);
+    expect(generated.content).toBe("首个增量");
+  });
+
   it("首轮对话默认使用提示词前十五字并可由独立模型生成标题", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
@@ -1796,13 +1845,35 @@ describe("AI 供应商、模型与建议 API", () => {
     let completionCount = 0;
     fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      const body = JSON.parse(String(init?.body)) as {
+        stream?: boolean;
+        tools?: Array<{ function?: { name?: string } }>;
+        messages: Array<{ role: string; reasoning_content?: string | null; tool_calls?: Array<{ function?: { arguments?: string } }> }>;
+      };
+      expect(body.stream).toBe(true);
+      expect(body.tools).toEqual(expect.arrayContaining([
+        expect.objectContaining({ function: expect.objectContaining({ name: "story_index" }) })
+      ]));
       completionCount += 1;
       if (completionCount === 1) {
-        return new Response(JSON.stringify({ choices: [{ message: { content: "我先读取作品目录。", reasoning_content: "需要先确认作品结构。", tool_calls: [{ id: "stream-tool", type: "function", function: { name: "story_index", arguments: "{\"limit\":1}" } }] } }], usage: { prompt_tokens: 100, prompt_tokens_details: { cached_tokens: 50 } } }), { status: 200 });
+        return new Response([
+          'data: {"choices":[{"delta":{"reasoning_content":"需要先确认作品结构。"}}]}',
+          'data: {"choices":[{"delta":{"content":"我先读取作品目录。"}}]}',
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"stream-tool","type":"function","function":{"name":"story_","arguments":"{\\"lim"}}]}}]}',
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"index","arguments":"it\\":1}"}}]},"finish_reason":"tool_calls"}]}',
+          'data: {"choices":[],"usage":{"prompt_tokens":100,"prompt_tokens_details":{"cached_tokens":50},"completion_tokens":6}}',
+          "data: [DONE]"
+        ].join("\n\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } });
       }
-      const body = JSON.parse(String(init?.body)) as { messages: Array<{ role: string; reasoning_content?: string | null }> };
       expect(body.messages.find((message) => message.role === "assistant")?.reasoning_content).toBe("需要先确认作品结构。");
-      return new Response(JSON.stringify({ choices: [{ message: { content: "已读取目录。", reasoning_content: "目录结果足以回答。" } }], usage: { prompt_tokens: 200, prompt_tokens_details: { cached_tokens: 150 }, completion_tokens: 8 } }), { status: 200 });
+      expect(body.messages.find((message) => message.role === "assistant")?.tool_calls?.[0]?.function?.arguments).toBe("{\"limit\":1}");
+      return new Response([
+        'data: {"choices":[{"delta":{"reasoning_content":"目录结果足以回答。"}}]}',
+        'data: {"choices":[{"delta":{"content":"已读取"}}]}',
+        'data: {"choices":[{"delta":{"content":"目录。"},"finish_reason":"stop"}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":200,"prompt_tokens_details":{"cached_tokens":150},"completion_tokens":8}}',
+        "data: [DONE]"
+      ].join("\n\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } });
     });
 
     const streamed = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
@@ -1814,17 +1885,22 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text).toContain("event: tool_call");
     expect(streamed.text).toContain("event: process_step");
     expect(streamed.text).toContain('"type":"thinking","round":1,"content":"需要先确认作品结构。"');
-    expect(streamed.text).toContain('"type":"intermediate","round":1,"content":"我先读取作品目录。"');
     expect(streamed.text).toContain('"type":"thinking","round":2,"content":"目录结果足以回答。"');
     expect(streamed.text.indexOf('"type":"thinking","round":1')).toBeLessThan(streamed.text.indexOf("event: tool_call"));
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"我先读取作品目录。"}');
+    expect(streamed.text.indexOf('"delta":"我先读取作品目录。"')).toBeLessThan(streamed.text.indexOf("event: tool_call"));
     expect(streamed.text).toContain('"name":"story_index"');
     expect(streamed.text).toContain('"arguments":{"offset":0,"limit":1}');
     expect(streamed.text).toMatch(/"calledAt":"\d{4}-\d{2}-\d{2}T/u);
     expect(streamed.text).toContain('"result":{"ok":true');
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"已读取"}');
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"目录。"}');
     expect(streamed.text).toContain('event: complete');
     expect(streamed.text).toContain('"outputTokens":8,"cacheHitPercent":66.7');
     expect(streamed.text).toContain('"toolCalls":[{"id":"stream-tool"');
     expect(streamed.text).toContain('"processSteps":[{"id":"process_');
+    const generatedSuggestions = await request(runtime.app).get(`/api/works/${workId}/suggestions`).expect(200);
+    expect(generatedSuggestions.body.data[0].content).toBe("我先读取作品目录。已读取目录。");
 
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const toolCalls = [{ id: "stream-tool", name: "story_index", calledAt: "2026-07-17T12:34:56.000Z", arguments: { offset: 0, limit: 1 }, status: "completed", result: { ok: true, data: { totalChapters: 1 } } }];

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1790,6 +1790,81 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text).toContain(`"modelRecordId":"${modelId}"`);
   });
 
+  it("OpenAI 工具参数收齐前只转发正文，结束标记后才执行工具并继续流式回答", async () => {
+    const { providerId, modelId } = await configureAi();
+    await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    let releaseFirstRound = (): void => undefined;
+    const firstRoundGate = new Promise<void>((resolve) => {
+      releaseFirstRound = resolve;
+    });
+    let firstRoundFinished = false;
+    let completionCount = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) {
+        return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      }
+      completionCount += 1;
+      const body = JSON.parse(String(init?.body)) as {
+        stream?: boolean;
+        tools?: Array<{ function?: { name?: string } }>;
+        messages: Array<{ role: string; tool_calls?: Array<{ function?: { arguments?: string } }> }>;
+      };
+      expect(body.stream).toBe(true);
+      expect(body.tools?.some((tool) => tool.function?.name === "story_index")).toBe(true);
+      if (completionCount === 1) {
+        return new Response(new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"我先读取目录。"}}]}\n\n'));
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"stream-tool","type":"function","function":{"name":"story_index","arguments":"{\\"lim"}}]}}]}\n\n'));
+            await firstRoundGate;
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"it\\":1}"}}]},"finish_reason":"tool_calls"}]}\n\n'));
+            controller.enqueue(encoder.encode('data: {"choices":[],"usage":{"prompt_tokens":20,"completion_tokens":5}}\n\n'));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            firstRoundFinished = true;
+            controller.close();
+          }
+        }), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+      }
+      const assistant = body.messages.find((message) => message.role === "assistant");
+      expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"limit":1}');
+      expect(body.messages.some((message) => message.role === "tool")).toBe(true);
+      return new Response([
+        'data: {"choices":[{"delta":{"content":"已读取"}}]}',
+        'data: {"choices":[{"delta":{"content":"目录。"},"finish_reason":"stop"}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":30,"completion_tokens":4}}',
+        "data: [DONE]"
+      ].join("\n\n") + "\n\n", { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    });
+
+    const deltas: string[] = [];
+    const toolEvents: Array<{ arguments: unknown }> = [];
+    const generatedPromise = runtime.ai.createStreamingChat({
+      workId,
+      instruction: "读取目录后回答。",
+      scope: { type: "chapter", chapterId },
+      modelId,
+      onToolCall: (toolCall) => toolEvents.push({ arguments: toolCall.arguments })
+    }, (delta) => deltas.push(delta));
+    const safetyRelease = setTimeout(releaseFirstRound, 1_000);
+    for (let index = 0; index < 100 && deltas.length === 0; index += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(deltas).toEqual(["我先读取目录。"]);
+    expect(toolEvents).toHaveLength(0);
+    expect(firstRoundFinished).toBe(false);
+    releaseFirstRound();
+    clearTimeout(safetyRelease);
+
+    const generated = await generatedPromise;
+    expect(generated.content).toBe("我先读取目录。已读取目录。");
+    expect(generated.toolCalls).toEqual([
+      expect.objectContaining({ id: "stream-tool", name: "story_index", arguments: { offset: 0, limit: 1 }, status: "completed" })
+    ]);
+    expect(toolEvents).toEqual([{ arguments: { offset: 0, limit: 1 } }]);
+    expect(completionCount).toBe(2);
+  });
+
   it("通过 SSE 推送工具调用并在对话 metadata 中持久化详情", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1839,6 +1839,81 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text).toContain(`"modelRecordId":"${modelId}"`);
   });
 
+  it("OpenAI 工具参数收齐前只转发正文，结束标记后才执行工具并继续流式回答", async () => {
+    const { providerId, modelId } = await configureAi();
+    await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    let releaseFirstRound = (): void => undefined;
+    const firstRoundGate = new Promise<void>((resolve) => {
+      releaseFirstRound = resolve;
+    });
+    let firstRoundFinished = false;
+    let completionCount = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) {
+        return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      }
+      completionCount += 1;
+      const body = JSON.parse(String(init?.body)) as {
+        stream?: boolean;
+        tools?: Array<{ function?: { name?: string } }>;
+        messages: Array<{ role: string; tool_calls?: Array<{ function?: { arguments?: string } }> }>;
+      };
+      expect(body.stream).toBe(true);
+      expect(body.tools?.some((tool) => tool.function?.name === "story_index")).toBe(true);
+      if (completionCount === 1) {
+        return new Response(new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"我先读取目录。"}}]}\n\n'));
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"stream-tool","type":"function","function":{"name":"story_index","arguments":"{\\"lim"}}]}}]}\n\n'));
+            await firstRoundGate;
+            controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"it\\":1}"}}]},"finish_reason":"tool_calls"}]}\n\n'));
+            controller.enqueue(encoder.encode('data: {"choices":[],"usage":{"prompt_tokens":20,"completion_tokens":5}}\n\n'));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            firstRoundFinished = true;
+            controller.close();
+          }
+        }), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+      }
+      const assistant = body.messages.find((message) => message.role === "assistant");
+      expect(assistant?.tool_calls?.[0]?.function?.arguments).toBe('{"limit":1}');
+      expect(body.messages.some((message) => message.role === "tool")).toBe(true);
+      return new Response([
+        'data: {"choices":[{"delta":{"content":"已读取"}}]}',
+        'data: {"choices":[{"delta":{"content":"目录。"},"finish_reason":"stop"}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":30,"completion_tokens":4}}',
+        "data: [DONE]"
+      ].join("\n\n") + "\n\n", { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    });
+
+    const deltas: string[] = [];
+    const toolEvents: Array<{ arguments: unknown }> = [];
+    const generatedPromise = runtime.ai.createStreamingChat({
+      workId,
+      instruction: "读取目录后回答。",
+      scope: { type: "chapter", chapterId },
+      modelId,
+      onToolCall: (toolCall) => toolEvents.push({ arguments: toolCall.arguments })
+    }, (delta) => deltas.push(delta));
+    const safetyRelease = setTimeout(releaseFirstRound, 1_000);
+    for (let index = 0; index < 100 && deltas.length === 0; index += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(deltas).toEqual(["我先读取目录。"]);
+    expect(toolEvents).toHaveLength(0);
+    expect(firstRoundFinished).toBe(false);
+    releaseFirstRound();
+    clearTimeout(safetyRelease);
+
+    const generated = await generatedPromise;
+    expect(generated.content).toBe("我先读取目录。已读取目录。");
+    expect(generated.toolCalls).toEqual([
+      expect.objectContaining({ id: "stream-tool", name: "story_index", arguments: { offset: 0, limit: 1 }, status: "completed" })
+    ]);
+    expect(toolEvents).toEqual([{ arguments: { offset: 0, limit: 1 } }]);
+    expect(completionCount).toBe(2);
+  });
+
   it("通过 SSE 推送工具调用并在对话 metadata 中持久化详情", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);

--- a/tests/integration/anthropic-messages-api.test.ts
+++ b/tests/integration/anthropic-messages-api.test.ts
@@ -172,6 +172,96 @@ describe("Anthropic Messages 供应商", () => {
     });
   });
 
+  it("Anthropic 工具参数在 content_block_stop 前只拼接，收齐后才执行并继续流式回答", async () => {
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: ["story_index"] }).expect(200);
+    let releaseToolBlock = (): void => undefined;
+    const toolBlockGate = new Promise<void>((resolve) => {
+      releaseToolBlock = resolve;
+    });
+    let firstRoundFinished = false;
+    let streamedCompletionCount = 0;
+    fetchMock.mockImplementation(async (_input, init) => {
+      streamedCompletionCount += 1;
+      const body = JSON.parse(String(init?.body)) as {
+        stream?: boolean;
+        tools?: Array<{ name?: string }>;
+        messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      };
+      expect(body.stream).toBe(true);
+      expect(body.tools?.some((tool) => tool.name === "story_index")).toBe(true);
+      if (streamedCompletionCount === 1) {
+        return new Response(new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            const send = (payload: Record<string, unknown>): void => {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+            };
+            send({ type: "message_start", message: { usage: { input_tokens: 20 } } });
+            send({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } });
+            send({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "我先读取目录。" } });
+            send({ type: "content_block_stop", index: 0 });
+            send({ type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_stream", name: "story_index", input: {} } });
+            send({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"lim' } });
+            await toolBlockGate;
+            send({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: 'it":1}' } });
+            send({ type: "content_block_stop", index: 1 });
+            send({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 5 } });
+            send({ type: "message_stop" });
+            firstRoundFinished = true;
+            controller.close();
+          }
+        }), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+      }
+      const assistant = body.messages.find((message) => message.role === "assistant");
+      expect(assistant?.content).toEqual(expect.arrayContaining([
+        { type: "tool_use", id: "toolu_stream", name: "story_index", input: { limit: 1 } }
+      ]));
+      const toolResult = body.messages.find((message) => (
+        message.role === "user" && message.content.some((block) => block.type === "tool_result")
+      ));
+      expect(toolResult?.content[0]).toMatchObject({ type: "tool_result", tool_use_id: "toolu_stream" });
+      return new Response([
+        { type: "message_start", message: { usage: { input_tokens: 30 } } },
+        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+        { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "已读取" } },
+        { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "目录。" } },
+        { type: "content_block_stop", index: 0 },
+        { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 4 } },
+        { type: "message_stop" }
+      ].map((payload) => `data: ${JSON.stringify(payload)}`).join("\n\n") + "\n\n", {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" }
+      });
+    });
+
+    const deltas: string[] = [];
+    const toolEvents: Array<{ arguments: unknown }> = [];
+    const generatedPromise = runtime.ai.createStreamingChat({
+      workId,
+      instruction: "读取目录后回答。",
+      scope: { type: "chapter", chapterId },
+      modelId,
+      onToolCall: (toolCall) => toolEvents.push({ arguments: toolCall.arguments })
+    }, (delta) => deltas.push(delta));
+    const safetyRelease = setTimeout(releaseToolBlock, 1_000);
+    for (let index = 0; index < 100 && deltas.length === 0; index += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(deltas).toEqual(["我先读取目录。"]);
+    expect(toolEvents).toHaveLength(0);
+    expect(firstRoundFinished).toBe(false);
+    releaseToolBlock();
+    clearTimeout(safetyRelease);
+
+    const generated = await generatedPromise;
+    expect(generated.content).toBe("我先读取目录。已读取目录。");
+    expect(generated.toolCalls).toEqual([
+      expect.objectContaining({ id: "toolu_stream", name: "story_index", arguments: { offset: 0, limit: 1 }, status: "completed" })
+    ]);
+    expect(toolEvents).toEqual([{ arguments: { offset: 0, limit: 1 } }]);
+    expect(streamedCompletionCount).toBe(2);
+  });
+
   it("解析 LongCat Messages SSE 的思考、正文与用量", async () => {
     streaming = true;
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: [] }).expect(200);

--- a/tests/integration/anthropic-messages-api.test.ts
+++ b/tests/integration/anthropic-messages-api.test.ts
@@ -196,4 +196,70 @@ describe("Anthropic Messages 供应商", () => {
       cacheHitRate: 33.3
     });
   });
+
+  it("流式收集 tool_use 参数、执行工具并继续输出正文", async () => {
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: ["story_index"] }).expect(200);
+    let streamRound = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      expect(String(input)).toBe("https://api.longcat.chat/anthropic/v1/messages");
+      const body = JSON.parse(String(init?.body)) as {
+        stream?: boolean;
+        tools?: Array<{ name?: string }>;
+        tool_choice?: Record<string, unknown>;
+        messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      };
+      expect(body.stream).toBe(true);
+      expect(body.tools).toEqual(expect.arrayContaining([expect.objectContaining({ name: "story_index" })]));
+      expect(body.tool_choice).toEqual({ type: "auto" });
+      streamRound += 1;
+      if (streamRound === 1) {
+        return new Response([
+          'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":30}}}',
+          'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"先读取目录。"}}',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"stream-signature"}}',
+          'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}',
+          'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_stream","name":"story_index","input":{}}}',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"lim"}}',
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"it\\":1}"}}',
+          'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}',
+          'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":8}}',
+          'event: message_stop\ndata: {"type":"message_stop"}'
+        ].join("\n\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+      }
+
+      const assistant = body.messages.find((message) => message.role === "assistant");
+      expect(assistant?.content).toEqual(expect.arrayContaining([
+        { type: "thinking", thinking: "先读取目录。", signature: "stream-signature" },
+        { type: "tool_use", id: "toolu_stream", name: "story_index", input: { limit: 1 } }
+      ]));
+      const toolResult = body.messages.find((message) => message.role === "user"
+        && message.content.some((block) => block.type === "tool_result"));
+      expect(toolResult?.content[0]).toMatchObject({ type: "tool_result", tool_use_id: "toolu_stream" });
+      return new Response([
+        'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":50}}}',
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"已读取"}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"目录。"}}',
+        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}',
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}',
+        'event: message_stop\ndata: {"type":"message_stop"}'
+      ].join("\n\n"), { status: 200, headers: { "Content-Type": "text/event-stream" } });
+    });
+
+    const response = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+      instruction: "读取目录后回答。",
+      scope: { type: "chapter", chapterId },
+      modelId
+    }).expect(200).expect("Content-Type", /text\/event-stream/u);
+
+    expect(streamRound).toBe(2);
+    expect(response.text).toContain('event: tool_call');
+    expect(response.text).toContain('"id":"toolu_stream","name":"story_index"');
+    expect(response.text).toContain('event: delta\ndata: {"delta":"已读取"}');
+    expect(response.text).toContain('event: delta\ndata: {"delta":"目录。"}');
+    expect(response.text.indexOf("event: tool_call")).toBeLessThan(response.text.indexOf('"delta":"已读取"'));
+    const suggestions = await request(runtime.app).get(`/api/works/${workId}/suggestions`).expect(200);
+    expect(suggestions.body.data[0].content).toBe("已读取目录。");
+  });
 });

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -1008,7 +1008,9 @@ describe("作者完整创作流程", () => {
       scope: { type: "chapter", chapterId },
       modelId: model.body.data.id
     }).expect(200).expect("Content-Type", /text\/event-stream/u);
-    expect(streamed.text).toContain('event: delta\ndata: {"delta":"舱门关闭，林舟望向逐渐远去的北港。"}');
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"舱门关闭，"}');
+    expect(streamed.text).toContain('event: delta\ndata: {"delta":"飞船离开北港。"}');
+    expect(streamed.text.indexOf('"delta":"舱门关闭，"')).toBeLessThan(streamed.text.indexOf('"delta":"飞船离开北港。"'));
     expect(streamed.text).toContain("event: complete");
 
     const suggestion = await request(runtime.app).post(`/api/works/${workId}/suggestions`).send({


### PR DESCRIPTION
Closes MUXUE-8. Depends on #387 and includes its latest reconciled head via merge commit 605a217. Adds the strict protocol boundary on top: OpenAI tool calls are exposed only after finish_reason=tool_calls, Anthropic inputs only after content_block_stop, incomplete calls fail without execution, and both paths have gated timing coverage.