### PR TITLE
fix(ai): bypass provider endpoint check in development

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1126,7 +1126,9 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     store,
     credentialVault,
     options.fetchImpl ?? fetch,
-    options.security ? (url) => assertSafeAiEndpoint(url, options.security?.allowPrivateAiEndpoints) : undefined,
+    options.developmentServer === true
+      ? undefined
+      : options.security ? (url) => assertSafeAiEndpoint(url, options.security?.allowPrivateAiEndpoints) : undefined,
     (task, actor) => {
       const requiredModules = analysisTaskReadModules(task.taskType, task.scope);
       const creator = actor ? null : database.get(

--- a/tests/integration/ai-development-endpoint.test.ts
+++ b/tests/integration/ai-development-endpoint.test.ts
@@ -1,0 +1,63 @@
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRuntime, type Runtime } from "../../src/app.js";
+
+const runtimes: Runtime[] = [];
+
+afterEach(async () => {
+  for (const runtime of runtimes.splice(0)) await runtime.close();
+});
+
+async function testProviderConnection(developmentServer: boolean): Promise<{
+  result: Record<string, unknown>;
+  requestedUrls: string[];
+}> {
+  const requestedUrls: string[] = [];
+  const fetchMock = vi.fn<typeof fetch>(async (input) => {
+    const url = String(input);
+    requestedUrls.push(url);
+    if (url.endsWith("/models")) {
+      return new Response(JSON.stringify({ data: [{ id: "development-model" }] }), { status: 200 });
+    }
+    return new Response(JSON.stringify({ choices: [{ message: { content: "连接成功" } }] }), { status: 200 });
+  });
+  const runtime = createRuntime({
+    databasePath: ":memory:",
+    masterSecret: "test-master-secret-with-at-least-32-characters",
+    disableUserAuth: true,
+    fetchImpl: fetchMock,
+    serveUi: false,
+    security: { allowPrivateAiEndpoints: false, enforceSameOrigin: false },
+    developmentServer
+  });
+  runtimes.push(runtime);
+
+  const provider = await request(runtime.app).post("/api/platform/ai/providers").send({
+    name: "开发地址测试供应商",
+    baseUrl: "https://198.18.0.7/v1",
+    apiKey: "development-test-key",
+    status: "enabled"
+  }).expect(201);
+  const tested = await request(runtime.app).post(`/api/providers/${provider.body.data.id}/test`).send({}).expect(200);
+  return { result: tested.body.data as Record<string, unknown>, requestedUrls };
+}
+
+describe("开发服务 AI 供应商地址校验", () => {
+  it("开发模式跳过供应商地址 SSRF 校验", async () => {
+    const result = await testProviderConnection(true);
+
+    expect(result.result).toMatchObject({ ok: true, availableModels: ["development-model"] });
+    expect(result.requestedUrls).toEqual([
+      "https://198.18.0.7/v1/models",
+      "https://198.18.0.7/v1/chat/completions"
+    ]);
+  });
+
+  it("非开发模式仍拒绝受保护地址", async () => {
+    const result = await testProviderConnection(false);
+
+    expect(result.result).toMatchObject({ ok: false });
+    expect(result.result.error).toContain("AI 供应商地址指向受保护的本机、内网或链路本地网络");
+    expect(result.requestedUrls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 变更

- 开发服务复用现有 `NODE_ENV=development`，跳过 AI 供应商地址的 SSRF 校验。
- 非开发模式继续执行严格校验，S3 地址校验保持不变。
- 增加开发模式与非开发模式的回归测试。

## 根因

代理/DNS 将 `api.longcat.chat` 解析为 `198.18.0.7`，该地址被安全校验识别为受保护地址，导致请求尚未发出就返回 `UNSAFE_PROVIDER_ENDPOINT`。

## 验证

- `npm run typecheck`
- `npm exec vitest -- run tests/integration/ai-development-endpoint.test.ts --maxWorkers=1`
- `npm test`：150 个测试文件、784 个测试通过
- 本地开发服务健康检查通过