### PR TITLE
MUXUE-51: bound search queries and escape LIKE literals

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -51,9 +51,11 @@ import {
 } from "./google-vertex-auth.js";
 import {
   HYBRID_SEARCH_TYPES,
+  MAXIMUM_WORK_SEARCH_QUERY_LENGTH,
   buildHybridSearchSnippet,
   documentParagraphLineRange,
   fuseHybridSearchChannels,
+  normalizeWorkSearchQuery,
   type HybridSearchCandidate,
   type HybridSearchMatchKind,
   type HybridSearchType
@@ -703,7 +705,7 @@ const grepArguments = z.object({
   cursor: agentToolCursor
 }).strict();
 const searchStoryEntitiesArguments = z.object({
-  query: z.string().trim().min(1).max(200),
+  query: z.string().trim().min(1).max(MAXIMUM_WORK_SEARCH_QUERY_LENGTH),
   categories: z.array(z.enum(["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"])).max(8).default([]),
   limit: z.number().int().min(1).max(30).default(30),
   cursor: agentToolCursor
@@ -769,7 +771,7 @@ const AGENT_TOOL_DEFINITIONS: Record<AgentToolId, Record<string, unknown>> = {
     function: {
       name: "search_story_entities",
       description: "按短关键词在结构化作品实体中进行元数据、精确全文和拼音混合检索：设定、人物（含 Markdown 档案章节）、种族、组织、时间线、关系、大纲和伏笔。人物、种族、组织结果分别包含权威布尔状态 isDead、isExtinct、isDissolved；只有值为 true 才能判定该角色已死亡、该种族已灭绝或该组织已解散，字段为 false 时必须视为仍存活、未灭绝或未解散，禁止根据正文情节自行改判。不是语义问答；请传入实体名、别名、标题、拼音或短关键词，不要传入自然语言整句。结果按综合相关度排序；人物结果含 sectionId 时可再调用 read_character_sections 精读。无匹配时改用更短关键词，或改用 story_index / grep。",
-      parameters: { type: "object", properties: { query: { type: "string", minLength: 1, maxLength: 200 }, categories: { type: "array", items: { type: "string", enum: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"] }, maxItems: 8 }, limit: { type: "integer", minimum: 1, maximum: 30, default: 30 }, cursor: agentToolCursorParameter }, required: ["query"], additionalProperties: false }
+      parameters: { type: "object", properties: { query: { type: "string", minLength: 1, maxLength: MAXIMUM_WORK_SEARCH_QUERY_LENGTH }, categories: { type: "array", items: { type: "string", enum: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"] }, maxItems: 8 }, limit: { type: "integer", minimum: 1, maximum: 30, default: 30 }, cursor: agentToolCursorParameter }, required: ["query"], additionalProperties: false }
     }
   },
   read_character_sections: {
@@ -1961,7 +1963,7 @@ export class AiManager {
     options: { type?: HybridSearchType; limit?: number; includeAgentHistory?: boolean } = {}
   ): Promise<Record<string, unknown>[]> {
     this.store.getWork(workId);
-    const normalizedQuery = normalizeRelationshipSearchText(query).trim();
+    const normalizedQuery = normalizeWorkSearchQuery(query);
     if (!normalizedQuery) return [];
     const requestedTypes = options.type ? new Set<HybridSearchType>([options.type]) : new Set(HYBRID_SEARCH_TYPES);
     if (options.includeAgentHistory === false) requestedTypes.delete("agent-history");

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ import { assertSafeDocxArchive } from "./docx-security.js";
 import { CREATABLE_ANALYSIS_TASK_TYPES, DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
 import { AppError } from "./errors.js";
 import { isOfficialGoogleVertexBaseUrl, parseGoogleServiceAccount } from "./google-vertex-auth.js";
-import { HYBRID_SEARCH_TYPES } from "./hybrid-search.js";
+import { HYBRID_SEARCH_TYPES, MAXIMUM_WORK_SEARCH_QUERY_LENGTH } from "./hybrid-search.js";
 import { applyImportFileHints, parseNovelText } from "./parser.js";
 import { aiConversationTaskTypes, attachmentPermissionModules, RECYCLE_BIN_RETENTION_DAYS, Store, versionedEntityTypes } from "./store.js";
 import { paginated, parsePagination } from "./pagination.js";
@@ -2741,7 +2741,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
 
   app.get("/api/works/:workId/search", async (request, response) => {
     const query = parse(z.object({
-      q: z.string().trim().min(1).max(500),
+      q: z.string().trim().min(1).max(MAXIMUM_WORK_SEARCH_QUERY_LENGTH),
       type: z.enum(HYBRID_SEARCH_TYPES).optional(),
       limit: z.coerce.number().int().min(1).max(100).optional()
     }).strict(), request.query);

--- a/src/hybrid-search.ts
+++ b/src/hybrid-search.ts
@@ -13,6 +13,16 @@ export const HYBRID_SEARCH_TYPES = [
   "agent-history"
 ] as const;
 
+export const MAXIMUM_WORK_SEARCH_QUERY_LENGTH = 100;
+
+export function normalizeWorkSearchQuery(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase("zh-CN")
+    .trim()
+    .slice(0, MAXIMUM_WORK_SEARCH_QUERY_LENGTH);
+}
+
 export type HybridSearchType = typeof HYBRID_SEARCH_TYPES[number];
 export type HybridSearchMatchKind = "metadata" | "exact" | "phonetic";
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -619,7 +619,7 @@
       </div>
       <div class="access-dialog-body">
         <form id="search-form" class="search-form">
-          <label>关键词<input id="search-query" name="query" type="search" maxlength="500" placeholder="搜索正文、设定、人物、时间线、关系、大纲、伏笔或 Agent 历史" required></label>
+          <label>关键词<input id="search-query" name="query" type="search" maxlength="100" placeholder="搜索正文、设定、人物、时间线、关系、大纲、伏笔或 Agent 历史" required></label>
           <label>资料类型<select id="search-type" name="type">
             <option value="">全部资料</option>
             <option value="chapter">章节</option>

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ import {
 } from "./database.js";
 import { exportWorkDocx } from "./docx-export.js";
 import { AppError, notFound } from "./errors.js";
+import { normalizeWorkSearchQuery } from "./hybrid-search.js";
 import { accountReference, logger } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
 import { currentRequestActor } from "./request-context.js";
@@ -23,6 +24,7 @@ import {
 import {
   countWords,
   documentShortSearchTerms,
+  escapeSqlLikePattern,
   id,
   json,
   normalizeDocumentSearchText,
@@ -3959,7 +3961,7 @@ export class Store {
     this.getWork(workId);
     const safeLimit = Math.min(30, Math.max(1, Math.trunc(limit)));
     const normalizedQuery = query.normalize("NFKC").trim();
-    const escapedQuery = normalizedQuery.replace(/[\\%_]/gu, "\\$&");
+    const escapedQuery = escapeSqlLikePattern(normalizedQuery);
     const pattern = `%${escapedQuery}%`;
     const rows = normalizedQuery
       ? this.db.all(
@@ -8887,14 +8889,15 @@ export class Store {
 
   search(workId: string, query: string): Record<string, unknown>[] {
     this.getWork(workId);
-    const pattern = `%${query.replaceAll("%", "\\%").replaceAll("_", "\\_")}%`;
+    const normalizedQuery = normalizeWorkSearchQuery(query);
+    if (!normalizedQuery) return [];
+    const pattern = `%${escapeSqlLikePattern(normalizedQuery)}%`;
     const chapters = this.db.all(
       "SELECT id, title, content, volume_id FROM chapters WHERE work_id = ? AND deleted_at IS NULL AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\') LIMIT 50",
       workId,
       pattern,
       pattern
     );
-    const normalizedQuery = query.toLocaleLowerCase("zh-CN");
     const races = this.listRaces(workId).filter((race) => {
       const lineage = race.lineage as Array<{ name: string }>;
       const effectiveSettings = race.effectiveSettings as Array<{ value: string; sourceRaceName: string }>;
@@ -8944,9 +8947,9 @@ export class Store {
       pattern,
       pattern
     );
-    const characterSections = this.searchCharacterProfileSections(workId, query, 30);
+    const characterSections = this.searchCharacterProfileSections(workId, normalizedQuery, 30);
     const snippet = (content: string): string => {
-      const index = content.toLocaleLowerCase().indexOf(query.toLocaleLowerCase());
+      const index = content.toLocaleLowerCase().indexOf(normalizedQuery);
       const start = Math.max(0, index - 40);
       return content.slice(start, start + 120);
     };

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -7,6 +7,7 @@ import { accountReference, logger } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
 import { runWithRequestActor, type RequestActor } from "./request-context.js";
 import { normalizeApiPath } from "./security.js";
+import { escapeSqlLikePattern } from "./utils.js";
 import {
   canReadWorkModule,
   canWriteWorkModule,
@@ -436,7 +437,7 @@ export class UserAuthService {
   }
 
   directory(query: string): Pick<AuthUser, "userId" | "username" | "displayName" | "avatarUrl">[] {
-    const escapedQuery = query.trim().slice(0, 100).replace(/[\\%_]/gu, (character) => `\\${character}`);
+    const escapedQuery = escapeSqlLikePattern(query.trim().slice(0, 100));
     const pattern = `%${escapedQuery}%`;
     return this.database.all(
       `SELECT * FROM users WHERE status = 'active' AND (username LIKE ? ESCAPE '\\' OR display_name LIKE ? ESCAPE '\\')
@@ -450,7 +451,7 @@ export class UserAuthService {
   }
 
   directoryPage(query: string, pagination: Pagination): PaginatedResult<Pick<AuthUser, "userId" | "username" | "displayName" | "avatarUrl">> {
-    const escapedQuery = query.trim().slice(0, 100).replace(/[\\%_]/gu, (character) => `\\${character}`);
+    const escapedQuery = escapeSqlLikePattern(query.trim().slice(0, 100));
     const pattern = `%${escapedQuery}%`;
     const page = paginationSql(pagination);
     const rows = this.database.all(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,10 @@ export function parseBooleanEnvironmentValue(value: string | undefined): boolean
   return undefined;
 }
 
+export function escapeSqlLikePattern(value: string): string {
+  return value.replace(/[\\%_]/gu, (character) => `\\${character}`);
+}
+
 export function id(prefix: string): string {
   return `${prefix}_${randomUUID().replaceAll("-", "")}`;
 }

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -954,11 +954,19 @@ describe("AI 供应商、模型与建议 API", () => {
     fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
       completionCount += 1;
-      const body = JSON.parse(String(init?.body)) as { messages: Array<{ role: string; content?: string }>; tools?: Array<{ function?: { name?: string; description?: string } }> };
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content?: string }>;
+        tools?: Array<{ function?: {
+          name?: string;
+          description?: string;
+          parameters?: { properties?: { query?: { maxLength?: number } } };
+        } }>;
+      };
       if (completionCount === 1) {
         const searchTool = body.tools?.find((tool) => tool.function?.name === "search_story_entities");
         expect(searchTool?.function?.description).toContain("只有值为 true 才能判定");
         expect(searchTool?.function?.description).toContain("字段为 false 时必须视为仍存活、未灭绝或未解散");
+        expect(searchTool?.function?.parameters?.properties?.query?.maxLength).toBe(100);
         return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [{
           id: "race-knowledge",
           type: "function",

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -282,6 +282,47 @@ describe("作品混合检索", () => {
     expect(relationshipData.unresolvedCharacters).toEqual([source.id]);
   });
 
+  it("限制查询长度并按字面量搜索 LIKE 特殊字符", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime);
+    const workId = String(seeded.work.id);
+    const backslash = runtime.store.createSetting(workId, { title: String.raw`路径 a\b`, category: "测试", content: "" });
+    runtime.store.createSetting(workId, { title: "路径 ab", category: "测试", content: "" });
+    const combined = runtime.store.createSetting(workId, { title: String.raw`组合 \%_`, category: "测试", content: "" });
+    runtime.store.createSetting(workId, { title: String.raw`组合 \任意_`, category: "测试", content: "" });
+
+    const literalBackslash = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: String.raw`a\b`, type: "setting" })
+      .expect(200);
+    expect(literalBackslash.body.data.map((item: { id: string }) => item.id)).toEqual([backslash.id]);
+
+    const literalCombination = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: String.raw`\%_`, type: "setting" })
+      .expect(200);
+    expect(literalCombination.body.data.map((item: { id: string }) => item.id)).toEqual([combined.id]);
+
+    await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "\n北港\n" })
+      .expect(200);
+    await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "界".repeat(100) })
+      .expect(200);
+    const overlong = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "界".repeat(101) })
+      .expect(400);
+    expect(overlong.body.error.code).toBe("VALIDATION_ERROR");
+    const empty = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "\n \n" })
+      .expect(400);
+    expect(empty.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
   it("拒绝未知类型和越界数量", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime);

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -1366,6 +1366,11 @@ describe("用户、作品权限与操作者追踪 API", () => {
     await collaborator.agent.get(`/api/works/${workId}/audit-logs`).expect(403);
     await collaborator.agent.get(`/api/works/${workId}/unclassified-route`).expect(403);
     await collaborator.agent.get(`/api/works/${workId}/search?q=边界`).expect(403);
+    const overlongSearchDenied = await collaborator.agent
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "界".repeat(101) })
+      .expect(403);
+    expect(overlongSearchDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
     await collaborator.agent.get(`/api/works/${workId}/file-versions`).expect(403);
     const commentReadDenied = await collaborator.agent.get(`/api/works/${workId}/chapter-annotations`).expect(403);
     expect(commentReadDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -548,6 +548,7 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".work-audit-time strong { color: var(--ink); font-size: 18px;");
     expect(styles.text).toContain(".work-audit-event-heading strong { color: var(--ink); font-size: 17px;");
     expect(page.text).toContain('id="search-dialog"');
+    expect(page.text).toContain('id="search-query" name="query" type="search" maxlength="100"');
     expect(application.text).toContain('isGlobalSearchShortcut(event)');
     expect(application.text).toContain('const target = resolveGlobalSearchTarget(result);');
     expect(application.text).toContain('await selectChapter(target.id);');

--- a/tests/unit/hybrid-search.test.ts
+++ b/tests/unit/hybrid-search.test.ts
@@ -3,6 +3,7 @@ import {
   buildHybridSearchSnippet,
   documentParagraphLineRange,
   fuseHybridSearchChannels,
+  normalizeWorkSearchQuery,
   type HybridSearchCandidate
 } from "../../src/hybrid-search.js";
 
@@ -34,6 +35,14 @@ describe("混合检索排序", () => {
     const channel = { weight: 1, candidates: [candidate("a", "exact"), candidate("b", "exact")] };
     expect(fuseHybridSearchChannels([channel], 1)).toHaveLength(1);
     expect(fuseHybridSearchChannels([channel], 0)).toHaveLength(1);
+  });
+});
+
+describe("作品搜索输入边界", () => {
+  it("保留内部换行并把标准化后的查询限制为 100 字符", () => {
+    expect(normalizeWorkSearchQuery("\nＡ北港\n议会\n")).toBe("a北港\n议会");
+    expect(normalizeWorkSearchQuery("界".repeat(100))).toHaveLength(100);
+    expect(normalizeWorkSearchQuery(`${"界".repeat(100)}外`)).toBe("界".repeat(100));
   });
 });
 

--- a/tests/unit/store-search.test.ts
+++ b/tests/unit/store-search.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Database } from "../../src/database.js";
+import { Store } from "../../src/store.js";
+
+describe("Store 作品搜索", () => {
+  let database: Database;
+  let store: Store;
+  let workId: string;
+
+  beforeEach(() => {
+    database = new Database(":memory:");
+    store = new Store(database);
+    workId = String(store.createWork({ title: "搜索转义测试" }).id);
+  });
+
+  afterEach(() => {
+    database.close();
+  });
+
+  function settingIds(query: string): string[] {
+    return store.search(workId, query)
+      .filter((item) => item.type === "setting")
+      .map((item) => String(item.id));
+  }
+
+  it("把反斜杠和用户通配符作为普通字符匹配", () => {
+    const backslash = store.createSetting(workId, { title: String.raw`路径 a\b`, category: "测试", content: "" });
+    store.createSetting(workId, { title: "路径 ab", category: "测试", content: "" });
+    const percent = store.createSetting(workId, { title: "比例 100%", category: "测试", content: "" });
+    store.createSetting(workId, { title: "比例 1000", category: "测试", content: "" });
+    const underscore = store.createSetting(workId, { title: "标识 item_value", category: "测试", content: "" });
+    store.createSetting(workId, { title: "标识 itemXvalue", category: "测试", content: "" });
+    const combined = store.createSetting(workId, { title: String.raw`组合 \%_`, category: "测试", content: "" });
+    const combinedDecoy = store.createSetting(workId, { title: String.raw`组合 \任意_`, category: "测试", content: "" });
+
+    expect(settingIds(String.raw`a\b`)).toEqual([backslash.id]);
+    expect(new Set(settingIds("%"))).toEqual(new Set([String(percent.id), String(combined.id)]));
+    expect(new Set(settingIds("_"))).toEqual(new Set([String(underscore.id), String(combined.id), String(combinedDecoy.id)]));
+    expect(settingIds(String.raw`\%_`)).toEqual([combined.id]);
+  });
+});

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseBooleanEnvironmentValue } from "../../src/utils.js";
+import { escapeSqlLikePattern, parseBooleanEnvironmentValue } from "../../src/utils.js";
 
 describe("布尔环境变量", () => {
   it("仅接受 true、false、1 和 0", () => {
@@ -11,5 +11,12 @@ describe("布尔环境变量", () => {
     expect(parseBooleanEnvironmentValue("-1")).toBeUndefined();
     expect(parseBooleanEnvironmentValue("TRUE")).toBeUndefined();
     expect(parseBooleanEnvironmentValue(undefined)).toBeUndefined();
+  });
+});
+
+describe("SQL LIKE 字面量转义", () => {
+  it("按顺序转义反斜杠、百分号和下划线", () => {
+    expect(escapeSqlLikePattern(String.raw`\%_`)).toBe(String.raw`\\\%\_`);
+    expect(escapeSqlLikePattern("普通关键词")).toBe("普通关键词");
   });
 });


### PR DESCRIPTION
## Summary

- cap work-search API and shared Agent entity-search queries at 100 characters
- normalize and defensively bound shared search input before database work
- escape backslashes, percent signs, and underscores as SQL LIKE literals
- align the web search input and add store, API, permission, Agent-tool, and UI regressions

## Verification

- `npm run typecheck`
- targeted Vitest: 7 files, 115 tests passed
- `npm test`: 161 files, 831 tests passed
- `npm run build`
- isolated production health check: HTTP 200 / `status=ok`
- isolated SQLite: `integrity_check=ok`, no foreign-key violations
- browser: 1280x720 and 390x844 search dialog layout, focus, Enter submission, overflow, and app-console checks

## Risk assessment

Leading-wildcard metadata LIKE searches remain bounded scans within a work; the existing per-channel result limits and FTS-backed exact/phonetic channels remain unchanged. No database migration or index change is included.
