### PR TITLE
MUXUE-44: require review access for JSON exports

### DIFF
--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -832,6 +832,12 @@ const contentPermissionModules = workPermissionModules.filter((module) => !["dra
 const aiInteractionModules = ["ai-chat", "ai-analysis"] as const satisfies readonly WorkPermissionModule[];
 const attachmentModules = ["prose", "drafts", "settings", "characters", "races", "organizations"] as const satisfies readonly WorkPermissionModule[];
 
+export function exportReadPermissionModules(format: unknown): WorkPermissionModule[] {
+  return format === "json" || format === undefined
+    ? ["drafts", ...contentPermissionModules, "reviews"]
+    : ["prose"];
+}
+
 function requestedAttachmentModule(request: Request): WorkPermissionModule {
   const module = String(request.query.module ?? "settings");
   return attachmentModules.includes(module as typeof attachmentModules[number])
@@ -1061,7 +1067,7 @@ function workModuleRequirements(request: Request, write: boolean): WorkAuthoriza
       : { read: [...contentPermissionModules] };
   }
   if (/^\/api\/works\/[^/]+\/export$/u.test(pathname)) {
-    return { read: request.query.format === "json" || request.query.format === undefined ? ["drafts", ...contentPermissionModules] : ["prose"] };
+    return { read: exportReadPermissionModules(request.query.format) };
   }
   return { ownerOnly: true };
 }

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -2,6 +2,7 @@ import { createServer, type Server } from "node:http";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import JSZip from "jszip";
 import request from "supertest";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createRuntime, type Runtime } from "../../src/app.js";
@@ -1440,6 +1441,148 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .expect(200);
     const reviewReadDenied = await collaborator.agent.get(`/api/reviews/${reviewId}`).expect(403);
     expect(reviewReadDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
+    expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("JSON 导出拒绝缺少审核读取权限的协作者且正文格式保持可用", async () => {
+    const owner = await register(runtime, "export_review_owner");
+    const collaborator = await register(runtime, "export_review_collaborator");
+    const outsider = await register(runtime, "export_review_outsider");
+    const work = await owner.agent.post("/api/works")
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "审核权限导出作品" })
+      .expect(201);
+    const workId = String(work.body.data.id);
+    const volume = await owner.agent.post(`/api/works/${workId}/volumes`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "正文" })
+      .expect(201);
+    const proseSecret = "EXPORT_PROSE_CONTENT";
+    await owner.agent.post(`/api/works/${workId}/chapters`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ volumeId: volume.body.data.id, title: "第一章", content: proseSecret })
+      .expect(201);
+    const reviewSecrets = {
+      title: "EXPORT_REVIEW_TITLE_SECRET",
+      description: "EXPORT_REVIEW_DESCRIPTION_SECRET",
+      evidence: "EXPORT_REVIEW_EVIDENCE_SECRET",
+      suggestion: "EXPORT_REVIEW_SUGGESTION_SECRET",
+      resolutionNote: "EXPORT_REVIEW_RESOLUTION_SECRET"
+    };
+    await owner.agent.post(`/api/works/${workId}/reviews`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({
+        itemType: "timeline-conflict",
+        title: reviewSecrets.title,
+        description: reviewSecrets.description,
+        evidence: [{ excerpt: reviewSecrets.evidence }],
+        suggestion: reviewSecrets.suggestion,
+        resolutionNote: reviewSecrets.resolutionNote
+      })
+      .expect(201);
+    const permissions = {
+      prose: "read",
+      drafts: "read",
+      settings: "read",
+      characters: "read",
+      races: "read",
+      organizations: "read",
+      timeline: "read",
+      relationships: "read",
+      outlines: "read",
+      reviews: "none",
+      "ai-chat": "none",
+      "ai-analysis": "none",
+      "ai-settings": "none"
+    };
+    await owner.agent.post(`/api/works/${workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ userId: collaborator.user.userId, permissions })
+      .expect(201);
+
+    for (const query of ["", "?format=json"]) {
+      const denied = await collaborator.agent.get(`/api/works/${workId}/export${query}`).expect(403);
+      expect(denied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
+      expect(denied.headers["content-disposition"]).toBeUndefined();
+      const deniedBody = JSON.stringify(denied.body);
+      for (const secret of Object.values(reviewSecrets)) expect(deniedBody).not.toContain(secret);
+    }
+    const outsiderDenied = await outsider.agent.get(`/api/works/${workId}/export?format=json`).expect(403);
+    expect(outsiderDenied.body.error.code).toBe("WORK_ACCESS_DENIED");
+    for (const secret of Object.values(reviewSecrets)) {
+      expect(JSON.stringify(outsiderDenied.body)).not.toContain(secret);
+    }
+    const otherWork = await outsider.agent.post("/api/works")
+      .set("X-CSRF-Token", outsider.csrfToken)
+      .send({ title: "其他作品" })
+      .expect(201);
+    const otherWorkId = String(otherWork.body.data.id);
+    const otherWorkSecret = "CROSS_WORK_REVIEW_SECRET";
+    await outsider.agent.post(`/api/works/${otherWorkId}/reviews`)
+      .set("X-CSRF-Token", outsider.csrfToken)
+      .send({ itemType: "timeline-conflict", title: otherWorkSecret })
+      .expect(201);
+    const crossWorkDenied = await collaborator.agent.get(`/api/works/${otherWorkId}/export?format=json`).expect(403);
+    expect(crossWorkDenied.body.error.code).toBe("WORK_ACCESS_DENIED");
+    expect(JSON.stringify(crossWorkDenied.body)).not.toContain(otherWorkSecret);
+
+    const textExport = await collaborator.agent.get(`/api/works/${workId}/export?format=txt`)
+      .expect("Content-Type", /text\/plain/u)
+      .expect("Content-Disposition", `attachment; filename=novel-${workId}.txt`)
+      .expect(200);
+    expect(textExport.text).toContain(proseSecret);
+    for (const secret of Object.values(reviewSecrets)) expect(textExport.text).not.toContain(secret);
+
+    const markdownExport = await collaborator.agent.get(`/api/works/${workId}/export?format=markdown`)
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+        response.on("error", callback);
+      })
+      .expect("Content-Type", /application\/zip/u)
+      .expect("Content-Disposition", `attachment; filename=novel-${workId}.zip`)
+      .expect(200);
+    const markdownArchive = await JSZip.loadAsync(markdownExport.body as Buffer);
+    const markdown = await markdownArchive.file(`novel-${workId}.md`)?.async("string");
+    expect(markdown).toContain(proseSecret);
+    for (const secret of Object.values(reviewSecrets)) expect(markdown).not.toContain(secret);
+
+    const docxExport = await collaborator.agent.get(`/api/works/${workId}/export?format=docx`)
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => callback(null, Buffer.concat(chunks)));
+        response.on("error", callback);
+      })
+      .expect("Content-Type", /application\/vnd\.openxmlformats-officedocument\.wordprocessingml\.document/u)
+      .expect("Content-Disposition", `attachment; filename=novel-${workId}.docx`)
+      .expect(200);
+    const docxArchive = await JSZip.loadAsync(docxExport.body as Buffer);
+    const documentXml = await docxArchive.file("word/document.xml")?.async("string");
+    expect(documentXml).toContain(proseSecret);
+    for (const secret of Object.values(reviewSecrets)) expect(documentXml).not.toContain(secret);
+
+    await owner.agent.patch(`/api/works/${workId}/members/${collaborator.user.userId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ permissions: { ...permissions, reviews: "read" } })
+      .expect(200);
+    const authorized = await collaborator.agent.get(`/api/works/${workId}/export?format=json`)
+      .expect("Content-Type", /application\/json/u)
+      .expect("Content-Disposition", `attachment; filename=novel-${workId}.json`)
+      .expect(200);
+    expect(authorized.body.data.reviews).toEqual([
+      expect.objectContaining({
+        workId,
+        title: reviewSecrets.title,
+        description: reviewSecrets.description,
+        evidence: [{ excerpt: reviewSecrets.evidence }],
+        suggestion: reviewSecrets.suggestion,
+        resolutionNote: reviewSecrets.resolutionNote
+      })
+    ]);
     expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
   });
 

--- a/tests/unit/work-permissions.test.ts
+++ b/tests/unit/work-permissions.test.ts
@@ -16,8 +16,29 @@ import {
   storedMembershipForPermissions,
   storedWorkModulePermissions
 } from "../../src/work-permissions.js";
+import { exportReadPermissionModules } from "../../src/user-auth.js";
 
 describe("作品模块权限", () => {
+  it("JSON 导出必须读取审核模块且正文格式不扩大授权范围", () => {
+    const completeExportModules = [
+      "drafts",
+      "prose",
+      "settings",
+      "characters",
+      "races",
+      "organizations",
+      "timeline",
+      "relationships",
+      "outlines",
+      "reviews"
+    ];
+    expect(exportReadPermissionModules(undefined)).toEqual(completeExportModules);
+    expect(exportReadPermissionModules("json")).toEqual(completeExportModules);
+    for (const format of ["txt", "markdown", "docx"]) {
+      expect(exportReadPermissionModules(format)).toEqual(["prose"]);
+    }
+  });
+
   it("将旧成员角色映射为等价模块权限", () => {
     const legacySettings = storedWorkModulePermissions("editor", JSON.stringify({ editScope: "settings" }));
     expect(legacySettings).toEqual(settingsEditorModulePermissions());


### PR DESCRIPTION
## 变更

- 默认及 `format=json` 导出在进入路由、构造导出对象前要求当前用户拥有目标作品的审核读取权限。
- 缺少审核读取权限时沿用现有授权语义返回 `403 WORK_MODULE_READ_DENIED`，不生成下载文件，也不读取审核项。
- 保持有权限用户的 JSON 字段、Content-Type 与下载文件名兼容；TXT、Markdown、DOCX 仍只要求正文读取权限。

## 验证

- `npm run typecheck`
- `npx vitest run tests/integration/user-auth-api.test.ts --maxWorkers=1`
- `npx vitest run tests/unit/work-permissions.test.ts tests/unit/docx-export.test.ts tests/integration/work-chapter-api.test.ts tests/integration/drafts-api.test.ts tests/integration/knowledge-api.test.ts --maxWorkers=1`
- `npm test`：152 个测试文件、800 个测试通过
- `npm run build`

回归覆盖无审核权限协作者、非成员、跨作品 ID、有审核读取权限用户，以及 TXT、Markdown、DOCX 下载内容不携带审核数据。
