### PR TITLE
MUXUE-17: virtualize chapter editor line rendering

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -3,7 +3,8 @@ import { collapseExcessBlankLines, formatDateTime, normalizeParagraphSpacing } f
 import { renderMarkdown } from "/markdown.js?v=20260731-no-external-images-v1";
 import { findAiMention, listAiMentionOptions, mergeAiReferenceScope } from "/ai-mentions.js?v=20260801-context-setting-mention-v1";
 import { shouldShowAiQuickActions } from "/ai-conversation.js?v=20260713-quick-actions";
-import { calculateLineNumberRowHeight, calculateLineNumberRowTop, calculateLineNumberTextOffset, calculateLineNumberTop } from "/line-number-layout.js?v=20260713-row-box-alignment";
+import { calculateLineNumberTextOffset, calculateLineNumberTop } from "/line-number-layout.js?v=20260713-row-box-alignment";
+import { buildChapterLineMirror, findChapterLineWindow } from "/chapter-editor-virtualization.js?v=20260810-visible-lines-v1";
 import { buildVditorLineNumberRows } from "/vditor-line-number-layout.js?v=20260729-vditor-line-numbers-v3";
 import { MIN_MODEL_CONTEXT_WINDOW, MODEL_PURPOSE_OPTIONS, isKimiModelId, modelContextWindowGuidance, modelFormValues, modelOptionLabel, modelPayload, supportsMultimodalModelProtocol } from "/model-config.js?v=20260803-multimodal-model-config-v2";
 import { shouldSendAiPrompt } from "/ai-prompt-keyboard.js?v=20260713-enter-to-send";
@@ -939,6 +940,9 @@ function setupPanelResize(handle, side) {
 }
 
 let chapterLineNumberFrame = null;
+let chapterLineNumberTimer = null;
+let chapterLineLayout = null;
+let chapterLineVirtualWindow = null;
 let chapterLineSelection = null;
 let chapterLineDrag = null;
 let chapterWhitespaceVisible = true;
@@ -948,6 +952,7 @@ let chapterSaveGuardInFlight = null;
 let lastSavedChapterSnapshot = null;
 let moduleNavExpanded = false;
 const chapterAutoSaveDelay = 800;
+const chapterLineInputRenderDelay = 32;
 let aiMentionMatch = null;
 let aiMentionRange = null;
 let aiMentionActiveIndex = -1;
@@ -1104,6 +1109,13 @@ function syncChapterLineNumberScroll() {
     whitespace.style.transform = `translate(${-input.scrollLeft}px, ${-input.scrollTop}px)`;
     whitespace.dataset.scrollTop = String(input.scrollTop);
   }
+  if (!chapterLineVirtualWindow) return;
+  const buffer = input.clientHeight * 0.35;
+  const viewportBottom = input.scrollTop + input.clientHeight;
+  const needsPreviousLines = chapterLineVirtualWindow.start > 0 && input.scrollTop < chapterLineVirtualWindow.top + buffer;
+  const needsNextLines = chapterLineVirtualWindow.end < chapterLineVirtualWindow.lineCount
+    && viewportBottom > chapterLineVirtualWindow.bottom - buffer;
+  if (needsPreviousLines || needsNextLines) scheduleChapterLineNumbers();
 }
 
 function syncChapterWhitespaceControls() {
@@ -1119,7 +1131,7 @@ function toggleChapterWhitespaceVisibility() {
   scheduleChapterLineNumbers();
 }
 
-function renderChapterWhitespaceMarkers(input, style) {
+function renderChapterWhitespaceMarkers(input, style, layout, lineWindow, getLineBounds, totalHeight) {
   const overlay = $("#chapter-whitespace-overlay");
   const inner = $("#chapter-whitespace-inner");
   syncChapterWhitespaceControls();
@@ -1127,10 +1139,17 @@ function renderChapterWhitespaceMarkers(input, style) {
   overlay.classList.toggle("is-visible", chapterWhitespaceVisible);
   if (!chapterWhitespaceVisible) {
     inner.replaceChildren();
+    delete inner.dataset.virtualStart;
+    delete inner.dataset.virtualEnd;
+    delete inner.dataset.renderedLineCount;
     return;
   }
+  const paddingTop = parseFloat(style.paddingTop) || 0;
+  const paddingBottom = parseFloat(style.paddingBottom) || 0;
+  const firstLineTop = getLineBounds(lineWindow.start).top;
   Object.assign(inner.style, {
     width: `${input.clientWidth}px`,
+    height: `${Math.max(input.clientHeight, totalHeight + paddingTop + paddingBottom)}px`,
     fontFamily: style.fontFamily,
     fontSize: style.fontSize,
     fontWeight: style.fontWeight,
@@ -1139,11 +1158,14 @@ function renderChapterWhitespaceMarkers(input, style) {
     letterSpacing: style.letterSpacing,
     tabSize: style.tabSize,
     padding: style.padding,
+    paddingTop: `${paddingTop + firstLineTop}px`,
+    whiteSpace: style.whiteSpace,
     overflowWrap: style.overflowWrap,
     wordBreak: style.wordBreak
   });
   const fragment = document.createDocumentFragment();
-  for (const token of tokenizeVisibleSpaces(input.value.replace(/\r\n?/gu, "\n"))) {
+  const visibleText = layout.lines.slice(lineWindow.start, lineWindow.end).join("\n");
+  for (const token of tokenizeVisibleSpaces(visibleText)) {
     if (token.type === "text") {
       fragment.append(document.createTextNode(token.text));
       continue;
@@ -1155,9 +1177,93 @@ function renderChapterWhitespaceMarkers(input, style) {
     fragment.append(marker);
   }
   inner.replaceChildren(fragment);
+  inner.dataset.virtualStart = String(lineWindow.start);
+  inner.dataset.virtualEnd = String(lineWindow.end - 1);
+  inner.dataset.renderedLineCount = String(lineWindow.end - lineWindow.start);
 }
 
-function renderChapterLineNumbers() {
+function prepareChapterLineLayout(input, measure, style, contentWidth) {
+  Object.assign(measure.style, {
+    width: `${contentWidth}px`,
+    fontFamily: style.fontFamily,
+    fontSize: style.fontSize,
+    fontWeight: style.fontWeight,
+    fontStyle: style.fontStyle,
+    lineHeight: style.lineHeight,
+    letterSpacing: style.letterSpacing,
+    tabSize: style.tabSize,
+    overflowWrap: style.overflowWrap,
+    wordBreak: style.wordBreak
+  });
+  const value = input.value.replace(/\r\n?/gu, "\n");
+  const styleKey = JSON.stringify([
+    contentWidth,
+    style.fontFamily,
+    style.fontSize,
+    style.fontWeight,
+    style.fontStyle,
+    style.lineHeight,
+    style.letterSpacing,
+    style.tabSize,
+    style.overflowWrap,
+    style.wordBreak
+  ]);
+  if (!chapterLineLayout || chapterLineLayout.value !== value) {
+    const mirror = buildChapterLineMirror(value);
+    measure.textContent = mirror.text;
+    chapterLineLayout = { ...mirror, value, styleKey, bounds: new Map() };
+  } else if (chapterLineLayout.styleKey !== styleKey) {
+    chapterLineLayout.styleKey = styleKey;
+    chapterLineLayout.bounds.clear();
+  }
+  return chapterLineLayout;
+}
+
+function createChapterLineBoundsGetter(layout, measure, lineHeight, targetHeight = null) {
+  const textNode = measure.firstChild;
+  const measureRect = measure.getBoundingClientRect();
+  const contentHeight = Number.isFinite(targetHeight) && targetHeight > 0 ? targetHeight : measureRect.height;
+  const geometryScale = measureRect.height > 0 ? contentHeight / measureRect.height : 1;
+  const geometryKey = `${measureRect.height}:${contentHeight}:${lineHeight}`;
+  if (layout.geometryKey !== geometryKey) {
+    layout.geometryKey = geometryKey;
+    layout.bounds.clear();
+  }
+  return {
+    measureHeight: contentHeight,
+    getLineBounds(index) {
+      const cached = layout.bounds.get(index);
+      if (cached) return cached;
+      const range = document.createRange();
+      const start = layout.offsets[index];
+      range.setStart(textNode, start);
+      range.setEnd(textNode, start + layout.lines[index].length + 1);
+      const rects = [...range.getClientRects()].filter((rect) => rect.height > 0);
+      let top;
+      let bottom;
+      if (rects.length > 0) {
+        const lineBoxes = rects.map((rect) => {
+          const height = Math.max(lineHeight, rect.height);
+          const leading = Math.max(0, (lineHeight - rect.height) / 2);
+          const boxTop = (rect.top - measureRect.top - leading) * geometryScale;
+          return { top: boxTop, bottom: boxTop + height * geometryScale };
+        });
+        top = Math.max(0, Math.min(...lineBoxes.map((box) => box.top)));
+        bottom = Math.max(...lineBoxes.map((box) => box.bottom));
+      } else {
+        const scaledLineHeight = lineHeight * geometryScale;
+        const availableHeight = Math.max(0, contentHeight - scaledLineHeight);
+        top = layout.lines.length > 1 ? availableHeight * index / (layout.lines.length - 1) : 0;
+        bottom = top + scaledLineHeight;
+      }
+      const bounds = { top, bottom: Math.max(top + lineHeight * geometryScale, bottom) };
+      layout.bounds.set(index, bounds);
+      return bounds;
+    }
+  };
+}
+
+function renderChapterLineNumbers({ targetLineIndex = null } = {}) {
   const input = $("#chapter-content");
   const inner = $("#chapter-line-numbers-inner");
   const measure = $("#chapter-line-measure");
@@ -1167,28 +1273,28 @@ function renderChapterLineNumbers() {
   const lineHeight = parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.55;
   const numberStyle = getComputedStyle($("#chapter-line-numbers"));
   const numberLineHeight = parseFloat(numberStyle.lineHeight) || parseFloat(numberStyle.fontSize) * 1.2;
-  inner.style.top = `${calculateLineNumberTop(parseFloat(style.paddingTop), lineHeight, numberLineHeight)}px`;
+  const paddingTop = parseFloat(style.paddingTop) || 0;
+  inner.style.top = `${calculateLineNumberTop(paddingTop, lineHeight, numberLineHeight)}px`;
   const numberTextOffset = calculateLineNumberTextOffset(lineHeight, numberLineHeight);
-  Object.assign(measure.style, {
-    width: `${contentWidth}px`,
-    fontFamily: style.fontFamily,
-    fontSize: style.fontSize,
-    fontWeight: style.fontWeight,
-    fontStyle: style.fontStyle,
-    lineHeight: style.lineHeight,
-    letterSpacing: style.letterSpacing,
-    tabSize: style.tabSize
-  });
-  const lines = input.value.replace(/\r\n?/gu, "\n").split("\n");
-  const measureRows = lines.map((line) => {
-    const row = document.createElement("div");
-    row.textContent = line || "\u200b";
-    return row;
-  });
-  measure.replaceChildren(...measureRows);
-  const measureRect = measure.getBoundingClientRect();
+  const layout = prepareChapterLineLayout(input, measure, style, contentWidth);
+  const paddingBottom = parseFloat(style.paddingBottom) || 0;
+  const scrollContentHeight = input.scrollHeight - paddingTop - paddingBottom;
+  const targetHeight = input.scrollHeight > input.clientHeight + 1 ? scrollContentHeight : null;
+  const { getLineBounds, measureHeight } = createChapterLineBoundsGetter(layout, measure, lineHeight, targetHeight);
+  if (Number.isInteger(targetLineIndex)) {
+    const safeTarget = Math.max(0, Math.min(targetLineIndex, layout.lines.length - 1));
+    input.scrollTop = Math.max(0, getLineBounds(safeTarget).top + paddingTop - input.clientHeight / 3);
+  }
+  const viewportTop = Math.max(0, input.scrollTop - paddingTop);
+  const overscan = Math.max(input.clientHeight, lineHeight * 8);
+  const lineWindow = findChapterLineWindow(
+    layout.lines.length,
+    getLineBounds,
+    viewportTop - overscan,
+    viewportTop + input.clientHeight + overscan
+  );
   const numbers = document.createDocumentFragment();
-  measureRows.forEach((row, index) => {
+  for (let index = lineWindow.start; index < lineWindow.end; index += 1) {
     const number = document.createElement("button");
     number.type = "button";
     number.className = "chapter-line-number";
@@ -1201,27 +1307,54 @@ function renderChapterLineNumbers() {
       number.classList.add("is-line-selected");
       number.setAttribute("aria-pressed", "true");
     }
-    const rowRect = row.getBoundingClientRect();
-    const rowHeight = calculateLineNumberRowHeight(lineHeight, rowRect.height);
-    number.style.top = `${calculateLineNumberRowTop(measureRect.top, rowRect.top)}px`;
-    number.style.height = `${rowHeight}px`;
+    const bounds = getLineBounds(index);
+    number.style.top = `${bounds.top}px`;
+    number.style.height = `${bounds.bottom - bounds.top}px`;
     number.style.paddingTop = `${numberTextOffset}px`;
     numbers.append(number);
-  });
+  }
   inner.replaceChildren(numbers);
-  inner.style.height = `${measureRect.height}px`;
-  inner.dataset.lineCount = String(lines.length);
-  measure.replaceChildren();
-  renderChapterWhitespaceMarkers(input, style);
+  inner.style.height = `${measureHeight}px`;
+  inner.dataset.lineCount = String(layout.lines.length);
+  inner.dataset.virtualStart = String(lineWindow.start);
+  inner.dataset.virtualEnd = String(lineWindow.end - 1);
+  inner.dataset.renderedLineCount = String(lineWindow.end - lineWindow.start);
+  const firstBounds = getLineBounds(lineWindow.start);
+  const lastBounds = getLineBounds(lineWindow.end - 1);
+  chapterLineVirtualWindow = {
+    start: lineWindow.start,
+    end: lineWindow.end,
+    lineCount: layout.lines.length,
+    top: firstBounds.top + paddingTop,
+    bottom: lastBounds.bottom + paddingTop
+  };
+  renderChapterWhitespaceMarkers(input, style, layout, lineWindow, getLineBounds, measureHeight);
   syncChapterLineNumberScroll();
 }
 
-function scheduleChapterLineNumbers() {
+function requestChapterLineNumberFrame() {
   if (chapterLineNumberFrame !== null) return;
   chapterLineNumberFrame = requestAnimationFrame(() => {
     chapterLineNumberFrame = null;
     renderChapterLineNumbers();
   });
+}
+
+function scheduleChapterLineNumbers(delay = 0) {
+  const wait = typeof delay === "number" && Number.isFinite(delay) ? Math.max(0, delay) : 0;
+  if (wait === 0) {
+    if (chapterLineNumberTimer !== null) {
+      clearTimeout(chapterLineNumberTimer);
+      chapterLineNumberTimer = null;
+    }
+    requestChapterLineNumberFrame();
+    return;
+  }
+  if (chapterLineNumberFrame !== null || chapterLineNumberTimer !== null) return;
+  chapterLineNumberTimer = setTimeout(() => {
+    chapterLineNumberTimer = null;
+    requestChapterLineNumberFrame();
+  }, wait);
 }
 
 function collapseChapterInputBlankLines(input) {
@@ -1240,10 +1373,10 @@ function collapseChapterInputBlankLines(input) {
 function lineIndexAtPointer(clientY) {
   const rows = [...$("#chapter-line-numbers-inner").querySelectorAll(".chapter-line-number")];
   if (!rows.length) return 0;
-  for (let index = 0; index < rows.length; index += 1) {
-    if (clientY < rows[index].getBoundingClientRect().bottom) return index;
+  for (const row of rows) {
+    if (clientY < row.getBoundingClientRect().bottom) return Number(row.dataset.lineIndex);
   }
-  return rows.length - 1;
+  return Number(rows[rows.length - 1].dataset.lineIndex);
 }
 
 function paintChapterLineSelection(anchor, focus) {
@@ -4624,10 +4757,8 @@ function revealChapterSearchLines(startLine, endLine) {
   input.setSelectionRange(selection.startOffset, selection.startOffset + selection.text.length);
   scheduleChapterLineNumbers();
   requestAnimationFrame(() => {
+    renderChapterLineNumbers({ targetLineIndex: selection.safeStart });
     paintChapterLineSelection(selection.safeStart, selection.safeEnd);
-    const row = $("#chapter-line-numbers-inner").querySelector(`[data-line-index="${selection.safeStart}"]`);
-    if (row) input.scrollTop = Math.max(0, row.offsetTop - input.clientHeight / 3);
-    syncChapterLineNumberScroll();
   });
 }
 
@@ -12522,7 +12653,7 @@ $("#chapter-content").addEventListener("input", (event) => {
   updateChapterStats();
   scheduleChapterAutoSave();
   clearChapterLineSelection();
-  scheduleChapterLineNumbers();
+  scheduleChapterLineNumbers(chapterLineInputRenderDelay);
   setAiContextMeter(null);
 });
 $("#chapter-content").addEventListener("select", () => setAiContextMeter(null));

--- a/src/public/chapter-editor-virtualization.js
+++ b/src/public/chapter-editor-virtualization.js
@@ -1,0 +1,52 @@
+const lineMarker = "\u200b";
+
+export function buildChapterLineMirror(value) {
+  const lines = String(value ?? "").replace(/\r\n?/gu, "\n").split("\n");
+  const offsets = [];
+  const parts = [];
+  let offset = 0;
+  lines.forEach((line, index) => {
+    offsets.push(offset);
+    parts.push(lineMarker, line);
+    offset += lineMarker.length + line.length;
+    if (index < lines.length - 1) {
+      parts.push("\n");
+      offset += 1;
+    }
+  });
+  return { lines, offsets, text: parts.join("") };
+}
+
+export function findChapterLineWindow(lineCount, getBounds, viewportStart, viewportEnd) {
+  const count = Math.max(0, Math.floor(Number(lineCount) || 0));
+  if (count === 0) return { start: 0, end: 0 };
+  const startTarget = Number.isFinite(Number(viewportStart)) ? Number(viewportStart) : 0;
+  const endTarget = Math.max(startTarget, Number.isFinite(Number(viewportEnd)) ? Number(viewportEnd) : startTarget);
+
+  let low = 0;
+  let high = count - 1;
+  let start = count - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (getBounds(middle).bottom >= startTarget) {
+      start = middle;
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
+  }
+
+  low = start;
+  high = count - 1;
+  let end = start;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (getBounds(middle).top <= endTarget) {
+      end = middle;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return { start, end: end + 1 };
+}

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -71,6 +71,7 @@ describe("作者完整创作流程", () => {
     const page = await request(runtime.app).get("/").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
     const application = await request(runtime.app).get("/app.js").expect(200);
+    const chapterVirtualization = await request(runtime.app).get("/chapter-editor-virtualization.js").expect(200);
     expect(page.text).toContain('<div class="editor-body">');
     expect(page.text).not.toContain('id="chapter-insight"');
     expect(page.text).toContain('id="insight-button" class="ghost-button" type="button" aria-controls="chapter-insight-toast" aria-expanded="false"');
@@ -93,9 +94,14 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".chapter-stats { display: none; }");
     expect(styles.text).toContain(".editor-body { display: flex; min-height: 0; flex-direction: column; }");
     expect(styles.text).toContain(".chapter-editor-frame { position: relative; display: grid;");
-    expect(application.text).toContain("function renderChapterLineNumbers()");
+    expect(application.text).toContain("function renderChapterLineNumbers({ targetLineIndex = null } = {})");
     expect(application.text).toContain("syncChapterLineNumberScroll");
-    expect(application.text).toContain("function renderChapterWhitespaceMarkers(input, style)");
+    expect(application.text).toContain("function renderChapterWhitespaceMarkers(input, style, layout, lineWindow, getLineBounds, totalHeight)");
+    expect(application.text).toContain('/chapter-editor-virtualization.js?v=20260810-visible-lines-v1');
+    expect(application.text).toContain("scheduleChapterLineNumbers(chapterLineInputRenderDelay)");
+    expect(application.text).toContain("inner.dataset.renderedLineCount");
+    expect(chapterVirtualization.text).toContain("export function buildChapterLineMirror(value)");
+    expect(chapterVirtualization.text).toContain("export function findChapterLineWindow(lineCount, getBounds, viewportStart, viewportEnd)");
     expect(application.text).toContain('element.className = "toast chapter-insight-toast"');
     expect(application.text).toContain('element.id = "chapter-insight-toast"');
     expect(application.text).toContain('chapterName.className = "chapter-insight-toast-chapter-title"');

--- a/tests/unit/chapter-editor-virtualization.test.ts
+++ b/tests/unit/chapter-editor-virtualization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error 浏览器端模块没有单独的类型声明，测试仅调用纯函数导出。
+import { buildChapterLineMirror, findChapterLineWindow } from "../../src/public/chapter-editor-virtualization.js";
+
+describe("正文编辑器可视区虚拟化", () => {
+  it("构建单文本节点镜像并保留空行与规范化后的偏移", () => {
+    const mirror = buildChapterLineMirror("甲\r\n\r\n乙");
+
+    expect(mirror.lines).toEqual(["甲", "", "乙"]);
+    expect(mirror.text).toBe("\u200b甲\n\u200b\n\u200b乙");
+    expect(mirror.offsets).toEqual([0, 3, 5]);
+    expect(mirror.offsets.map((offset: number, index: number) => (
+      mirror.text.slice(offset + 1, offset + 1 + mirror.lines[index].length)
+    ))).toEqual(mirror.lines);
+  });
+
+  it("空正文仍生成一个可测量的逻辑行", () => {
+    expect(buildChapterLineMirror("")).toEqual({ lines: [""], offsets: [0], text: "\u200b" });
+  });
+
+  it("按可视高度二分选出包含软换行高度的逻辑行窗口", () => {
+    const rows = [
+      { top: 0, bottom: 24 },
+      { top: 24, bottom: 72 },
+      { top: 72, bottom: 96 },
+      { top: 96, bottom: 144 },
+      { top: 144, bottom: 168 }
+    ];
+
+    expect(findChapterLineWindow(rows.length, (index: number) => rows[index], 50, 118)).toEqual({ start: 1, end: 4 });
+    expect(findChapterLineWindow(rows.length, (index: number) => rows[index], -100, 10)).toEqual({ start: 0, end: 1 });
+    expect(findChapterLineWindow(rows.length, (index: number) => rows[index], 200, 240)).toEqual({ start: 4, end: 5 });
+  });
+});


### PR DESCRIPTION
## Summary

- virtualize chapter line numbers and whitespace markers to the visible viewport with overscan
- keep a single-text-node measurement mirror and cache on-demand logical-line geometry
- throttle input-triggered rebuilds while preserving line drag selection, citations, and whitespace toggling

## Verification

- `npm run check` — 137 test files, 705 tests, typecheck, and production build passed
- 5000-line browser fixture at 1280×720 and 390×844 — line/whitespace DOM stayed bounded, drag selection and citations passed
- isolated health check and SQLite integrity/foreign-key checks passed
