### PR TITLE
fix(ui): polish homepage loading, shelf actions, and branding

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260813-scrollbar-stable-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260814-pending-footer-layout-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -15,7 +15,7 @@
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
       <div class="auth-card">
-        <div class="auth-brand"><span class="brand-mark">叙</span><div><strong>叙界</strong><small>小说 AI 创作工作台</small></div></div>
+        <div class="auth-brand"><img class="brand-mark" src="/icon.svg?v=20260712" alt=""><div><strong>叙界</strong><small>小说 AI 创作工作台</small></div></div>
         <span class="eyebrow">账户与作品空间</span>
         <h1 id="auth-title">登录后继续创作</h1>
         <p id="auth-description">你的作品、协作权限和每一次修改都会绑定到账户。</p>
@@ -65,7 +65,7 @@
     <div id="app" class="app-shell">
       <header class="topbar">
         <button id="home-button" class="brand-block" type="button" aria-label="返回书架">
-          <span class="brand-mark">叙</span>
+          <img class="brand-mark" src="/icon.svg?v=20260712" alt="">
           <div>
             <strong>叙界</strong>
             <small>小说 AI 创作工作台</small>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260814-pending-footer-layout-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260814-shelf-action-height-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -3578,7 +3578,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
   #shelf-view .product-footer, #settings-hub-view .product-footer { margin-bottom: 0; padding-bottom: env(safe-area-inset-bottom); }
   .shelf-header, .module-header { align-items: stretch; flex-direction: column; gap: 14px; margin-bottom: 20px; }
   .shelf-header h1 { font-size: clamp(24px, 7.5vw, 32px); }
-  .shelf-header .primary-button { align-self: flex-start; min-width: 150px; min-height: 40px; padding: 10px 18px; }
+  .shelf-header .primary-button { align-self: flex-start; min-width: 150px; min-height: 40px; padding: 8px 18px; }
   .shelf-header-actions { align-self: flex-start; flex-wrap: wrap; }
   .settings-detail-actions { align-items: stretch; flex-direction: column; }
   .settings-detail-actions .primary-button, .settings-detail-actions .settings-parent-button { align-self: stretch; width: 100%; }

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -94,7 +94,7 @@
 [data-pending-view="settings"] .auth-pending #settings-hub-view.hidden,
 [data-pending-view="platform-ai"] .auth-pending #platform-ai-view.hidden,
 [data-pending-view="platform-usage"] .auth-pending #platform-usage-view.hidden,
-[data-pending-view="work-audit"] .auth-pending #work-audit-view.hidden,
+[data-pending-view="work-audit"] .auth-pending #work-audit-view.hidden { display: flex !important; }
 [data-pending-view="module"] .auth-pending #module-view.hidden { display: block !important; }
 [data-pending-view="welcome"] .auth-pending #welcome-view.hidden,
 [data-pending-view="editor"] .auth-pending #editor-view.hidden { display: grid !important; }

--- a/tests/system/ai-user-message-mentions-ui.test.ts
+++ b/tests/system/ai-user-message-mentions-ui.test.ts
@@ -10,7 +10,7 @@ describe("AI 用户消息角色引用横幅", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application).toContain('/ai-mentions.js?v=20260811-user-message-mentions-v1');
     expect(application).toContain("persistedUserMessage.createdAt, persistedUserMessage.metadata, persistedUserMessage.id");

--- a/tests/system/ai-user-message-mentions-ui.test.ts
+++ b/tests/system/ai-user-message-mentions-ui.test.ts
@@ -10,7 +10,7 @@ describe("AI 用户消息角色引用横幅", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application).toContain('/ai-mentions.js?v=20260811-user-message-mentions-v1');
     expect(application).toContain("persistedUserMessage.createdAt, persistedUserMessage.metadata, persistedUserMessage.id");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -328,7 +328,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/index.css?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');
@@ -372,6 +372,7 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".dev-auth-bypass .auth-view { display: none !important; }");
     expect(styles.text).toContain(".dev-auth-bypass .auth-loading { display: none !important; }");
     expect(styles.text).toContain(".shelf-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 30px; width: 100%;");
+    expect(styles.text).toContain(".shelf-header .primary-button { align-self: flex-start; min-width: 150px; min-height: 40px; padding: 8px 18px; }");
     expect(styles.text).toContain("width: 90%; margin-inline: auto; aspect-ratio: 3 / 4.25;");
     expect(styles.text).toContain(".settings-hub-header h1 { font-size: clamp(26px, 3vw, 36px); line-height: 1.15; letter-spacing: -.02em; }");
     expect(styles.text).toContain(".settings-hub-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -357,6 +357,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('<body>');
     expect(page.text).toContain('id="auth-view" class="auth-view hidden"');
     expect(page.text).toContain('<html lang="zh-CN" class="dev-auth-bypass">');
+    expect(page.text.match(/<img class="brand-mark" src="\/icon\.svg\?v=20260712" alt="">/gu)).toHaveLength(2);
     expect(page.text).toContain('id="presence-button"');
     expect(page.text).toContain('<span id="presence-count">1 人</span>');
     expect(page.text).not.toContain('id="presence-count">1 人在线</span>');

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -328,7 +328,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/index.css?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
     expect(application.text).toContain('/api/platform/ai/usage?timezoneOffset=');

--- a/tests/system/character-extraction-preview-ui.test.ts
+++ b/tests/system/character-extraction-preview-ui.test.ts
@@ -11,7 +11,7 @@ describe("角色抽取结果入库预览界面", () => {
       readFile(join(publicPath, "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application).toContain("function renderCharacterExtractionPreview(task, result)");
     expect(application).toContain("function renderCharacterExtractionEditor(preview)");

--- a/tests/system/character-extraction-preview-ui.test.ts
+++ b/tests/system/character-extraction-preview-ui.test.ts
@@ -11,7 +11,7 @@ describe("角色抽取结果入库预览界面", () => {
       readFile(join(publicPath, "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application).toContain("function renderCharacterExtractionPreview(task, result)");
     expect(application).toContain("function renderCharacterExtractionEditor(preview)");

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
   });
 });

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
   });
 });

--- a/tests/system/foreshadow-reminder-ui.test.ts
+++ b/tests/system/foreshadow-reminder-ui.test.ts
@@ -20,7 +20,7 @@ describe("编辑器伏笔提醒界面", () => {
       request(runtime.app).get("/foreshadow-reminder.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(page.text).toContain('id="chapter-foreshadow-reminder" class="chapter-foreshadow-reminder hidden"');
     expect(page.text).toContain('aria-live="polite" aria-labelledby="chapter-foreshadow-reminder-title"');

--- a/tests/system/foreshadow-reminder-ui.test.ts
+++ b/tests/system/foreshadow-reminder-ui.test.ts
@@ -20,7 +20,7 @@ describe("编辑器伏笔提醒界面", () => {
       request(runtime.app).get("/foreshadow-reminder.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(page.text).toContain('id="chapter-foreshadow-reminder" class="chapter-foreshadow-reminder hidden"');
     expect(page.text).toContain('aria-live="polite" aria-labelledby="chapter-foreshadow-reminder-title"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260813-outline-board-page-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260813-outline-board-page-v1"></script>');
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/outline-board-ui.test.ts
+++ b/tests/system/outline-board-ui.test.ts
@@ -20,7 +20,7 @@ describe("章节大纲看板界面", () => {
       request(runtime.app).get("/outline-board.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('/outline-board.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('outlineBoardRequestPath(workId, outlineBoardFilters');

--- a/tests/system/outline-board-ui.test.ts
+++ b/tests/system/outline-board-ui.test.ts
@@ -20,7 +20,7 @@ describe("章节大纲看板界面", () => {
       request(runtime.app).get("/outline-board.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('/outline-board.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('outlineBoardRequestPath(workId, outlineBoardFilters');

--- a/tests/system/product-footer.test.ts
+++ b/tests/system/product-footer.test.ts
@@ -42,6 +42,8 @@ describe("产品信息页脚", () => {
     expect(application.text).toContain('element.textContent = `发现新版本 v${latestVersion}，查看更新说明`;');
     expect(application.text).toContain('const [authenticated] = await Promise.all([initializeAuthentication(), initializeProductFooters()]);');
     expect(styles.text).toContain(".shelf-view { display: flex; flex-direction: column; height: 100%;");
+    expect(styles.text).toContain('[data-pending-view="shelf"] .auth-pending #shelf-view.hidden,');
+    expect(styles.text).toContain('[data-pending-view="work-audit"] .auth-pending #work-audit-view.hidden { display: flex !important; }');
     expect(styles.text).toContain("#shelf-view, #settings-hub-view { padding-bottom: 24px; }");
     expect(styles.text).toContain("width: 100%; min-width: 0; max-width: 1400px;");
     expect(styles.text).toContain("margin: auto auto 0;");

--- a/tests/system/reading-preview-ui.test.ts
+++ b/tests/system/reading-preview-ui.test.ts
@@ -22,7 +22,7 @@ describe("沉浸式阅读预览界面", () => {
     const readingState = await request(runtime.app).get("/reading-preview.js").expect(200);
     const pageRoute = await request(runtime.app).get("/page-route.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(page.text).toContain('id="reader-open-button" class="module-nav-secondary hidden"');
     expect(page.text).toMatch(/id="module-more-button"[\s\S]*id="reader-open-button"[\s\S]*data-module="comments"/u);

--- a/tests/system/reading-preview-ui.test.ts
+++ b/tests/system/reading-preview-ui.test.ts
@@ -22,7 +22,7 @@ describe("沉浸式阅读预览界面", () => {
     const readingState = await request(runtime.app).get("/reading-preview.js").expect(200);
     const pageRoute = await request(runtime.app).get("/page-route.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(page.text).toContain('id="reader-open-button" class="module-nav-secondary hidden"');
     expect(page.text).toMatch(/id="module-more-button"[\s\S]*id="reader-open-button"[\s\S]*data-module="comments"/u);

--- a/tests/system/recycle-bin-ui.test.ts
+++ b/tests/system/recycle-bin-ui.test.ts
@@ -46,7 +46,7 @@ describe("作品与正文回收站界面", () => {
     expect(styles.text).toContain(".shelf-header-actions");
     expect(styles.text).toContain(".recycle-bin-section-list");
     expect(styles.text).toContain(".recycle-bin-card { grid-template-columns: minmax(0, 1fr);");
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
   });
 });

--- a/tests/system/recycle-bin-ui.test.ts
+++ b/tests/system/recycle-bin-ui.test.ts
@@ -46,7 +46,7 @@ describe("作品与正文回收站界面", () => {
     expect(styles.text).toContain(".shelf-header-actions");
     expect(styles.text).toContain(".recycle-bin-section-list");
     expect(styles.text).toContain(".recycle-bin-card { grid-template-columns: minmax(0, 1fr);");
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
   });
 });

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,7 +23,7 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,7 +23,7 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -44,7 +44,7 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
 
     expect(application.text).toContain('/s3-backup-ui.js?v=20260810-backup-encryption-v1');

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -44,7 +44,7 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
 
     expect(application.text).toContain('/s3-backup-ui.js?v=20260810-backup-encryption-v1');

--- a/tests/system/setting-filters-ui.test.ts
+++ b/tests/system/setting-filters-ui.test.ts
@@ -20,7 +20,7 @@ describe("设定筛选界面", () => {
       request(runtime.app).get("/setting-filters.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260813-scrollbar-stable-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('/setting-filters.js?v=20260810-setting-inline-filters-v1');
     expect(application.text).toContain('const settingFilters = { keyword: "", category: "", lockState: "all" };');

--- a/tests/system/setting-filters-ui.test.ts
+++ b/tests/system/setting-filters-ui.test.ts
@@ -20,7 +20,7 @@ describe("设定筛选界面", () => {
       request(runtime.app).get("/setting-filters.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260814-pending-footer-layout-v1');
+    expect(page.text).toContain('/styles.css?v=20260814-shelf-action-height-v1');
     expect(page.text).toContain('/app.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('/setting-filters.js?v=20260810-setting-inline-filters-v1');
     expect(application.text).toContain('const settingFilters = { keyword: "", category: "", lockState: "all" };');


### PR DESCRIPTION
## 变更内容

- 修复首页会话加载期间的书架布局，避免 footer 在加载完成后跳动。
- 统一移动端“作品回收站”和“新建作品”按钮高度。
- 使用现有 favicon 的叙界 Logo 替换登录页和工作台顶部的文字品牌方块。

## 验证

- 相关系统测试通过。
- 类型检查与生产构建通过。
- 使用内置浏览器验证桌面端与 390×844 移动端布局，确认无横向溢出和控制台错误。