### PR TITLE
MUXUE-68: limit GIF attachment animation frames

### DIFF
--- a/src/attachment-storage.ts
+++ b/src/attachment-storage.ts
@@ -9,6 +9,7 @@ import { DEFAULT_ATTACHMENT_IMAGE_MAX_BYTES, formatUploadLimit } from "./upload-
 const maximumPixels = 25_000_000;
 const maximumAnimationFrames = 100;
 const maximumAnimationPixels = 50_000_000;
+const maximumGifFrames = 10_000;
 const allowedFormats = new Set(["png", "jpeg", "webp", "gif"]);
 
 type StoredImageMimeType = "image/png" | "image/jpeg" | "image/webp" | "image/gif";
@@ -135,6 +136,9 @@ export class AttachmentStorage {
     const pageCount = Math.max(1, Number(metadata.pages ?? 1));
     if (!Number.isInteger(width) || width <= 0 || !Number.isInteger(pageHeight) || pageHeight <= 0) {
       throw new AppError(415, "INVALID_ATTACHMENT_IMAGE", "无法读取附件图片尺寸");
+    }
+    if (isGif && pageCount > maximumGifFrames) {
+      throw new AppError(413, "ATTACHMENT_GIF_TOO_MANY_FRAMES", "GIF 动画不能超过 10,000 帧");
     }
     if (!isGif && width * pageHeight > maximumPixels) throw new AppError(413, "ATTACHMENT_IMAGE_TOO_LARGE", "附件图片像素尺寸过大");
     if (!isGif && (!Number.isInteger(pageCount) || pageCount > maximumAnimationFrames)) {

--- a/tests/integration/character-markdown-attachments.test.ts
+++ b/tests/integration/character-markdown-attachments.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import request from "supertest";
 import sharp from "sharp";
@@ -94,17 +95,30 @@ describe("人物 Markdown 章节与附件", () => {
     }
   });
 
-  it("GIF 附件只按文件大小限制，不因动画帧数拦截", async () => {
+  it("允许 10,000 帧 GIF 附件并在持久化前拒绝 10,001 帧", async () => {
     const work = await createWork(runtime);
-    const upload = await request(runtime.app)
+    const boundaryUpload = await request(runtime.app)
       .post("/api/works/" + String(work.id) + "/attachments")
-      .attach("file", animatedGif(154), { filename: "多帧动画.gif", contentType: "image/gif" })
+      .attach("file", animatedGif(10_000), { filename: "一万帧动画.gif", contentType: "image/gif" })
       .expect(201);
-    expect(upload.body.data).toMatchObject({
+    expect(boundaryUpload.body.data).toMatchObject({
       originalMimeType: "image/gif",
-      pageCount: 154,
+      pageCount: 10_000,
       animated: true
     });
+
+    const excessiveGif = animatedGif(10_001);
+    const rejected = await request(runtime.app)
+      .post("/api/works/" + String(work.id) + "/attachments")
+      .attach("file", excessiveGif, { filename: "超限动画.gif", contentType: "image/gif" })
+      .expect(413);
+    expect(rejected.body.error).toEqual({
+      code: "ATTACHMENT_GIF_TOO_MANY_FRAMES",
+      message: "GIF 动画不能超过 10,000 帧"
+    });
+    expect(runtime.store.listAttachments(String(work.id))).toHaveLength(1);
+    const rejectedSha256 = createHash("sha256").update(excessiveGif).digest("hex");
+    expect(existsSync(runtime.attachmentStorage.path(`${rejectedSha256.slice(0, 2)}/${rejectedSha256}.gif`))).toBe(false);
   });
 
   it("作品在回收站时保留附件，彻底删除后清理不再使用的附件文件", async () => {

--- a/tests/system/attachment-upload-error-ui.test.ts
+++ b/tests/system/attachment-upload-error-ui.test.ts
@@ -1,0 +1,53 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
+
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+describe("图片附件上传错误提示", () => {
+  it("将服务端 GIF 帧数错误通过统一错误链路显示为 toast", async () => {
+    const application = await readFile(join(process.cwd(), "src/public/app.js"), "utf8");
+    const clientErrorSource = sourceBetween(application, "function createClientError(", "\nfunction aiStreamInterruptionLabel");
+    const uploadHandlerSource = sourceBetween(application, "function createVditorUploadHandler(", "\nfunction createVditorEditor");
+    const shownToasts: Array<{ message: string; type: string }> = [];
+    let placeholderFailed = false;
+    const context = {
+      createVditorUploadPlaceholder: () => ({
+        update: () => undefined,
+        complete: () => undefined,
+        fail: () => { placeholderFailed = true; }
+      }),
+      normalizeVditorAttachmentImages: () => undefined,
+      toast: (message: string, type: string) => shownToasts.push({ message, type }),
+      window: { getSelection: () => null }
+    };
+    const functions = vm.runInNewContext(
+      `(() => { ${clientErrorSource}\n${uploadHandlerSource}\nreturn { createClientError, createVditorUploadHandler }; })()`,
+      context
+    ) as {
+      createClientError: (payload: unknown, fallbackMessage: string, status: number) => Error & { code?: string; status?: number };
+      createVditorUploadHandler: (
+        uploadAttachment: () => Promise<never>,
+        getEditor: () => null
+      ) => (files: Array<{ name: string }>) => Promise<null>;
+    };
+    const serverError = functions.createClientError({
+      code: "ATTACHMENT_GIF_TOO_MANY_FRAMES",
+      message: "GIF 动画不能超过 10,000 帧"
+    }, "请求失败：413", 413);
+
+    const handler = functions.createVditorUploadHandler(async () => { throw serverError; }, () => null);
+    await handler([{ name: "超限动画.gif" }]);
+
+    expect(serverError).toMatchObject({ code: "ATTACHMENT_GIF_TOO_MANY_FRAMES", status: 413 });
+    expect(placeholderFailed).toBe(true);
+    expect(shownToasts).toEqual([{ message: "GIF 动画不能超过 10,000 帧", type: "error" }]);
+  });
+});


### PR DESCRIPTION
## Summary

- cap GIF image attachments at 10,000 frames before file or database persistence
- keep GIF attachments exempt from the existing 100-frame, per-frame pixel, and total animation pixel limits
- cover the 10,000/10,001 boundary and the unified frontend error-toast path

## Validation

- `npx vitest run tests/integration/character-markdown-attachments.test.ts tests/system/attachment-upload-error-ui.test.ts --maxWorkers=1` (12 passed)
- `npm run typecheck`
- `npm test` (187 files, 942 tests passed)
- `npm run build`
- browser validation at 1280×720 and 390×844: error toast visible, no horizontal overflow, keyboard focus remains in the dialog, no application console errors
- isolated SQLite `PRAGMA integrity_check` and `PRAGMA foreign_key_check`

Closes MUXUE-68
