### PR TITLE
build(release): bump version to 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.5";
+export const APP_VERSION = "0.7.6";


### PR DESCRIPTION
## 发布版本号

将应用版本统一从 0.7.5 更新为 0.7.6，包含 `package.json`、`package-lock.json` 顶层与根包、`src/version.ts`。

## 验证

- 相关测试：8 个测试文件、123 项通过
- 全量测试：186 个测试文件、938 项通过
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- SQLite 只读 `PRAGMA integrity_check` 与 `PRAGMA foreign_key_check`
- 隔离生产构建健康检查：`/api/health` 返回 `status: ok`、版本 `0.7.6`

## 审计

本次 `develop` 相对 `main` 的功能变更未修改 CLI 实现或 CLI 契约，无需额外 CLI 同步。
