### PR TITLE
build(release): bump version to 0.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.6";
+export const APP_VERSION = "0.7.7";


### PR DESCRIPTION
## 背景

将已合入 `develop` 的功能和修复发布为 `0.7.7`，统一包元数据与运行时版本。

## 变更

- 更新 `package.json` 版本。
- 更新 `package-lock.json` 顶层版本和根包版本。
- 更新 `src/version.ts` 的 `APP_VERSION`。

## 验证

- `tests/unit`：95 个文件、495 项通过。
- `npm run typecheck`：通过。
- `npm test`：187 个文件、942 项通过。
- `npm run build`：通过。
- `git diff --check`：通过。

无数据库迁移、CLI 契约或发布物内容变化。
