### PR TITLE
MUXUE-61: bump version to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.4";
+export const APP_VERSION = "0.7.5";


### PR DESCRIPTION
## Summary

- bump package and runtime versions from 0.7.4 to 0.7.5
- keep package metadata, lockfile root metadata, and `APP_VERSION` aligned

## CLI audit

The `main...develop` changes only affect frontend UI behavior and tests. No API route, request/response contract, authentication scope, import/export format, or CLI command changed, so no CLI update is required.

## Validation

- `npm exec vitest run tests/unit/version.test.ts -- --reporter=dot`
- explicit package/lockfile/runtime version consistency check
