### PR TITLE
fix(ai): allow model output limits above 32k

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -444,6 +444,7 @@ type CharacterExtractionApplicationItem = {
 
 const allowedParameters = new Set(["temperature", "top_p", "max_tokens", "presence_penalty", "frequency_penalty", "seed"]);
 const DEFAULT_MAX_TOKENS = 32_000;
+const MAX_MODEL_OUTPUT_TOKENS = 2_000_000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const RELATIONSHIP_MAX_FUZZY_REFERENCES = 32;
 const RELATIONSHIP_MAX_FUZZY_SOURCES = 200;
@@ -1165,7 +1166,7 @@ function completionPayloadOutputText(payload: CompletionPayload): string {
 
 function normalizeModelPreset(input: Record<string, unknown>, modelId = ""): Record<string, unknown> {
   const maxTokens = typeof input.max_tokens === "number" && Number.isFinite(input.max_tokens)
-    ? Math.round(clamp(input.max_tokens, 1, 32_768))
+    ? Math.round(clamp(input.max_tokens, 1, MAX_MODEL_OUTPUT_TOKENS))
     : DEFAULT_MAX_TOKENS;
   const temperature = input.temperature;
   const defaultTemperature = isKimiModelId(modelId) && !(typeof temperature === "number" && Number.isFinite(temperature))
@@ -10196,7 +10197,7 @@ export class AiManager {
     if (isKimiModelId(modelId) && typeof output.temperature !== "number") output.temperature = 1;
     if (typeof output.top_p === "number") output.top_p = clamp(output.top_p, 0, 1);
     output.max_tokens = typeof output.max_tokens === "number"
-      ? Math.round(clamp(output.max_tokens, 1, 32_768))
+      ? Math.round(clamp(output.max_tokens, 1, MAX_MODEL_OUTPUT_TOKENS))
       : DEFAULT_MAX_TOKENS;
     return output;
   }

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1650,8 +1650,9 @@ describe("AI 供应商、模型与建议 API", () => {
   it("生成建议不改正文，作者采纳后才生成新版本", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
-    expectedMaxTokens = 24_000;
-    await request(runtime.app).patch(`/api/models/${modelId}`).send({ preset: { max_tokens: expectedMaxTokens } }).expect(200);
+    expectedMaxTokens = 64_000;
+    const updatedModel = await request(runtime.app).patch(`/api/models/${modelId}`).send({ preset: { max_tokens: expectedMaxTokens } }).expect(200);
+    expect(updatedModel.body.data.preset.max_tokens).toBe(expectedMaxTokens);
 
     const suggestion = await request(runtime.app).post(`/api/works/${workId}/suggestions`).send({
       taskType: "continue",
@@ -1670,7 +1671,7 @@ describe("AI 供应商、模型与建议 API", () => {
 
     const calls = await request(runtime.app).get(`/api/works/${workId}/ai-calls`).expect(200);
     const continuationCall = calls.body.data.find((call: { taskType: string }) => call.taskType === "continue");
-    expect(continuationCall).toMatchObject({ status: "completed", parameters: { temperature: 2, max_tokens: 24_000 } });
+    expect(continuationCall).toMatchObject({ status: "completed", parameters: { temperature: 2, max_tokens: 64_000 } });
     expect(continuationCall.provider.name).toBe("本地兼容服务");
     expect(continuationCall.model.displayName).toBe("小说模型");
     expect(suggestion.body.data.guard).toMatchObject({ status: "clear", issues: [] });


### PR DESCRIPTION
## 变更内容

修复模型默认最大输出令牌数无法配置为大于 32K 的问题。

## 根因

模型配置归一化和实际请求参数清洗都将 `max_tokens` 强制截断为 32,768，导致前端即使保存更大的值也无法真正发送给供应商。

## 修复

- 将可配置最大输出令牌数上限提升至 2,000,000。
- 保留默认值 32,000。
- 实际请求继续根据模型上下文窗口和输入占用进行动态限制。
- 增加 64,000 输出令牌配置的回归验证。

## 验证

- 相关集成测试：59 项通过。
- 前端与静态资源测试：14 项通过。
- 全量测试：186 个测试文件、938 项通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。