### PR TITLE
MUXUE-71: avoid per-section character search lookups

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -5874,7 +5874,7 @@ export class Store {
   searchCharacterProfileSections(workId: string, query: string, limit = 20): Record<string, unknown>[] {
     this.getWork(workId);
     const normalized = normalizeDocumentSearchText(query);
-    const columns = `SELECT section.*, character.name AS character_name
+    const columns = `SELECT section.*, character.name AS character_name, character.is_dead AS character_is_dead
       FROM character_profile_section_search search
       JOIN character_profile_sections section ON section.id = search.section_id
       JOIN characters character ON character.id = search.character_id`;
@@ -5896,7 +5896,11 @@ export class Store {
         `"${normalized.replaceAll('"', '""')}"`,
         limit
       );
-    return rows.map((row) => ({ ...this.mapCharacterProfileSection(row), characterName: requiredString(row, "character_name") }));
+    return rows.map((row) => ({
+      ...this.mapCharacterProfileSection(row),
+      characterName: requiredString(row, "character_name"),
+      isDead: booleanValue(row, "character_is_dead")
+    }));
   }
 
   private mapAttachment(row: Row): Record<string, unknown> {
@@ -9887,7 +9891,7 @@ export class Store {
         title: `${String(section.characterName)} / ${String(section.title)}`,
         snippet: snippet(String(section.contentMarkdown)),
         sectionType: String(section.sectionType),
-        isDead: Boolean(this.getCharacter(String(section.characterId)).isDead)
+        isDead: Boolean(section.isDead)
       })),
       ...settings.map((row) => ({ type: "setting", id: requiredString(row, "id"), title: requiredString(row, "title"), snippet: snippet(requiredString(row, "content")), category: requiredString(row, "category") })),
       ...races.map((race) => {

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Runtime } from "../../src/app.js";
 import { createTestRuntime, seedChapter } from "../helpers.js";
@@ -199,7 +199,7 @@ describe("作品混合检索", () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime, "马克博士曾经守护北港。马克·罗素接替了他。 ");
     const workId = String(seeded.work.id);
-    const source = runtime.store.createCharacter(workId, { name: "马克博士" });
+    const source = runtime.store.createCharacter(workId, { name: "马克博士", isDead: true });
     const target = runtime.store.createCharacter(workId, { name: "马克·罗素" });
     runtime.store.createCharacterProfileSection(String(source.id), {
       sectionType: "background",
@@ -219,11 +219,11 @@ describe("作品混合检索", () => {
       expect.objectContaining({ type: "character", id: source.id })
     ]));
     expect(metadataResults).toEqual(expect.arrayContaining([
-      expect.objectContaining({ type: "character", id: target.id, title: "马克·罗素" })
+      expect.objectContaining({ type: "character", id: target.id, title: "马克·罗素", isDead: false })
     ]));
     const sectionResults = runtime.store.searchCharacterProfileSections(workId, "旧身份");
     expect(sectionResults).toEqual(expect.arrayContaining([
-      expect.objectContaining({ characterId: target.id, characterName: "马克·罗素" })
+      expect.objectContaining({ characterId: target.id, characterName: "马克·罗素", isDead: false })
     ]));
     expect(sectionResults).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ characterId: source.id })
@@ -280,6 +280,61 @@ describe("作品混合检索", () => {
     const relationshipData = relationshipResult.data as Record<string, unknown>;
     expect(relationshipExecution.status).toBe("completed");
     expect(relationshipData.unresolvedCharacters).toEqual([source.id]);
+  });
+
+  it("资料段落搜索复用角色联表状态且不逐段查询角色详情", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime);
+    const workId = String(seeded.work.id);
+    const deadCharacter = runtime.store.createCharacter(workId, { name: "岑夜", isDead: true });
+    const livingCharacter = runtime.store.createCharacter(workId, { name: "林昼" });
+    const firstDeadSection = runtime.store.createCharacterProfileSection(String(deadCharacter.id), {
+      sectionType: "background",
+      title: "星轨密令上篇",
+      contentMarkdown: "星轨密令刻在北港旧碑上。"
+    });
+    const secondDeadSection = runtime.store.createCharacterProfileSection(String(deadCharacter.id), {
+      sectionType: "experience",
+      title: "星轨密令下篇",
+      contentMarkdown: "岑夜曾经守护星轨密令。"
+    });
+    const livingSection = runtime.store.createCharacterProfileSection(String(livingCharacter.id), {
+      sectionType: "ability",
+      title: "星轨密令解读",
+      contentMarkdown: "林昼能够解读星轨密令。"
+    });
+    const databaseGet = vi.spyOn(runtime.store.db, "get");
+
+    const fullTextSections = runtime.store.searchCharacterProfileSections(workId, "星轨密令");
+    expect(fullTextSections).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: firstDeadSection.id,
+        characterId: deadCharacter.id,
+        characterName: "岑夜",
+        title: "星轨密令上篇",
+        isDead: true
+      }),
+      expect.objectContaining({ id: secondDeadSection.id, characterId: deadCharacter.id, isDead: true }),
+      expect.objectContaining({ id: livingSection.id, characterId: livingCharacter.id, isDead: false })
+    ]));
+
+    const fullTextResults = runtime.store.search(workId, "星轨密令")
+      .filter((item) => typeof item.sectionId === "string");
+    expect(fullTextResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sectionId: firstDeadSection.id,
+        title: "岑夜 / 星轨密令上篇",
+        snippet: expect.stringContaining("星轨密令"),
+        isDead: true
+      }),
+      expect.objectContaining({ sectionId: secondDeadSection.id, isDead: true }),
+      expect.objectContaining({ sectionId: livingSection.id, isDead: false })
+    ]));
+
+    const shortTermResults = runtime.store.search(workId, "星轨")
+      .filter((item) => typeof item.sectionId === "string");
+    expect(shortTermResults).toHaveLength(3);
+    expect(databaseGet.mock.calls.filter(([sql]) => sql === "SELECT * FROM characters WHERE id = ?")).toHaveLength(0);
   });
 
   it("限制查询长度并按字面量搜索 LIKE 特殊字符", async () => {


### PR DESCRIPTION
## Summary
- return character death state from the existing profile-section JOIN
- remove per-hit character detail lookups from metadata search mapping
- cover FTS, short terms, merged characters, result fields, and query counts

## Verification
- npm run typecheck
- npx vitest run tests/integration/hybrid-search.test.ts --maxWorkers=1
- npx vitest run tests/integration/user-auth-api.test.ts --maxWorkers=1 -t '模块权限默认拒绝未知路由，并裁剪跨模块数据与关联写入'
- npm test
- npm run build