### PR TITLE
MUXUE-21: enforce scoped global replace access

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -178,7 +178,7 @@ const settingSchema = z.object({
 const globalReplaceSchema = z.object({
   find: z.string().min(1).max(500),
   replacement: z.string().max(200_000),
-  scope: z.enum(["prose", "settings", "prose-and-settings"]).default("prose")
+  scope: z.enum(["prose", "settings", "prose-and-settings"])
 }).strict();
 
 const draftSchema = z.object({

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -898,6 +898,14 @@ function aiContextReadModules(request: Request): WorkPermissionModule[] {
   return [...modules];
 }
 
+function globalReplaceWriteModules(request: Request): WorkPermissionModule[] {
+  const scope = requestBodyRecord(request).scope;
+  if (scope === "prose") return ["prose"];
+  if (scope === "settings") return ["settings"];
+  if (scope === "prose-and-settings") return ["prose", "settings"];
+  return [];
+}
+
 function workModuleRequirements(request: Request, write: boolean): WorkAuthorizationRequirements {
   const pathname = normalizeApiPath(request.path);
   const direct = (module: WorkPermissionModule, extraWrite: WorkPermissionModule[] = []): WorkAuthorizationRequirements => (
@@ -924,7 +932,7 @@ function workModuleRequirements(request: Request, write: boolean): WorkAuthoriza
     return write ? { write: [...proseReplacementPermissionModules] } : { read: ["prose"] };
   }
   if (write && /^\/api\/works\/[^/]+\/replace$/u.test(pathname)) {
-    return {};
+    return { anyWrite: globalReplaceWriteModules(request) };
   }
   if (/^\/api\/chapters\/[^/]+\/outline$/u.test(pathname)) return direct("outlines");
   if (/^\/api\/(?:chapters\/[^/]+\/annotations|chapter-annotations\/[^/]+)$/u.test(pathname)) return direct("prose");

--- a/tests/integration/global-replace-api.test.ts
+++ b/tests/integration/global-replace-api.test.ts
@@ -30,10 +30,10 @@ describe("全局替换 API", () => {
 
   afterEach(() => runtime.close());
 
-  it("默认只替换正文并创建章节版本", async () => {
+  it("只替换正文并创建章节版本", async () => {
     const response = await request(runtime.app)
       .post(`/api/works/${workId}/replace`)
-      .send({ find: "共同词", replacement: "正文词" })
+      .send({ find: "共同词", replacement: "正文词", scope: "prose" })
       .expect(200);
 
     expect(response.body.data).toMatchObject({
@@ -105,13 +105,20 @@ describe("全局替换 API", () => {
     )?.count;
     const response = await request(runtime.app)
       .post(`/api/works/${workId}/replace`)
-      .send({ find: "不存在的文字", replacement: "替换" })
+      .send({ find: "不存在的文字", replacement: "替换", scope: "prose" })
       .expect(200);
     expect(response.body.data).toMatchObject({ chapterCount: 0, settingCount: 0, totalMatches: 0 });
     expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?", chapterId)?.count).toBe(beforeChapterVersions);
     expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?", settingId)?.count).toBe(beforeSettingVersions);
 
+    const missingScope = await request(runtime.app)
+      .post(`/api/works/${workId}/replace`)
+      .send({ find: "共同词", replacement: "不应替换" })
+      .expect(400);
+    expect(missingScope.body.error.code).toBe("VALIDATION_ERROR");
     await request(runtime.app).post(`/api/works/${workId}/replace`).send({ find: "共同词", replacement: "替换", scope: "unknown" }).expect(400);
     await request(runtime.app).post(`/api/works/${workId}/replace`).send({ find: "", replacement: "替换" }).expect(400);
+    expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?", chapterId)?.count).toBe(beforeChapterVersions);
+    expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?", settingId)?.count).toBe(beforeSettingVersions);
   });
 });

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -826,6 +826,20 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-CSRF-Token", viewer.csrfToken)
       .send({ title: "越权设定", category: "世界规则", content: "不应创建。" })
       .expect(403);
+    const chapterVersionsBeforeMissingScopeReplace = Number(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?",
+      chapter.body.data.id
+    )?.count);
+    const missingScopeReplace = await viewer.agent.post(`/api/works/${workId}/replace`)
+      .set("X-CSRF-Token", viewer.csrfToken)
+      .send({ find: "只能阅读", replacement: "越权替换" })
+      .expect(400);
+    expect(missingScopeReplace.body.error.code).toBe("VALIDATION_ERROR");
+    expect(runtime.database.get("SELECT content FROM chapters WHERE id = ?", chapter.body.data.id)?.content).toBe("只能阅读的正文。");
+    expect(Number(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?",
+      chapter.body.data.id
+    )?.count)).toBe(chapterVersionsBeforeMissingScopeReplace);
     const replaceWrite = await viewer.agent.post(`/api/works/${workId}/replace`)
       .set("X-CSRF-Token", viewer.csrfToken)
       .send({ find: "只能阅读", replacement: "越权替换", scope: "prose-and-settings" })
@@ -1214,6 +1228,17 @@ describe("用户、作品权限与操作者追踪 API", () => {
       "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?",
       editableSettingId
     )?.count);
+    const missingScopeReplace = await collaborator.agent.post(`/api/works/${workId}/replace`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ find: "正文侧替换", replacement: "不应替换" })
+      .expect(400);
+    expect(missingScopeReplace.body.error.code).toBe("VALIDATION_ERROR");
+    expect(runtime.database.get("SELECT content FROM chapters WHERE id = ?", chapter.body.data.id)?.content)
+      .toBe("已批量替换正文编辑，正文侧替换。");
+    expect(Number(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?",
+      chapter.body.data.id
+    )?.count)).toBe(chapterVersionsBeforeReadOnlyReplace);
     const combinedReplaceDenied = await collaborator.agent.post(`/api/works/${workId}/replace`)
       .set("X-CSRF-Token", collaborator.csrfToken)
       .send({ find: "正文侧替换", replacement: "不应替换", scope: "prose-and-settings" })

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -826,6 +826,11 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-CSRF-Token", viewer.csrfToken)
       .send({ title: "越权设定", category: "世界规则", content: "不应创建。" })
       .expect(403);
+    const replaceWrite = await viewer.agent.post(`/api/works/${workId}/replace`)
+      .set("X-CSRF-Token", viewer.csrfToken)
+      .send({ find: "只能阅读", replacement: "越权替换", scope: "prose-and-settings" })
+      .expect(403);
+    expect(replaceWrite.body.error.code).toBe("WORK_EDIT_DENIED");
     const mergeBody = {
       targetCharacterId: firstCharacter.body.data.id,
       expectedTargetVersionNo: firstCharacter.body.data.versionNo,
@@ -855,6 +860,11 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-CSRF-Token", viewer.csrfToken)
       .send({ content: "获得编辑权限后的修改。" })
       .expect(200);
+    const editorReplace = await viewer.agent.post(`/api/works/${workId}/replace`)
+      .set("X-CSRF-Token", viewer.csrfToken)
+      .send({ find: "获得编辑权限", replacement: "完整编辑权限", scope: "prose" })
+      .expect(200);
+    expect(editorReplace.body.data).toMatchObject({ scope: "prose", chapterCount: 1, totalMatches: 1 });
     expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
   });
 
@@ -1050,28 +1060,21 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .send({ find: "允许", replacement: "已经", scope: "settings" })
       .expect(200);
     expect(settingsReplace.body.data).toMatchObject({ scope: "settings", settingCount: 1, totalMatches: 1 });
-    const chapterVersionsBeforeSkippedProseReplace = Number(runtime.database.get(
+    const chapterVersionsBeforeDeniedProseReplace = Number(runtime.database.get(
       "SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?",
       chapter.body.data.id
     )?.count);
-    const proseReplaceSkipped = await collaborator.agent.post(`/api/works/${workId}/replace`)
+    const proseReplaceDenied = await collaborator.agent.post(`/api/works/${workId}/replace`)
       .set("X-CSRF-Token", collaborator.csrfToken)
       .send({ find: "模块权限正文", replacement: "不应替换", scope: "prose" })
-      .expect(200);
-    expect(proseReplaceSkipped.body.data).toMatchObject({
-      scope: "prose",
-      processedModules: [],
-      skippedModules: ["prose"],
-      chapterCount: 0,
-      settingCount: 0,
-      totalMatches: 0
-    });
+      .expect(403);
+    expect(proseReplaceDenied.body.error.code).toBe("WORK_MODULE_WRITE_DENIED");
     expect(runtime.database.get("SELECT content FROM chapters WHERE id = ?", chapter.body.data.id)?.content)
       .toBe("模块权限正文，双向词。");
     expect(Number(runtime.database.get(
       "SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?",
       chapter.body.data.id
-    )?.count)).toBe(chapterVersionsBeforeSkippedProseReplace);
+    )?.count)).toBe(chapterVersionsBeforeDeniedProseReplace);
     const chapterVersionsBeforeSettingsOnlyReplace = Number(runtime.database.get(
       "SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?",
       chapter.body.data.id
@@ -1150,28 +1153,21 @@ describe("用户、作品权限与操作者追踪 API", () => {
       "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?",
       editableSettingId
     )?.count)).toBe(settingVersionsBeforeProseOnlyReplace);
-    const settingVersionsBeforeSkippedSettingsReplace = Number(runtime.database.get(
+    const settingVersionsBeforeDeniedSettingsReplace = Number(runtime.database.get(
       "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?",
       editableSettingId
     )?.count);
-    const settingsReplaceSkipped = await collaborator.agent.post(`/api/works/${workId}/replace`)
+    const settingsReplaceDenied = await collaborator.agent.post(`/api/works/${workId}/replace`)
       .set("X-CSRF-Token", collaborator.csrfToken)
       .send({ find: "已经", replacement: "不应替换", scope: "settings" })
-      .expect(200);
-    expect(settingsReplaceSkipped.body.data).toMatchObject({
-      scope: "settings",
-      processedModules: [],
-      skippedModules: ["settings"],
-      chapterCount: 0,
-      settingCount: 0,
-      totalMatches: 0
-    });
+      .expect(403);
+    expect(settingsReplaceDenied.body.error.code).toBe("WORK_MODULE_WRITE_DENIED");
     expect(runtime.database.get("SELECT content FROM settings WHERE id = ?", editableSettingId)?.content)
       .toBe("设定侧替换设定，双向词，已经写入。");
     expect(Number(runtime.database.get(
       "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?",
       editableSettingId
-    )?.count)).toBe(settingVersionsBeforeSkippedSettingsReplace);
+    )?.count)).toBe(settingVersionsBeforeDeniedSettingsReplace);
     await collaborator.agent.post(`/api/works/${workId}/settings`)
       .set("X-CSRF-Token", collaborator.csrfToken)
       .send({ title: "只读后越权", category: "世界规则", content: "不应写入。" })
@@ -1218,18 +1214,16 @@ describe("用户、作品权限与操作者追踪 API", () => {
       "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?",
       editableSettingId
     )?.count);
-    const combinedReplaceSkipped = await collaborator.agent.post(`/api/works/${workId}/replace`)
+    const combinedReplaceDenied = await collaborator.agent.post(`/api/works/${workId}/replace`)
       .set("X-CSRF-Token", collaborator.csrfToken)
       .send({ find: "正文侧替换", replacement: "不应替换", scope: "prose-and-settings" })
-      .expect(200);
-    expect(combinedReplaceSkipped.body.data).toMatchObject({
-      scope: "prose-and-settings",
-      processedModules: [],
-      skippedModules: ["prose", "settings"],
-      chapterCount: 0,
-      settingCount: 0,
-      totalMatches: 0
-    });
+      .expect(403);
+    expect(combinedReplaceDenied.body.error.code).toBe("WORK_MODULE_WRITE_DENIED");
+    const invalidScopeReplace = await collaborator.agent.post(`/api/works/${workId}/replace`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ find: "正文侧替换", replacement: "不应替换", scope: "unknown" })
+      .expect(400);
+    expect(invalidScopeReplace.body.error.code).toBe("VALIDATION_ERROR");
     expect(runtime.database.get("SELECT content FROM chapters WHERE id = ?", chapter.body.data.id)?.content)
       .toBe("已批量替换正文编辑，正文侧替换。");
     expect(runtime.database.get("SELECT content FROM settings WHERE id = ?", editableSettingId)?.content)


### PR DESCRIPTION
## 背景

全局替换接口此前没有在作品授权中间件声明写模块，viewer 或自定义只读成员会进入 store 并静默得到“替换 0 处”。

## 实现

- 根据请求体 `scope` 将替换范围映射为 `prose`、`settings` 或两者，并通过现有 `anyWrite` 语义执行入口校验。
- 保留 store 内逐模块权限判定；组合范围内只要有一个模块可写就继续处理，未授权模块仍按原逻辑跳过。
- 将 `scope` 设为必填；缺失或非法 scope 由现有 Zod 校验返回 400，避免缺失字段绕过入口权限检查。
- 补充 viewer、完整编辑者、自定义只读成员、单模块权限、组合范围部分权限与缺失 scope 回归测试，并验证拒绝后内容和版本不变。

## 验证

- `npx vitest run tests/integration/user-auth-api.test.ts tests/integration/global-replace-api.test.ts --maxWorkers=1`：35 项通过。
- `npm run typecheck`：通过。
- `npm test`：通过。
- `npm run build`：通过。
- 隔离数据库启动后 `/api/health` 返回 200；`PRAGMA integrity_check` 返回 `ok`，`PRAGMA foreign_key_check` 无异常。

无数据库迁移、前端或部署配置变更。

Closes MUXUE-21
