### PR TITLE
MUXUE-64: stream large EPUB exports

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { dirname, extname, join } from "node:path";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import type { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { z, ZodError } from "zod";
 import { AI_PROVIDER_PROTOCOLS } from "./ai-protocol.js";
@@ -782,17 +783,11 @@ function noContent(response: Response): void {
   response.status(204).end();
 }
 
-async function sendEpub(response: Response, archive: JSZip, title: string, fallbackStem: string): Promise<void> {
+async function sendEpub(response: Response, archive: Readable, title: string, fallbackStem: string): Promise<void> {
   response.type(EPUB_MIME_TYPE);
   response.setHeader("Content-Disposition", epubContentDisposition(title, fallbackStem));
   response.setHeader("Cache-Control", "private, no-store");
-  await pipeline(archive.generateNodeStream({
-    type: "nodebuffer",
-    // 逐条目压缩后再写入，确保首个 mimetype 本地头包含确定长度且没有额外字段。
-    streamFiles: false,
-    compression: "DEFLATE",
-    compressionOptions: { level: 6 }
-  }), response);
+  await pipeline(archive, response);
 }
 
 function parse<T>(schema: z.ZodType<T>, value: unknown): T {

--- a/src/epub-export.ts
+++ b/src/epub-export.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from "node:crypto";
-import JSZip from "jszip";
+import type { Readable } from "node:stream";
 import sharp from "sharp";
+import { createZipStream, type ZipStreamEntry } from "./zip-stream.js";
 
 export const EPUB_MIME_TYPE = "application/epub+zip";
 
 export type EpubExportChapter = {
   title: string;
-  content: string;
+  content: string | (() => string);
 };
 
 export type EpubExportVolume = {
@@ -40,7 +41,6 @@ type EpubDocument = {
   id: string;
   href: string;
   title: string;
-  content: string;
 };
 
 const bidiControlCharacters = /[\u202a-\u202e\u2066-\u2069]/gu;
@@ -309,7 +309,7 @@ export function epubContentDisposition(title: string, fallbackStem: string): str
   return `attachment; filename="${asciiFallbackFileName(fallbackStem)}"; filename*=UTF-8''${encodeRfc5987(epubDownloadFileName(title))}`;
 }
 
-export async function createEpubArchive(input: EpubExportInput): Promise<JSZip> {
+export async function createEpubArchive(input: EpubExportInput): Promise<Readable> {
   const title = String(input.title || "未命名作品");
   const author = String(input.author ?? "").trim();
   const description = String(input.description ?? "").trim();
@@ -317,27 +317,24 @@ export async function createEpubArchive(input: EpubExportInput): Promise<JSZip> 
   const identifier = String(input.identifier ?? `urn:uuid:${randomUUID()}`);
   const modified = normalizeModifiedAt(input.modifiedAt);
   const cover = input.cover ? await prepareCover(input.cover) : null;
-  const archive = new JSZip();
-  const fileOptions = { date: modified.date };
-
-  archive.file("mimetype", EPUB_MIME_TYPE, { ...fileOptions, compression: "STORE" });
-  archive.file("META-INF/container.xml", `<?xml version="1.0" encoding="UTF-8"?>
+  const entries: ZipStreamEntry[] = [{ name: "mimetype", content: EPUB_MIME_TYPE, compression: "STORE" }];
+  entries.push({ name: "META-INF/container.xml", content: `<?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
   <rootfiles>
     <rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml" />
   </rootfiles>
 </container>
-`, fileOptions);
-  archive.file("OEBPS/styles/book.css", bookStyles, fileOptions);
+` });
+  entries.push({ name: "OEBPS/styles/book.css", content: bookStyles });
 
   if (cover) {
-    archive.file(`OEBPS/images/cover.${cover.extension}`, cover.content, fileOptions);
-    archive.file("OEBPS/text/cover.xhtml", xhtmlPage({
+    entries.push({ name: `OEBPS/images/cover.${cover.extension}`, content: cover.content });
+    entries.push({ name: "OEBPS/text/cover.xhtml", content: xhtmlPage({
       language,
       title: `${title}封面`,
       body: `    <div class="cover-page"><img src="../images/cover.${cover.extension}" alt="${xml(title)}封面" /></div>`,
       bodyType: "cover"
-    }), fileOptions);
+    }) });
   }
 
   const titleBody = `    <section class="title-page" epub:type="titlepage">
@@ -346,10 +343,12 @@ export async function createEpubArchive(input: EpubExportInput): Promise<JSZip> 
   const titleDocument: EpubDocument = {
     id: "title-page",
     href: "text/title.xhtml",
-    title,
-    content: xhtmlPage({ language, title, body: titleBody, bodyType: "frontmatter" })
+    title
   };
-  archive.file(`OEBPS/${titleDocument.href}`, titleDocument.content, fileOptions);
+  entries.push({
+    name: `OEBPS/${titleDocument.href}`,
+    content: xhtmlPage({ language, title, body: titleBody, bodyType: "frontmatter" })
+  });
 
   const volumeDocuments = input.volumes.map((volume, volumeIndex) => {
     const volumeNumber = String(volumeIndex + 1).padStart(3, "0");
@@ -357,39 +356,43 @@ export async function createEpubArchive(input: EpubExportInput): Promise<JSZip> 
     const volumeDocument: EpubDocument = {
       id: `volume-${volumeNumber}`,
       href: `text/volume-${volumeNumber}.xhtml`,
-      title: volumeTitle,
+      title: volumeTitle
+    };
+    entries.push({
+      name: `OEBPS/${volumeDocument.href}`,
       content: xhtmlPage({
         language,
         title: volumeTitle,
         body: `    <section class="volume-page" epub:type="part"><h1>${xml(volumeTitle)}</h1></section>`,
         bodyType: "bodymatter"
       })
-    };
-    archive.file(`OEBPS/${volumeDocument.href}`, volumeDocument.content, fileOptions);
+    });
     const chapters = volume.chapters.map((chapter, chapterIndex) => {
       const chapterNumber = String(chapterIndex + 1).padStart(3, "0");
       const chapterTitle = String(chapter.title ?? "");
       const chapterDocument: EpubDocument = {
         id: `chapter-${volumeNumber}-${chapterNumber}`,
         href: `text/chapter-${volumeNumber}-${chapterNumber}.xhtml`,
-        title: chapterTitle,
-        content: xhtmlPage({
+        title: chapterTitle
+      };
+      entries.push({
+        name: `OEBPS/${chapterDocument.href}`,
+        content: () => xhtmlPage({
           language,
           title: chapterTitle,
-          body: `    <article epub:type="chapter">\n      <p class="volume-label">${xml(volumeTitle)}</p>\n      <h1>${xml(chapterTitle)}</h1>\n${renderChapterBody(chapter.content)}\n    </article>`,
+          body: `    <article epub:type="chapter">\n      <p class="volume-label">${xml(volumeTitle)}</p>\n      <h1>${xml(chapterTitle)}</h1>\n${renderChapterBody(typeof chapter.content === "function" ? chapter.content() : chapter.content)}\n    </article>`,
           bodyType: "bodymatter"
         })
-      };
-      archive.file(`OEBPS/${chapterDocument.href}`, chapterDocument.content, fileOptions);
+      });
       return chapterDocument;
     });
     return { document: volumeDocument, chapters };
   });
 
   const documents = [titleDocument, ...volumeDocuments.flatMap((volume) => [volume.document, ...volume.chapters])];
-  archive.file("OEBPS/nav.xhtml", navigationDocument({ title, language, volumes: volumeDocuments, hasCover: Boolean(cover) }), fileOptions);
-  archive.file("OEBPS/toc.ncx", ncxDocument({ title, identifier, volumes: volumeDocuments }), fileOptions);
-  archive.file("OEBPS/package.opf", packageDocument({
+  entries.push({ name: "OEBPS/nav.xhtml", content: navigationDocument({ title, language, volumes: volumeDocuments, hasCover: Boolean(cover) }) });
+  entries.push({ name: "OEBPS/toc.ncx", content: ncxDocument({ title, identifier, volumes: volumeDocuments }) });
+  entries.push({ name: "OEBPS/package.opf", content: packageDocument({
     title,
     author,
     description,
@@ -398,6 +401,6 @@ export async function createEpubArchive(input: EpubExportInput): Promise<JSZip> 
     modifiedAt: modified.value,
     documents,
     cover
-  }), fileOptions);
-  return archive;
+  }) });
+  return createZipStream(entries, modified.date);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -9721,23 +9721,63 @@ export class Store {
   }
 
   async exportEpub(workId: string, volumeId?: string): Promise<{ title: string; archive: Awaited<ReturnType<typeof createEpubArchive>> }> {
-    const tree = this.getWorkTree(workId);
-    const allVolumes = tree.volumes as Record<string, unknown>[];
-    const selectedVolume = volumeId ? allVolumes.find((volume) => String(volume.id) === volumeId) : undefined;
+    const work = this.getWork(workId);
+    const allVolumeRows = this.db.all(
+      "SELECT id, title FROM volumes WHERE work_id = ? AND deleted_at IS NULL ORDER BY sort_order, created_at",
+      workId
+    );
+    const selectedVolume = volumeId ? allVolumeRows.find((volume) => requiredString(volume, "id") === volumeId) : undefined;
     if (volumeId && !selectedVolume) throw notFound("分卷");
-    const sourceVolumes = selectedVolume ? [selectedVolume] : allVolumes;
-    const title = selectedVolume ? `${String(tree.title)} - ${String(selectedVolume.title)}` : String(tree.title);
+    const sourceVolumeRows = selectedVolume ? [selectedVolume] : allVolumeRows;
+    const chapterRows = volumeId
+      ? this.db.all(
+        `SELECT id, volume_id, title, version_no FROM chapters
+         WHERE work_id = ? AND volume_id = ? AND deleted_at IS NULL ORDER BY sort_order, created_at`,
+        workId,
+        volumeId
+      )
+      : this.db.all(
+        `SELECT id, volume_id, title, version_no FROM chapters
+         WHERE work_id = ? AND deleted_at IS NULL ORDER BY sort_order, created_at`,
+        workId
+      );
+    const chaptersByVolume = new Map<string, Row[]>();
+    for (const chapter of chapterRows) {
+      const chapterVolumeId = requiredString(chapter, "volume_id");
+      const chapters = chaptersByVolume.get(chapterVolumeId) ?? [];
+      chapters.push(chapter);
+      chaptersByVolume.set(chapterVolumeId, chapters);
+    }
+    const title = selectedVolume ? `${String(work.title)} - ${requiredString(selectedVolume, "title")}` : String(work.title);
     const cover = this.findWorkCover(workId);
     const archive = await createEpubArchive({
       title,
-      author: String(tree.author ?? ""),
-      description: String(tree.description ?? ""),
-      language: String(tree.language ?? "zh-CN"),
-      volumes: sourceVolumes.map((volume) => ({
-        title: String(volume.title),
-        chapters: (volume.chapters as Record<string, unknown>[]).map((chapter) => ({
-          title: String(chapter.title),
-          content: String(chapter.content ?? "")
+      author: String(work.author ?? ""),
+      description: String(work.description ?? ""),
+      language: String(work.language ?? "zh-CN"),
+      volumes: sourceVolumeRows.map((volume) => ({
+        title: requiredString(volume, "title"),
+        chapters: (chaptersByVolume.get(requiredString(volume, "id")) ?? []).map((chapter) => ({
+          title: requiredString(chapter, "title"),
+          content: () => {
+            const chapterId = requiredString(chapter, "id");
+            const versionNo = numberValue(chapter, "version_no");
+            const current = this.db.get(
+              "SELECT content FROM chapters WHERE id = ? AND work_id = ? AND version_no = ? AND deleted_at IS NULL",
+              chapterId,
+              workId,
+              versionNo
+            );
+            if (current) return requiredString(current, "content");
+            const historical = this.db.get(
+              "SELECT content FROM chapter_versions WHERE chapter_id = ? AND work_id = ? AND version_no = ?",
+              chapterId,
+              workId,
+              versionNo
+            );
+            if (!historical) throw new AppError(409, "EPUB_EXPORT_SOURCE_CHANGED", "导出过程中章节版本已不可用，请重新导出");
+            return requiredString(historical, "content");
+          }
         }))
       })),
       cover: cover ? { mimeType: cover.mimeType, content: cover.content } : null

--- a/src/zip-stream.ts
+++ b/src/zip-stream.ts
@@ -1,0 +1,173 @@
+import { Readable } from "node:stream";
+import { createDeflateRaw } from "node:zlib";
+
+export type ZipStreamEntry = {
+  name: string;
+  content: string | Buffer | (() => string | Buffer);
+  compression?: "STORE" | "DEFLATE";
+};
+
+type CentralDirectoryEntry = {
+  name: Buffer;
+  flags: number;
+  method: number;
+  dosTime: number;
+  dosDate: number;
+  crc: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  offset: number;
+};
+
+const ZIP32_MAX = 0xffff_ffff;
+const UTF8_FLAG = 0x0800;
+const DATA_DESCRIPTOR_FLAG = 0x0008;
+
+const crcTable = Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit += 1) crc = (crc & 1) ? 0xedb8_8320 ^ (crc >>> 1) : crc >>> 1;
+  return crc >>> 0;
+});
+
+function crc32(content: Buffer): number {
+  let crc = 0xffff_ffff;
+  for (const byte of content) crc = crcTable[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+  return (crc ^ 0xffff_ffff) >>> 0;
+}
+
+function dosTimestamp(date: Date): { dosTime: number; dosDate: number } {
+  const year = Math.min(2107, Math.max(1980, date.getFullYear()));
+  return {
+    dosTime: (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2),
+    dosDate: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+  };
+}
+
+function assertZip32(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > ZIP32_MAX) {
+    throw new Error(`ZIP32_LIMIT_EXCEEDED: ${label}`);
+  }
+}
+
+function localHeader(input: CentralDirectoryEntry, streamed: boolean): Buffer {
+  const header = Buffer.allocUnsafe(30 + input.name.length);
+  header.writeUInt32LE(0x0403_4b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(input.flags, 6);
+  header.writeUInt16LE(input.method, 8);
+  header.writeUInt16LE(input.dosTime, 10);
+  header.writeUInt16LE(input.dosDate, 12);
+  header.writeUInt32LE(streamed ? 0 : input.crc, 14);
+  header.writeUInt32LE(streamed ? 0 : input.compressedSize, 18);
+  header.writeUInt32LE(streamed ? 0 : input.uncompressedSize, 22);
+  header.writeUInt16LE(input.name.length, 26);
+  header.writeUInt16LE(0, 28);
+  input.name.copy(header, 30);
+  return header;
+}
+
+function dataDescriptor(input: CentralDirectoryEntry): Buffer {
+  const descriptor = Buffer.allocUnsafe(16);
+  descriptor.writeUInt32LE(0x0807_4b50, 0);
+  descriptor.writeUInt32LE(input.crc, 4);
+  descriptor.writeUInt32LE(input.compressedSize, 8);
+  descriptor.writeUInt32LE(input.uncompressedSize, 12);
+  return descriptor;
+}
+
+function centralHeader(input: CentralDirectoryEntry): Buffer {
+  const header = Buffer.allocUnsafe(46 + input.name.length);
+  header.writeUInt32LE(0x0201_4b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(20, 6);
+  header.writeUInt16LE(input.flags, 8);
+  header.writeUInt16LE(input.method, 10);
+  header.writeUInt16LE(input.dosTime, 12);
+  header.writeUInt16LE(input.dosDate, 14);
+  header.writeUInt32LE(input.crc, 16);
+  header.writeUInt32LE(input.compressedSize, 20);
+  header.writeUInt32LE(input.uncompressedSize, 24);
+  header.writeUInt16LE(input.name.length, 28);
+  header.writeUInt16LE(0, 30);
+  header.writeUInt16LE(0, 32);
+  header.writeUInt16LE(0, 34);
+  header.writeUInt16LE(0, 36);
+  header.writeUInt32LE(0, 38);
+  header.writeUInt32LE(input.offset, 42);
+  input.name.copy(header, 46);
+  return header;
+}
+
+function endOfCentralDirectory(entryCount: number, centralSize: number, centralOffset: number): Buffer {
+  if (entryCount > 0xffff) throw new Error("ZIP32_LIMIT_EXCEEDED: entry count");
+  const footer = Buffer.allocUnsafe(22);
+  footer.writeUInt32LE(0x0605_4b50, 0);
+  footer.writeUInt16LE(0, 4);
+  footer.writeUInt16LE(0, 6);
+  footer.writeUInt16LE(entryCount, 8);
+  footer.writeUInt16LE(entryCount, 10);
+  footer.writeUInt32LE(centralSize, 12);
+  footer.writeUInt32LE(centralOffset, 16);
+  footer.writeUInt16LE(0, 20);
+  return footer;
+}
+
+async function* generateZip(entries: readonly ZipStreamEntry[], date: Date): AsyncGenerator<Buffer> {
+  const directory: CentralDirectoryEntry[] = [];
+  const timestamp = dosTimestamp(date);
+  let offset = 0;
+
+  const tracked = (chunk: Buffer): Buffer => {
+    offset += chunk.length;
+    assertZip32(offset, "archive offset");
+    return chunk;
+  };
+
+  for (const source of entries) {
+    const name = Buffer.from(source.name, "utf8");
+    if (name.length > 0xffff) throw new Error("ZIP32_LIMIT_EXCEEDED: file name");
+    const resolved = typeof source.content === "function" ? source.content() : source.content;
+    const content = Buffer.isBuffer(resolved) ? resolved : Buffer.from(resolved, "utf8");
+    assertZip32(content.length, "entry size");
+    const streamed = source.compression !== "STORE";
+    const record: CentralDirectoryEntry = {
+      name,
+      flags: UTF8_FLAG | (streamed ? DATA_DESCRIPTOR_FLAG : 0),
+      method: streamed ? 8 : 0,
+      ...timestamp,
+      crc: crc32(content),
+      compressedSize: streamed ? 0 : content.length,
+      uncompressedSize: content.length,
+      offset
+    };
+    yield tracked(localHeader(record, streamed));
+    if (!streamed) {
+      yield tracked(content);
+    } else {
+      const compressor = createDeflateRaw({ level: 6 });
+      try {
+        compressor.end(content);
+        for await (const chunk of compressor) {
+          const compressed = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          record.compressedSize += compressed.length;
+          assertZip32(record.compressedSize, "compressed entry size");
+          yield tracked(compressed);
+        }
+      } finally {
+        compressor.destroy();
+      }
+      yield tracked(dataDescriptor(record));
+    }
+    directory.push(record);
+  }
+
+  const centralOffset = offset;
+  for (const entry of directory) yield tracked(centralHeader(entry));
+  const centralSize = offset - centralOffset;
+  assertZip32(centralSize, "central directory size");
+  yield endOfCentralDirectory(directory.length, centralSize, centralOffset);
+}
+
+export function createZipStream(entries: readonly ZipStreamEntry[], date: Date): Readable {
+  return Readable.from(generateZip(entries, date), { objectMode: false });
+}

--- a/tests/integration/work-chapter-api.test.ts
+++ b/tests/integration/work-chapter-api.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import JSZip from "jszip";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buffer } from "node:stream/consumers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Runtime } from "../../src/app.js";
 import { createTestRuntime } from "../helpers.js";
 
@@ -886,6 +887,58 @@ describe("作品、导入和章节版本 API", () => {
     const emptyArchive = await JSZip.loadAsync(emptyExport.body as Buffer);
     expect(Object.keys(emptyArchive.files).filter((name) => /chapter-\d/u.test(name))).toEqual([]);
     await request(runtime.app).get(`/api/volumes/${firstVolume.body.data.id}/export?format=docx`).expect(400);
+  });
+
+  it("大作品 EPUB 按章节读取正文并完整写出目录与元信息", async () => {
+    const work = await request(runtime.app).post("/api/works").send({
+      title: "长篇流式导出",
+      author: "测试作者",
+      description: "验证正文不会整本预载。"
+    }).expect(201);
+    const workId = String(work.body.data.id);
+    const chapterCount = 24;
+    const chapterIds: string[] = [];
+    for (let volumeIndex = 0; volumeIndex < 3; volumeIndex += 1) {
+      const volume = await request(runtime.app).post(`/api/works/${workId}/volumes`).send({
+        title: `第${volumeIndex + 1}卷`
+      }).expect(201);
+      for (let chapterIndex = 0; chapterIndex < 8; chapterIndex += 1) {
+        const sequence = volumeIndex * 8 + chapterIndex + 1;
+        const chapter = await request(runtime.app).post(`/api/works/${workId}/chapters`).send({
+          volumeId: volume.body.data.id,
+          title: `第${sequence}章`,
+          content: `章节标记-${sequence}\n${`第${sequence}章长正文 & <转义>。\n`.repeat(2_000)}`
+        }).expect(201);
+        chapterIds.push(String(chapter.body.data.id));
+      }
+    }
+
+    const treeRead = vi.spyOn(runtime.store, "getWorkTree");
+    const databaseRead = vi.spyOn(runtime.database, "get");
+    const exported = await runtime.store.exportEpub(workId);
+    const contentReadCount = (): number => databaseRead.mock.calls.filter(([sql]) =>
+      String(sql).includes("SELECT content FROM chapters WHERE id = ?")
+    ).length;
+    expect(treeRead).not.toHaveBeenCalled();
+    expect(contentReadCount()).toBe(0);
+    await request(runtime.app).patch(`/api/chapters/${chapterIds[0]}`).send({ content: "导出开始后的新正文" }).expect(200);
+
+    const archive = await JSZip.loadAsync(await buffer(exported.archive));
+    expect(contentReadCount()).toBe(chapterCount);
+    const packageXml = await archive.file("OEBPS/package.opf")?.async("string");
+    expect(packageXml).toContain("<dc:title>长篇流式导出</dc:title>");
+    expect(packageXml).toContain("<dc:creator>测试作者</dc:creator>");
+    const navigation = await archive.file("OEBPS/nav.xhtml")?.async("string");
+    expect(navigation).toContain("第1卷");
+    expect(navigation).toContain("第3卷");
+    for (let sequence = 1; sequence <= chapterCount; sequence += 1) {
+      const volumeNumber = String(Math.ceil(sequence / 8)).padStart(3, "0");
+      const chapterNumber = String(((sequence - 1) % 8) + 1).padStart(3, "0");
+      const chapter = await archive.file(`OEBPS/text/chapter-${volumeNumber}-${chapterNumber}.xhtml`)?.async("string");
+      expect(chapter).toContain(`章节标记-${sequence}`);
+      expect(chapter).toContain(`第${sequence}章长正文 &amp; &lt;转义&gt;。`);
+      expect(navigation).toContain(`第${sequence}章`);
+    }
   });
 
   it("删除章节后可列出版本并恢复", async () => {

--- a/tests/unit/epub-export.test.ts
+++ b/tests/unit/epub-export.test.ts
@@ -1,4 +1,7 @@
 import JSZip from "jszip";
+import { buffer } from "node:stream/consumers";
+import { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import sharp from "sharp";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
@@ -8,13 +11,6 @@ import {
   epubDownloadFileName
 } from "../../src/epub-export.js";
 
-const archiveOptions = {
-  type: "nodebuffer" as const,
-  streamFiles: false,
-  compression: "DEFLATE" as const,
-  compressionOptions: { level: 6 }
-};
-
 let validWebp: Buffer;
 
 async function generatedArchive(input: Parameters<typeof createEpubArchive>[0]): Promise<{ buffer: Buffer; zip: JSZip }> {
@@ -23,8 +19,8 @@ async function generatedArchive(input: Parameters<typeof createEpubArchive>[0]):
     modifiedAt: "2026-08-12T13:00:00.000Z",
     ...input
   });
-  const buffer = await archive.generateAsync(archiveOptions);
-  return { buffer, zip: await JSZip.loadAsync(buffer) };
+  const generated = await buffer(archive);
+  return { buffer: generated, zip: await JSZip.loadAsync(generated) };
 }
 
 describe("EPUB 导出生成器", () => {
@@ -118,6 +114,51 @@ describe("EPUB 导出生成器", () => {
     expect(chapter).toContain("星海中的长段落 &amp; 航线。");
     expect(chapter).toContain("结尾。");
     expect(chapter).not.toContain("<标签>");
+  });
+
+  it("消费到对应 ZIP 条目时才读取章节，并在读取失败后停止", async () => {
+    const reads: string[] = [];
+    const archive = await createEpubArchive({
+      title: "按章读取",
+      identifier: "urn:uuid:11111111-2222-4333-8444-555555555555",
+      modifiedAt: "2026-08-12T13:00:00.000Z",
+      volumes: [{
+        title: "正文",
+        chapters: [
+          { title: "第一章", content: () => { reads.push("first"); return "第一章正文"; } },
+          { title: "第二章", content: () => { reads.push("second"); throw new Error("chapter read failed"); } },
+          { title: "第三章", content: () => { reads.push("third"); return "不应读取"; } }
+        ]
+      }]
+    });
+
+    expect(reads).toEqual([]);
+    await expect(buffer(archive)).rejects.toThrow("chapter read failed");
+    expect(reads).toEqual(["first", "second"]);
+  });
+
+  it("下游断开时不继续读取尚未写出的章节", async () => {
+    const reads: string[] = [];
+    const archive = await createEpubArchive({
+      title: "中断导出",
+      identifier: "urn:uuid:11111111-2222-4333-8444-555555555555",
+      modifiedAt: "2026-08-12T13:00:00.000Z",
+      volumes: [{
+        title: "正文",
+        chapters: Array.from({ length: 20 }, (_, index) => ({
+          title: `第${index + 1}章`,
+          content: () => { reads.push(String(index)); return "正文".repeat(10_000); }
+        }))
+      }]
+    });
+    const disconnected = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(new Error("client disconnected"));
+      }
+    });
+
+    await expect(pipeline(archive, disconnected)).rejects.toThrow("client disconnected");
+    expect(reads).toEqual([]);
   });
 
   it("安全生成中文下载文件名和回退响应头", () => {


### PR DESCRIPTION
## Summary

- replace JSZip EPUB generation with a backpressure-aware sequential ZIP stream
- read chapter bodies lazily by pinned version instead of loading the full work tree
- preserve EPUB entry order, metadata, cover handling, XML escaping, filenames, and response headers
- stop pending chapter reads on failure or client disconnect

## Verification

- `npx vitest run tests/unit/epub-export.test.ts tests/integration/work-chapter-api.test.ts tests/integration/user-auth-api.test.ts` (76 passed)
- `npm test` (936 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes MUXUE-64
