### PR TITLE
fix(ai): align compact fallback with context and output budgets

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4357,6 +4357,7 @@ export class AiManager {
       - functionTokens);
     return {
       contextWindow,
+      configuredOutputTokens,
       outputReserveTokens,
       availableInputTokens,
       conversation,
@@ -4387,6 +4388,8 @@ export class AiManager {
     const threshold = Math.min(90, Math.max(50, Number(this.store.getWorkAiSettings(input.workId).contextCompactThreshold) || 85));
     const conversation = budget.conversation as AiConversationContext | null;
     const conversationUsagePercent = Number(budget.conversationUsagePercent) || 0;
+    const configuredOutputTokens = Number(budget.configuredOutputTokens) || DEFAULT_MAX_TOKENS;
+    const maxOutputUsagePercent = Math.min(100, Math.round(configuredOutputTokens / contextWindow * 100));
     const compactableMessageCount = Math.max(0, (conversation?.messages.length ?? 0) - 2);
     return {
       modelId: stringValue(model, "id"),
@@ -4396,6 +4399,9 @@ export class AiManager {
       conversationTokens: Number(budget.conversationTokens),
       conversationBudgetTokens: Number(budget.conversationBudgetTokens),
       conversationUsagePercent,
+      maxOutputTokens: configuredOutputTokens,
+      maxOutputUsagePercent,
+      maxOutputThresholdReached: configuredOutputTokens >= contextWindow * FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT / 100,
       outputReserveTokens: Number(budget.outputReserveTokens),
       remainingTokens,
       usagePercent: Math.min(100, Math.round(inputTokens / contextWindow * 100)),
@@ -4456,8 +4462,10 @@ export class AiManager {
   } {
     const usage = this.getContextUsage({ ...input, taskType: "chat" });
     const usagePercent = Number(usage.usagePercent) || 0;
+    const maxOutputThresholdReached = usage.maxOutputThresholdReached === true;
     const compactableMessageCount = Number(usage.compactableMessageCount) || 0;
-    if (usagePercent >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT) {
+    const outputThresholdNeedsCompaction = maxOutputThresholdReached && compactableMessageCount > 0;
+    if (usagePercent >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT || outputThresholdNeedsCompaction) {
       if (compactableMessageCount <= 0) {
         throw new AppError(
           409,
@@ -4497,6 +4505,14 @@ export class AiManager {
     }
     const compaction = await this.compactConversation(input);
     if (compaction.changed !== true) {
+      const inputBelowForcedThreshold = (Number(inspection.usage.usagePercent) || 0) < FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT;
+      if (inspection.usage.maxOutputThresholdReached === true && inputBelowForcedThreshold) {
+        return {
+          action: "ready",
+          reason: "output_budget_already_fits",
+          usage: { ...inspection.usage, contextWarningPending: false }
+        };
+      }
       throw new AppError(
         409,
         "AI_CONTEXT_COMPACTION_UNAVAILABLE",

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -150,6 +150,8 @@ const AUTO_RUN_RETRY_DELAYS_MS = [5_000, 30_000] as const;
 const AI_INTERACTIVE_TIMEOUT_MS = 60_000;
 const AI_LONG_RUNNING_TIMEOUT_MS = 300_000;
 const FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT = 95;
+const MIN_OUTPUT_RESERVE_TOKENS = 1_024;
+const MIN_CONTEXT_REMAINING_TOKENS = 5_000;
 const analysisTaskTypes = new Set<string>(ANALYSIS_TASK_TYPES);
 const interactiveStreamErrorCodes = new Set([
   "AI_STREAM_IDLE_TIMEOUT",
@@ -811,7 +813,7 @@ export type AiProcessStep = {
 
 const MAX_AGENT_TOOL_CALLS = 12;
 const TOOL_CONTEXT_COMPACT_MAX_TOKENS = 1_024;
-const TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS = 512;
+const TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS = MIN_OUTPUT_RESERVE_TOKENS;
 const IMAGE_TOOL_MAX_BYTES = 30 * 1024 * 1024;
 const IMAGE_TOOL_MAX_OUTPUT_TOKENS = 8_192;
 const agentToolCursor = z.number().int().min(0).max(100_000).default(0);
@@ -4338,7 +4340,7 @@ export class AiManager {
     const contextWindow = numberValue(model, "context_window") || DEFAULT_CONTEXT_WINDOW;
     const preset = safeJsonObject(stringValue(model, "preset_json"));
     const configuredOutputTokens = typeof preset.max_tokens === "number" ? preset.max_tokens : DEFAULT_MAX_TOKENS;
-    const outputReserveTokens = Math.max(512, Math.min(configuredOutputTokens, Math.floor(contextWindow * 0.25), contextWindow - 512));
+    const outputReserveTokens = Math.max(MIN_OUTPUT_RESERVE_TOKENS, Math.min(configuredOutputTokens, Math.floor(contextWindow * 0.25), contextWindow - MIN_OUTPUT_RESERVE_TOKENS));
     const availableInputTokens = Math.max(256, contextWindow - outputReserveTokens - 512);
     const conversation = input.conversationId
       ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
@@ -4391,6 +4393,7 @@ export class AiManager {
     const configuredOutputTokens = Number(budget.configuredOutputTokens) || DEFAULT_MAX_TOKENS;
     const maxOutputUsagePercent = Math.min(100, Math.round(configuredOutputTokens / contextWindow * 100));
     const compactableMessageCount = Math.max(0, (conversation?.messages.length ?? 0) - 2);
+    const contextFallbackReached = remainingTokens <= MIN_CONTEXT_REMAINING_TOKENS;
     return {
       modelId: stringValue(model, "id"),
       contextWindow,
@@ -4401,9 +4404,10 @@ export class AiManager {
       conversationUsagePercent,
       maxOutputTokens: configuredOutputTokens,
       maxOutputUsagePercent,
-      maxOutputThresholdReached: configuredOutputTokens >= contextWindow * FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT / 100,
+      maxOutputThresholdReached: maxOutputUsagePercent >= threshold,
       outputReserveTokens: Number(budget.outputReserveTokens),
       remainingTokens,
+      contextFallbackReached,
       usagePercent: Math.min(100, Math.round(inputTokens / contextWindow * 100)),
       tokenDistribution: {
         systemPromptTokens,
@@ -4414,7 +4418,7 @@ export class AiManager {
       },
       compactThreshold: threshold,
       compactableMessageCount,
-      compactRecommended: compactableMessageCount > 0 && conversationUsagePercent >= threshold,
+      compactRecommended: compactableMessageCount > 0 && (conversationUsagePercent >= threshold || contextFallbackReached),
       contextWarningPending: conversation?.warningPending ?? false,
       compactedMessageCount: conversation?.compactedMessageCount ?? 0,
       includedContextBlocks: contextPlan.includedBlockIds.length,
@@ -4445,6 +4449,7 @@ export class AiManager {
       contextWindow,
       inputTokens,
       remainingTokens,
+      contextFallbackReached: remainingTokens <= MIN_CONTEXT_REMAINING_TOKENS,
       usagePercent: Math.min(100, Math.round(inputTokens / contextWindow * 100)),
       tokenDistribution: {
         systemPromptTokens,
@@ -4463,8 +4468,9 @@ export class AiManager {
     const usage = this.getContextUsage({ ...input, taskType: "chat" });
     const usagePercent = Number(usage.usagePercent) || 0;
     const maxOutputThresholdReached = usage.maxOutputThresholdReached === true;
+    const contextFallbackReached = usage.contextFallbackReached === true;
     const compactableMessageCount = Number(usage.compactableMessageCount) || 0;
-    const outputThresholdNeedsCompaction = maxOutputThresholdReached && compactableMessageCount > 0;
+    const outputThresholdNeedsCompaction = (maxOutputThresholdReached || contextFallbackReached) && compactableMessageCount > 0;
     if (usagePercent >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT || outputThresholdNeedsCompaction) {
       if (compactableMessageCount <= 0) {
         throw new AppError(
@@ -4506,7 +4512,7 @@ export class AiManager {
     const compaction = await this.compactConversation(input);
     if (compaction.changed !== true) {
       const inputBelowForcedThreshold = (Number(inspection.usage.usagePercent) || 0) < FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT;
-      if (inspection.usage.maxOutputThresholdReached === true && inputBelowForcedThreshold) {
+      if ((inspection.usage.maxOutputThresholdReached === true || inspection.usage.contextFallbackReached === true) && inputBelowForcedThreshold) {
         return {
           action: "ready",
           reason: "output_budget_already_fits",
@@ -4520,7 +4526,8 @@ export class AiManager {
       );
     }
     const compactedUsage = this.getContextUsage({ ...input, taskType: "chat" });
-    if ((Number(compactedUsage.usagePercent) || 0) >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT) {
+    if ((Number(compactedUsage.usagePercent) || 0) >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT
+      || compactedUsage.contextFallbackReached === true) {
       throw new AppError(
         413,
         "AI_CONTEXT_STILL_OVER_LIMIT",
@@ -5625,6 +5632,7 @@ export class AiManager {
       ...thinkingParameters(provider, model)
     };
     const configuredOutputTokens = Number(requestedParameters.max_tokens) || DEFAULT_MAX_TOKENS;
+    const contextCompactThreshold = Math.min(90, Math.max(50, Number(this.store.getWorkAiSettings(input.workId).contextCompactThreshold) || 85));
     let effectiveInput = input;
     let context = this.buildContext(effectiveInput, model);
     let messages = this.buildMessages(effectiveInput, context);
@@ -6093,8 +6101,14 @@ export class AiManager {
         const projectedUsagePercent = Math.round(
           (currentTokens + maximumNewToolTokens + TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS) / contextWindow * 100
         );
-        const maxOutputThresholdReached = configuredOutputTokens >= contextWindow * FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT / 100;
-        return projectedUsagePercent >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT || maxOutputThresholdReached;
+        const projectedRemainingTokens = Math.max(
+          0,
+          contextWindow - currentTokens - maximumNewToolTokens - TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS
+        );
+        const maxOutputThresholdReached = configuredOutputTokens >= contextWindow * contextCompactThreshold / 100;
+        return projectedUsagePercent >= contextCompactThreshold
+          || maxOutputThresholdReached
+          || projectedRemainingTokens <= MIN_CONTEXT_REMAINING_TOKENS;
       };
       let payload = await requestCompletion("auto");
       let choice = payload.choices?.[0];

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -6098,17 +6098,14 @@ export class AiManager {
           agentToolCallQuotaNoticeBudgetChars(agentToolCallSoftWarningThreshold(agentToolCallLimit), agentToolCallLimit)
         );
         const maximumNewToolTokens = Math.ceil((AGENT_TOOL_RESULT_MAX_CHARS + noticeBudgetChars) * 1.1) * Math.max(1, toolCallCount);
-        const projectedUsagePercent = Math.round(
-          (currentTokens + maximumNewToolTokens + TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS) / contextWindow * 100
-        );
-        const projectedRemainingTokens = Math.max(
-          0,
-          contextWindow - currentTokens - maximumNewToolTokens - TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS
-        );
+        // 这里只按工具结果写入后的 context 剩余判断；输出 max_tokens 由下方独立判断。
+        const projectedContextTokens = currentTokens + maximumNewToolTokens;
+        const projectedUsagePercent = Math.round(projectedContextTokens / contextWindow * 100);
+        const projectedContextRemainingTokens = Math.max(0, contextWindow - projectedContextTokens);
         const maxOutputThresholdReached = configuredOutputTokens >= contextWindow * contextCompactThreshold / 100;
         return projectedUsagePercent >= contextCompactThreshold
           || maxOutputThresholdReached
-          || projectedRemainingTokens <= MIN_CONTEXT_REMAINING_TOKENS;
+          || projectedContextRemainingTokens <= MIN_CONTEXT_REMAINING_TOKENS;
       };
       let payload = await requestCompletion("auto");
       let choice = payload.choices?.[0];

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -5624,6 +5624,7 @@ export class AiManager {
       ...this.sanitizeParameters({ ...preset, ...(input.parameters ?? {}) }, stringValue(model, "model_id")),
       ...thinkingParameters(provider, model)
     };
+    const configuredOutputTokens = Number(requestedParameters.max_tokens) || DEFAULT_MAX_TOKENS;
     let effectiveInput = input;
     let context = this.buildContext(effectiveInput, model);
     let messages = this.buildMessages(effectiveInput, context);
@@ -6089,7 +6090,11 @@ export class AiManager {
           agentToolCallQuotaNoticeBudgetChars(agentToolCallSoftWarningThreshold(agentToolCallLimit), agentToolCallLimit)
         );
         const maximumNewToolTokens = Math.ceil((AGENT_TOOL_RESULT_MAX_CHARS + noticeBudgetChars) * 1.1) * Math.max(1, toolCallCount);
-        return currentTokens + maximumNewToolTokens + TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS >= contextWindow;
+        const projectedUsagePercent = Math.round(
+          (currentTokens + maximumNewToolTokens + TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS) / contextWindow * 100
+        );
+        const maxOutputThresholdReached = configuredOutputTokens >= contextWindow * FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT / 100;
+        return projectedUsagePercent >= FORCE_CONVERSATION_COMPACTION_USAGE_PERCENT || maxOutputThresholdReached;
       };
       let payload = await requestCompletion("auto");
       let choice = payload.choices?.[0];

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1266,7 +1266,7 @@ describe("AI 供应商、模型与建议 API", () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
     setLegacyModelContextWindow(modelId, 128_000);
-    runtime.database.run("UPDATE models SET preset_json = ? WHERE id = ?", JSON.stringify({ max_tokens: 128_000 }), modelId);
+    runtime.database.run("UPDATE models SET preset_json = ? WHERE id = ?", JSON.stringify({ max_tokens: 110_000 }), modelId);
     runtime.store.saveChapter(chapterId, { content: "工具分页证据。".repeat(2_500) });
     let completionCount = 0;
     let compactRequestCount = 0;

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1138,6 +1138,7 @@ describe("AI 供应商、模型与建议 API", () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
     setLegacyModelContextWindow(modelId, 16_000);
+    runtime.database.run("UPDATE models SET preset_json = ? WHERE id = ?", JSON.stringify({ max_tokens: 1_024 }), modelId);
     runtime.store.saveChapter(chapterId, { content: "分页上下文证据。".repeat(2_500) });
     let completionCount = 0;
     let firstPageContent = "";

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1262,6 +1262,55 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(returnedPages[0]?.pagination.nextCursor).toEqual(expect.any(Number));
   });
 
+  it("模型最大输出达到上下文 95% 时工具上下文也会先压缩", async () => {
+    const { providerId, modelId } = await configureAi();
+    await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
+    setLegacyModelContextWindow(modelId, 128_000);
+    runtime.database.run("UPDATE models SET preset_json = ? WHERE id = ?", JSON.stringify({ max_tokens: 128_000 }), modelId);
+    runtime.store.saveChapter(chapterId, { content: "工具分页证据。".repeat(2_500) });
+    let completionCount = 0;
+    let compactRequestCount = 0;
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      completionCount += 1;
+      const body = JSON.parse(String(init?.body)) as { messages: Array<{ role: string; content?: string }>; tools?: unknown[] };
+      if (body.messages[0]?.content?.includes("压缩已完成的 AI 工具调用上下文")) {
+        compactRequestCount += 1;
+        expect(body.tools).toBeUndefined();
+        return new Response(JSON.stringify({ choices: [{ message: { content: "已压缩旧工具结果，继续读取剩余分页。" } }] }), { status: 200 });
+      }
+      const toolMessages = body.messages.filter((message) => message.role === "tool");
+      if (toolMessages.length === 0) {
+        return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [{
+          id: "output-threshold-page-1",
+          type: "function",
+          function: { name: "read_chapters", arguments: { chapterIds: [chapterId], include: "content" } }
+        }] } }] }), { status: 200 });
+      }
+      if (!body.messages.some((message) => message.content?.includes("已压缩的工具调用上下文"))) {
+        const firstPage = JSON.parse(toolMessages.at(-1)?.content ?? "{}") as { pagination: { nextCursor: number | null } };
+        expect(firstPage.pagination.nextCursor).not.toBeNull();
+        return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [{
+          id: "output-threshold-page-2",
+          type: "function",
+          function: { name: "read_chapters", arguments: { chapterIds: [chapterId], include: "content", cursor: firstPage.pagination.nextCursor } }
+        }] } }] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ choices: [{ message: { content: "已完成工具上下文回答。" } }] }), { status: 200 });
+    });
+
+    const response = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+      instruction: "读取章节后回答。",
+      scope: { type: "none" },
+      modelId
+    }).expect(200).expect("Content-Type", /text\/event-stream/u);
+
+    expect(response.text).toContain('event: delta\ndata: {"delta":"已完成工具上下文回答。"}');
+    expect(response.text).toContain("event: context_compacted");
+    expect(compactRequestCount).toBe(1);
+    expect(completionCount).toBe(4);
+  });
+
   it("把无效工具参数和未知工具作为英文错误结果反馈给模型", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);

--- a/tests/integration/ai-context-compact.test.ts
+++ b/tests/integration/ai-context-compact.test.ts
@@ -50,7 +50,7 @@ describe("AI 对话上下文压缩", () => {
       contextWindow: 32_768
     }).expect(201);
     modelId = model.body.data.id;
-    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 4_096, modelId);
+    runtime.database.run("UPDATE models SET context_window = ?, preset_json = ? WHERE id = ?", 4_096, JSON.stringify({ max_tokens: 1_024 }), modelId);
     fetchMock.mockClear();
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ contextCompactThreshold: 50 }).expect(200);
   });
@@ -145,6 +145,36 @@ describe("AI 对话上下文压缩", () => {
     const firstRetry = await request(runtime.app).post(`/api/ai-conversations/${retryConversation.body.data.id}/messages`).send(retryPayload).expect(201);
     const secondRetry = await request(runtime.app).post(`/api/ai-conversations/${retryConversation.body.data.id}/messages`).send(retryPayload).expect(201);
     expect(secondRetry.body.data.id).toBe(firstRetry.body.data.id);
+  });
+
+  it("模型最大输出达到上下文 95% 时也会触发压缩", async () => {
+    runtime.database.run("UPDATE models SET context_window = ?, preset_json = ? WHERE id = ?", 32_768, JSON.stringify({ max_tokens: 32_000 }), modelId);
+    const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
+    const conversationId = conversation.body.data.id;
+    for (const [role, content] of [
+      ["user", `较早问题：${"飞船现在在哪里？".repeat(1_000)}`],
+      ["assistant", `较早回答：${"飞船在北港。".repeat(1_000)}`],
+      ["user", "最近问题：燃料还剩多少？"]
+    ] as const) {
+      await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({ role, content }).expect(201);
+    }
+
+    const prepared = await request(runtime.app).post(`/api/ai-conversations/${conversationId}/context/prepare`).send({
+      modelId,
+      scope: { type: "chapter", chapterId },
+      instruction: "继续回答燃料问题。"
+    }).expect(200);
+
+    expect(prepared.body.data).toMatchObject({
+      action: "compacted",
+      reason: "forced_usage_threshold",
+      usage: {
+        maxOutputTokens: 32_000,
+        maxOutputUsagePercent: 98,
+        maxOutputThresholdReached: true
+      }
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("流式提醒以 warningOnly 正常结束，忽略后只持久化一次并继续生成", async () => {

--- a/tests/integration/ai-context-compact.test.ts
+++ b/tests/integration/ai-context-compact.test.ts
@@ -58,10 +58,11 @@ describe("AI 对话上下文压缩", () => {
   afterEach(() => runtime.close());
 
   it("达到可配置阈值时可忽略本次提醒且下次仍会提醒", async () => {
+    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 16_384, modelId);
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = conversation.body.data.id;
-    const oldUser = `旧作者要求：${"必须遵守跃迁冷却规则。".repeat(30)}`;
-    const oldAssistant = `旧助手回答：${"飞船仍在北港附近。".repeat(30)}`;
+    const oldUser = `旧作者要求：${"必须遵守跃迁冷却规则。".repeat(180)}`;
+    const oldAssistant = `旧助手回答：${"飞船仍在北港附近。".repeat(180)}`;
     const recentUser = "最近问题：当前燃料还剩多少？";
     const recentAssistant = "最近回答：燃料数据尚未在正文中明确。";
     for (const [role, content] of [["user", oldUser], ["assistant", oldAssistant], ["user", recentUser], ["assistant", recentAssistant]] as const) {
@@ -147,8 +148,8 @@ describe("AI 对话上下文压缩", () => {
     expect(secondRetry.body.data.id).toBe(firstRetry.body.data.id);
   });
 
-  it("模型最大输出达到上下文 95% 时也会触发压缩", async () => {
-    runtime.database.run("UPDATE models SET context_window = ?, preset_json = ? WHERE id = ?", 32_768, JSON.stringify({ max_tokens: 32_000 }), modelId);
+  it("模型最大输出达到 Compact 阈值时也会触发压缩", async () => {
+    runtime.database.run("UPDATE models SET context_window = ?, preset_json = ? WHERE id = ?", 32_768, JSON.stringify({ max_tokens: 20_000 }), modelId);
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = conversation.body.data.id;
     for (const [role, content] of [
@@ -169,8 +170,8 @@ describe("AI 对话上下文压缩", () => {
       action: "compacted",
       reason: "forced_usage_threshold",
       usage: {
-        maxOutputTokens: 32_000,
-        maxOutputUsagePercent: 98,
+        maxOutputTokens: 20_000,
+        maxOutputUsagePercent: 61,
         maxOutputThresholdReached: true
       }
     });
@@ -178,11 +179,12 @@ describe("AI 对话上下文压缩", () => {
   });
 
   it("流式提醒以 warningOnly 正常结束，忽略后只持久化一次并继续生成", async () => {
+    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 16_384, modelId);
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = conversation.body.data.id;
     for (const [role, content] of [
-      ["user", `旧作者要求：${"必须遵守跃迁冷却规则。".repeat(30)}`],
-      ["assistant", `旧助手回答：${"飞船仍在北港附近。".repeat(30)}`],
+      ["user", `旧作者要求：${"必须遵守跃迁冷却规则。".repeat(120)}`],
+      ["assistant", `旧助手回答：${"飞船仍在北港附近。".repeat(120)}`],
       ["user", "最近问题：当前燃料还剩多少？"],
       ["assistant", "最近回答：燃料数据尚未在正文中明确。"]
     ] as const) {
@@ -231,11 +233,12 @@ describe("AI 对话上下文压缩", () => {
   });
 
   it("整次请求达到 95% 时先自动压缩再保存用户消息并调用 Agent", async () => {
+    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 16_384, modelId);
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = conversation.body.data.id;
     for (const [role, content] of [
-      ["user", `旧作者要求：${"必须遵守跃迁冷却规则。".repeat(90)}`],
-      ["assistant", `旧助手回答：${"飞船仍在北港附近。".repeat(90)}`],
+      ["user", `旧作者要求：${"必须遵守跃迁冷却规则。".repeat(600)}`],
+      ["assistant", `旧助手回答：${"飞船仍在北港附近。".repeat(600)}`],
       ["user", "最近问题：当前燃料还剩多少？"],
       ["assistant", "最近回答：燃料数据尚未在正文中明确。"]
     ] as const) {
@@ -341,7 +344,8 @@ describe("AI 对话上下文压缩", () => {
     expect(compacted.body.data.memoryItemCount).toBeGreaterThan(0);
   });
 
-  it("正文区块过长时降级正文而不误触发对话压缩", async () => {
+  it("正文区块过长时降级正文并标记上下文兜底", async () => {
+    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 16_384, modelId);
     runtime.store.saveChapter(chapterId, { content: `当前章节开头。${"非常长的章节正文。".repeat(2_000)}当前章节结尾。` });
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = conversation.body.data.id;
@@ -356,10 +360,50 @@ describe("AI 对话上下文压缩", () => {
     }).expect(200);
     const usage = prepared.body.data.usage;
 
-    expect(usage.compactRecommended).toBe(false);
+    expect(prepared.body.data.action).toBe("ready");
+    expect(usage.compactRecommended).toBe(true);
+    expect(usage.contextFallbackReached).toBe(true);
     expect(usage.degradedContextBlocks).toBeGreaterThan(0);
     expect(usage.inputTokens).toBeLessThan(usage.contextWindow);
     expect(usage).toMatchObject({ conversationTokens: expect.any(Number), conversationBudgetTokens: expect.any(Number) });
+  });
+
+  it("上下文剩余不足 5k 时即使低于 95% 也会自动压缩", async () => {
+    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 20_000, modelId);
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ contextCompactThreshold: 90, agentTools: [] }).expect(200);
+    const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
+    const conversationId = conversation.body.data.id;
+    for (const [role, content] of [
+      ["user", `较早要求：${"必须遵守跃迁冷却规则。".repeat(400)}`],
+      ["assistant", "最近回答：飞船仍在北港附近。"],
+      ["user", "最近问题：燃料还剩多少？"]
+    ] as const) {
+      await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({ role, content }).expect(201);
+    }
+    const instruction = "请检查当前章节。".repeat(1_080);
+    const usageBefore = runtime.ai.getContextUsage({
+      workId,
+      taskType: "chat",
+      modelId,
+      scope: { type: "chapter", chapterId },
+      instruction,
+      conversationId
+    });
+    expect(usageBefore.outputReserveTokens).toBe(1_024);
+    expect(usageBefore.remainingTokens).toBeLessThanOrEqual(5_000);
+    expect(usageBefore).toMatchObject({ contextFallbackReached: true });
+    expect(Number(usageBefore.usagePercent)).toBeLessThan(95);
+    expect(Number(usageBefore.conversationUsagePercent)).toBeLessThan(90);
+
+    const prepared = await request(runtime.app).post(`/api/ai-conversations/${conversationId}/context/prepare`).send({
+      modelId,
+      scope: { type: "chapter", chapterId },
+      instruction
+    }).expect(200);
+
+    expect(prepared.body.data).toMatchObject({ action: "compacted", reason: "forced_usage_threshold" });
+    expect(prepared.body.data.usage.contextFallbackReached).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("拒绝把其他作品的章节混入当前对话上下文", async () => {


### PR DESCRIPTION
## 变更

- 按作品配置的 Compact 百分比判断对话和工具上下文。
- 单独判断模型 max output token 是否达到 Compact 阈值。
- 输出预算最低预留 1,024 token。
- 上下文整体剩余不足 5,000 token 时触发 compact。
- 工具上下文的 5,000 兜底只按 context 剩余判断，不扣除 max output 预留。

## 根因

此前输出预算、工具上下文预留和 context 剩余共用了同一套判断，导致不同模型输出配置下 compact 时机不一致。

## 验证

- `npm run typecheck`
- `npx vitest run tests/integration/ai-api.test.ts tests/integration/ai-context-compact.test.ts tests/integration/ai-prompt-cache-stability.test.ts`
- 3 个测试文件，73/73 通过。