### PR TITLE
MUXUE-61: preserve hidden scrollbar width

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260813-reader-volume-mobile-v3">
+    <link rel="stylesheet" href="/styles.css?v=20260813-scrollbar-stable-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -307,10 +307,11 @@
 }
 
 * { box-sizing: border-box; }
-* { scrollbar-width: none; }
-*::-webkit-scrollbar { width: 0; }
-.is-scrollbar-visible { scrollbar-width: thin; }
-.is-scrollbar-visible::-webkit-scrollbar { width: 8px; }
+* { scrollbar-width: thin; scrollbar-color: transparent transparent; }
+*::-webkit-scrollbar { width: 8px; }
+*::-webkit-scrollbar-track, *::-webkit-scrollbar-thumb { background: transparent; }
+.is-scrollbar-visible { scrollbar-color: var(--muted) transparent; }
+.is-scrollbar-visible::-webkit-scrollbar-thumb { border-radius: 999px; background: var(--muted); }
 
 html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
 

--- a/tests/system/ai-user-message-mentions-ui.test.ts
+++ b/tests/system/ai-user-message-mentions-ui.test.ts
@@ -10,7 +10,7 @@ describe("AI 用户消息角色引用横幅", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(application).toContain('/ai-mentions.js?v=20260811-user-message-mentions-v1');
     expect(application).toContain("persistedUserMessage.createdAt, persistedUserMessage.metadata, persistedUserMessage.id");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -328,7 +328,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/index.css?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
@@ -608,7 +608,11 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain('.vditor-editor-host.vditor--dark .vditor-reset table tbody tr:nth-child(2n) { background: var(--surface-soft); }');
     expect(styles.text).toContain(".vditor-upload-queue {");
     expect(styles.text).toContain(".image-upload-progress-panel {");
-    expect(styles.text).toContain(".is-scrollbar-visible::-webkit-scrollbar {");
+    expect(styles.text).toContain("* { scrollbar-width: thin; scrollbar-color: transparent transparent; }");
+    expect(styles.text).toContain("*::-webkit-scrollbar { width: 8px; }");
+    expect(styles.text).toContain(".is-scrollbar-visible::-webkit-scrollbar-thumb {");
+    expect(styles.text).not.toContain("* { scrollbar-width: none; }");
+    expect(styles.text).not.toContain("*::-webkit-scrollbar { width: 0; }");
     expect(styles.text).toContain(".character-markdown-editor > .vditor-editor-host");
     expect(styles.text).toContain("#character-section-editor-view");
     expect(styles.text).toContain("#knowledge-section-editor-view");

--- a/tests/system/character-extraction-preview-ui.test.ts
+++ b/tests/system/character-extraction-preview-ui.test.ts
@@ -11,7 +11,7 @@ describe("角色抽取结果入库预览界面", () => {
       readFile(join(publicPath, "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(application).toContain("function renderCharacterExtractionPreview(task, result)");
     expect(application).toContain("function renderCharacterExtractionEditor(preview)");

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
   });
 });

--- a/tests/system/foreshadow-reminder-ui.test.ts
+++ b/tests/system/foreshadow-reminder-ui.test.ts
@@ -20,7 +20,7 @@ describe("编辑器伏笔提醒界面", () => {
       request(runtime.app).get("/foreshadow-reminder.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(page.text).toContain('id="chapter-foreshadow-reminder" class="chapter-foreshadow-reminder hidden"');
     expect(page.text).toContain('aria-live="polite" aria-labelledby="chapter-foreshadow-reminder-title"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260813-reader-volume-mobile-v3"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/outline-board-ui.test.ts
+++ b/tests/system/outline-board-ui.test.ts
@@ -20,7 +20,7 @@ describe("章节大纲看板界面", () => {
       request(runtime.app).get("/outline-board.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(application.text).toContain('/outline-board.js?v=20260812-outline-board-v1');
     expect(application.text).toContain('/api/works/${encodeURIComponent(workId)}/outline-board');

--- a/tests/system/reading-preview-ui.test.ts
+++ b/tests/system/reading-preview-ui.test.ts
@@ -22,7 +22,7 @@ describe("沉浸式阅读预览界面", () => {
     const readingState = await request(runtime.app).get("/reading-preview.js").expect(200);
     const pageRoute = await request(runtime.app).get("/page-route.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(page.text).toContain('id="reader-open-button" class="module-nav-secondary hidden"');
     expect(page.text).toMatch(/id="module-more-button"[\s\S]*id="reader-open-button"[\s\S]*data-module="comments"/u);

--- a/tests/system/recycle-bin-ui.test.ts
+++ b/tests/system/recycle-bin-ui.test.ts
@@ -46,7 +46,7 @@ describe("作品与正文回收站界面", () => {
     expect(styles.text).toContain(".shelf-header-actions");
     expect(styles.text).toContain(".recycle-bin-section-list");
     expect(styles.text).toContain(".recycle-bin-card { grid-template-columns: minmax(0, 1fr);");
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
   });
 });

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,7 +23,7 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -44,7 +44,7 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
 
     expect(application.text).toContain('/s3-backup-ui.js?v=20260810-backup-encryption-v1');

--- a/tests/system/setting-filters-ui.test.ts
+++ b/tests/system/setting-filters-ui.test.ts
@@ -20,7 +20,7 @@ describe("设定筛选界面", () => {
       request(runtime.app).get("/setting-filters.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260813-reader-volume-mobile-v3');
+    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
     expect(page.text).toContain('/app.js?v=20260813-reader-volume-mobile-v3');
     expect(application.text).toContain('/setting-filters.js?v=20260810-setting-inline-filters-v1');
     expect(application.text).toContain('const settingFilters = { keyword: "", category: "", lockState: "all" };');


### PR DESCRIPTION
## Summary

- keep the scrollbar gutter width stable while the idle scrollbar is visually hidden
- reveal only the scrollbar thumb during scrolling
- update the stylesheet cache key and regression assertions

## Validation

- `npm run typecheck`
- `npm test -- --reporter=dot` (186 files, 928 tests)
- `npm run build`
- browser verification at 1280x720 and 390x844: scrolling-to-idle width delta 0px, no horizontal overflow
