### PR TITLE
MUXUE-66: stop analysis when trashing works

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2507,6 +2507,22 @@ export class AiManager {
     };
   }
 
+  deleteWork(workId: string, expectedVersionNo?: number): string[] {
+    const taskIds = this.store.deleteWork(workId, expectedVersionNo);
+    const autoRunTimer = this.autoRunTimers.get(workId);
+    if (autoRunTimer) clearTimeout(autoRunTimer);
+    this.autoRunTimers.delete(workId);
+    this.autoRunStarting.delete(workId);
+    const relationshipIndexTimer = this.relationshipIndexSyncTimers.get(workId);
+    if (relationshipIndexTimer) clearTimeout(relationshipIndexTimer);
+    this.relationshipIndexSyncTimers.delete(workId);
+    for (const taskId of taskIds) {
+      this.taskControllers.get(taskId)?.abort(new Error("作品已移入回收站"));
+    }
+    logger.info("ai.work_tasks.expired", { workId, taskCount: taskIds.length });
+    return taskIds;
+  }
+
   dispose(): void {
     logger.info("ai.manager.disposing", { scheduledWorks: this.autoRunTimers.size, activeTasks: this.taskControllers.size });
     if (this.autoRunStartupTimer) clearTimeout(this.autoRunStartupTimer);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1545,7 +1545,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   });
   app.delete("/api/works/:workId", async (request, response) => {
     const input = parse(z.object({ expectedVersionNo: expectedVersionNoSchema }).strict(), request.body ?? {});
-    store.deleteWork(request.params.workId, input.expectedVersionNo);
+    ai.deleteWork(request.params.workId, input.expectedVersionNo);
     noContent(response);
   });
   app.get("/api/works/:workId/cover", (request, response) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1641,20 +1641,31 @@ export class Store {
   }
 
   deleteWork(workId: string, expectedVersionNo?: number): string[] {
-    this.db.transaction(() => {
+    return this.db.transaction(() => {
       const current = this.getWork(workId);
       this.assertExpectedVersion("work", workId, expectedVersionNo, "作品", Number(current.versionNo));
       const timestamp = now();
+      const activeTaskIds = this.db.all(
+        "SELECT id FROM analysis_tasks WHERE work_id = ? AND status IN ('pending', 'running') ORDER BY id",
+        workId
+      ).map((row) => requiredString(row, "id"));
       const versionNo = this.recordEntityVersion("work", workId, "delete", null, "删除作品（可恢复）", timestamp);
       this.db.run("UPDATE works SET version_no = ?, deleted_at = ?, updated_at = ? WHERE id = ?", versionNo, timestamp, timestamp, workId);
+      this.db.run(
+        `UPDATE analysis_tasks SET status = 'expired', next_attempt_at = NULL, updated_at = ?
+         WHERE work_id = ? AND status IN ('pending', 'running')`,
+        timestamp,
+        workId
+      );
+      this.db.run("DELETE FROM relationship_source_index_queue WHERE work_id = ?", workId);
       this.audit(workId, "work.deleted", "work", workId, {
         title: current.title,
         versionNo,
         recoverable: true,
         expiresAt: recycleBinExpiresAt(timestamp)
       });
+      return activeTaskIds;
     });
-    return [];
   }
 
   restoreWork(workId: string, expectedVersionNo?: number): Record<string, unknown> {
@@ -8267,7 +8278,10 @@ export class Store {
 
   listAutoRunWorkIds(): string[] {
     return this.db.all(
-      "SELECT work_id FROM work_ai_settings WHERE auto_run_enabled = 1 ORDER BY work_id"
+      `SELECT settings.work_id FROM work_ai_settings settings
+       JOIN works work ON work.id = settings.work_id
+       WHERE settings.auto_run_enabled = 1 AND work.deleted_at IS NULL
+       ORDER BY settings.work_id`
     ).map((row) => requiredString(row, "work_id"));
   }
 

--- a/tests/integration/recycle-bin-api.test.ts
+++ b/tests/integration/recycle-bin-api.test.ts
@@ -70,6 +70,132 @@ describe("作品、分卷与章节回收站", () => {
     expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
   });
 
+  it("软删除作品仅失效活动分析任务，恢复不重启旧任务且彻底删除仍完整级联", async () => {
+    runtime.ai.dispose();
+    const work = runtime.store.createWork({ title: "分析任务回收站作品" });
+    const workId = String(work.id);
+    const pending = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    const running = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    const completed = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    const cancelled = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    const pendingId = String(pending.id);
+    const runningId = String(running.id);
+    const completedId = String(completed.id);
+    const cancelledId = String(cancelled.id);
+    expect(runtime.store.claimPendingTask(runningId)).not.toBeNull();
+    runtime.store.updateTask(completedId, { status: "completed", progress: 100, result: { summary: "保留历史结果" } });
+    runtime.store.cancelTask(cancelledId);
+    runtime.store.updateWorkAiSettings(workId, { autoRunEnabled: true });
+    runtime.database.run(
+      `INSERT INTO ai_calls (id, work_id, task_id, task_type, provider_id, model_id, context_scope_json, status, created_at)
+       VALUES (?, ?, ?, 'book-analysis', 'provider-history', 'model-history', '{}', 'completed', ?)`,
+      "call-history",
+      workId,
+      completedId,
+      new Date().toISOString()
+    );
+    runtime.database.run(
+      `INSERT INTO relationship_source_index_queue (work_id, source_type, source_id, queued_at)
+       VALUES (?, 'work', ?, ?)
+       ON CONFLICT(work_id, source_type, source_id) DO UPDATE SET queued_at = excluded.queued_at`,
+      workId,
+      workId,
+      new Date().toISOString()
+    );
+    expect(runtime.store.listAutoRunWorkIds()).toContain(workId);
+
+    await request(runtime.app).delete(`/api/works/${workId}`).send({ expectedVersionNo: 1 }).expect(204);
+    expect(runtime.database.all(
+      "SELECT id, status FROM analysis_tasks WHERE work_id = ? ORDER BY id",
+      workId
+    )).toEqual(expect.arrayContaining([
+      { id: pendingId, status: "expired" },
+      { id: runningId, status: "expired" },
+      { id: completedId, status: "completed" },
+      { id: cancelledId, status: "cancelled" }
+    ]));
+    expect(runtime.database.get("SELECT result_json FROM analysis_tasks WHERE id = ?", completedId)).toEqual({
+      result_json: JSON.stringify({ summary: "保留历史结果" })
+    });
+    expect(runtime.database.get("SELECT id, task_id FROM ai_calls WHERE id = 'call-history'")).toEqual({
+      id: "call-history",
+      task_id: completedId
+    });
+    expect(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM relationship_source_index_queue WHERE work_id = ?",
+      workId
+    )?.count).toBe(0);
+    expect(runtime.store.listAutoRunWorkIds()).not.toContain(workId);
+
+    const repeated = await request(runtime.app).delete(`/api/works/${workId}`).send({ expectedVersionNo: 2 }).expect(404);
+    expect(repeated.body.error.code).toBe("NOT_FOUND");
+    expect(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'work' AND entity_id = ?",
+      workId
+    )?.count).toBe(2);
+
+    await request(runtime.app).post(`/api/recycle-bin/works/${workId}/restore`).send({ expectedVersionNo: 2 }).expect(200);
+    expect(runtime.store.listAutoRunWorkIds()).toContain(workId);
+    expect(runtime.database.all(
+      "SELECT id, status FROM analysis_tasks WHERE id IN (?, ?) ORDER BY id",
+      pendingId,
+      runningId
+    )).toEqual(expect.arrayContaining([
+      { id: pendingId, status: "expired" },
+      { id: runningId, status: "expired" }
+    ]));
+
+    await request(runtime.app).delete(`/api/works/${workId}`).send({ expectedVersionNo: 3 }).expect(204);
+    await request(runtime.app).delete(`/api/recycle-bin/works/${workId}/permanent`).send({ expectedVersionNo: 4 }).expect(204);
+    expect(runtime.database.get("SELECT id FROM analysis_tasks WHERE work_id = ?", workId)).toBeUndefined();
+    expect(runtime.database.get("SELECT id FROM ai_calls WHERE id = 'call-history'")).toBeUndefined();
+    expect(runtime.database.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("作品删除事务失败时回滚任务失效和关系索引队列清理", async () => {
+    runtime.ai.dispose();
+    const work = runtime.store.createWork({ title: "删除事务回滚作品" });
+    const workId = String(work.id);
+    const pending = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    const running = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    runtime.store.claimPendingTask(String(running.id));
+    runtime.database.run(
+      `INSERT INTO relationship_source_index_queue (work_id, source_type, source_id, queued_at)
+       VALUES (?, 'work', ?, ?)
+       ON CONFLICT(work_id, source_type, source_id) DO UPDATE SET queued_at = excluded.queued_at`,
+      workId,
+      workId,
+      new Date().toISOString()
+    );
+    runtime.database.raw.exec(`
+      CREATE TRIGGER fail_work_delete_audit
+      BEFORE INSERT ON audit_logs WHEN NEW.action = 'work.deleted'
+      BEGIN SELECT RAISE(ABORT, 'forced audit failure'); END;
+    `);
+
+    await request(runtime.app).delete(`/api/works/${workId}`).send({ expectedVersionNo: 1 }).expect(500);
+    expect(runtime.database.get("SELECT version_no, deleted_at FROM works WHERE id = ?", workId)).toEqual({
+      version_no: 1,
+      deleted_at: null
+    });
+    expect(runtime.database.all(
+      "SELECT id, status FROM analysis_tasks WHERE work_id = ? ORDER BY id",
+      workId
+    )).toEqual(expect.arrayContaining([
+      { id: pending.id, status: "pending" },
+      { id: running.id, status: "running" }
+    ]));
+    expect(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM relationship_source_index_queue WHERE work_id = ?",
+      workId
+    )?.count).toBe(1);
+    expect(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'work' AND entity_id = ?",
+      workId
+    )?.count).toBe(1);
+  });
+
   it("分卷软删除和恢复保持章节关联，彻底删除后清理历史且无悬挂外键", async () => {
     const work = await request(runtime.app).post("/api/works").send({ title: "分卷恢复作品" }).expect(201);
     const workId = String(work.body.data.id);

--- a/tests/integration/task-auto-run.test.ts
+++ b/tests/integration/task-auto-run.test.ts
@@ -46,8 +46,19 @@ async function setupWork(fetchMock: typeof fetch): Promise<{
         headers: { "Content-Type": "application/json" }
       });
     }
-    await new Promise<void>((resolve) => {
-      releaseGates.push(resolve);
+    await new Promise<void>((resolve, reject) => {
+      const signal = init?.signal;
+      const release = () => {
+        signal?.removeEventListener("abort", rejectOnAbort);
+        resolve();
+      };
+      const rejectOnAbort = () => reject(signal?.reason ?? new Error("AI request aborted"));
+      if (signal?.aborted) {
+        rejectOnAbort();
+        return;
+      }
+      signal?.addEventListener("abort", rejectOnAbort, { once: true });
+      releaseGates.push(release);
     });
     return fetchMock(input, init);
   };
@@ -427,6 +438,63 @@ describe("分析任务自动运行", () => {
     const statuses = (tasks.body.data.items as Array<{ status: string }>).map((item) => item.status);
     expect(statuses.filter((status) => status === "review")).toHaveLength(5);
     expect(statuses.filter((status) => status === "pending")).toHaveLength(0);
+  });
+
+  it("作品进入回收站后中止运行任务并清理后续调度", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ summary: "不应写入", events: [], characters: [], settings: [], evidence: [], uncertainties: [] }) } }]
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    const { runtime, workId } = await setupWork(fetchMock);
+    runtimes.push(runtime);
+
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
+      autoRunEnabled: true,
+      autoRunConcurrency: 1
+    }).expect(200);
+    await waitFor(() => runtime.store.countRunningTasks(workId) === 1);
+
+    const aiInternals = runtime.ai as unknown as {
+      autoRunStarting: Map<string, Set<string>>;
+      autoRunTimers: Map<string, ReturnType<typeof setTimeout>>;
+      relationshipIndexSyncTimers: Map<string, ReturnType<typeof setTimeout>>;
+      scheduleRelationshipIndexSync: (targetWorkId: string) => void;
+      taskControllers: Map<string, AbortController>;
+    };
+    const runningSignal = [...aiInternals.taskControllers.values()][0]?.signal;
+    expect(runningSignal?.aborted).toBe(false);
+    runtime.ai.scheduleAutoRun(workId, 25);
+    aiInternals.scheduleRelationshipIndexSync(workId);
+    expect(aiInternals.autoRunTimers.has(workId)).toBe(true);
+    expect(aiInternals.relationshipIndexSyncTimers.has(workId)).toBe(true);
+
+    await request(runtime.app).delete(`/api/works/${workId}`).send({ expectedVersionNo: 1 }).expect(204);
+    await waitFor(() => aiInternals.taskControllers.size === 0);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(runningSignal?.aborted).toBe(true);
+    expect(aiInternals.autoRunStarting.has(workId)).toBe(false);
+    expect(aiInternals.autoRunTimers.has(workId)).toBe(false);
+    expect(aiInternals.relationshipIndexSyncTimers.has(workId)).toBe(false);
+    expect(runtime.database.all(
+      "SELECT status, COUNT(*) AS count FROM analysis_tasks WHERE work_id = ? GROUP BY status ORDER BY status",
+      workId
+    )).toEqual([{ status: "expired", count: 5 }]);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await request(runtime.app).post(`/api/recycle-bin/works/${workId}/restore`).send({ expectedVersionNo: 2 }).expect(200);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(runtime.store.countPendingTasks(workId)).toBe(0);
+    expect(runtime.store.countRunningTasks(workId)).toBe(0);
+    expect(aiInternals.autoRunTimers.has(workId)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const newTask = runtime.store.createTask(workId, { taskType: "book-analysis", scope: { type: "book" } });
+    expect(aiInternals.autoRunTimers.has(workId)).toBe(true);
+    runtime.ai.scheduleAutoRun(workId, 60_000);
+    await request(runtime.app).delete(`/api/works/${workId}`).send({ expectedVersionNo: 3 }).expect(204);
+    expect(runtime.store.getTask(String(newTask.id)).status).toBe("expired");
+    expect(aiInternals.autoRunTimers.has(workId)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("自动任务连续失败后暂停剩余队列", async () => {


### PR DESCRIPTION
## Summary

- expire pending and running analysis tasks atomically when a work enters the recycle bin
- stop active AI requests and clear automatic-run and relationship-index timers for the work
- preserve completed task results and AI call history until permanent deletion
- exclude deleted works from automatic-run startup discovery and keep restore scheduling deterministic

## Verification

- `npm run typecheck`
- `npm test` (186 files, 936 tests)
- `npm run build`
- isolated SQLite `PRAGMA integrity_check` and `PRAGMA foreign_key_check`

Closes MUXUE-66
