### PR TITLE
build(release): bump version to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.2";
+export const APP_VERSION = "0.7.3";


### PR DESCRIPTION
## 变更内容

同步应用的补丁版本号至 0.7.3：

- package.json
- package-lock.json 顶层版本和根包版本
- src/version.ts 的 APP_VERSION

## 验证

- tests/unit/version.test.ts 通过