### PR TITLE
build(release): bump version to 0.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.3";
+export const APP_VERSION = "0.7.4";


### PR DESCRIPTION
## 发布版本提交

将版本号从 0.7.3 bump 到 0.7.4，统一更新 `package.json`、`package-lock.json` 顶层与根包、`src/version.ts`。

### 发布审计

- 已审计 develop 相对 main 的 115 个文件变更，覆盖 API 路由、认证与作品权限、导入导出、AI 流式请求、数据库迁移及 CLI。
- CLI 需要同步的功能为 EPUB manuscript export，已由已合入 develop 的 PR #419 完成 `scriverse manuscript get --format epub`、帮助文本和 CLI 单测；未发现其他现有 CLI 命令失效或遗漏入口。

### 验证

- `npm run check`：186 个测试文件、928 个测试通过，类型检查和构建通过。
- `tests/unit/version.test.ts` 通过。
- `npm run test:e2e:cli` 通过，隔离服务上的 CLI 命令、权限和身份隔离验证通过。
