### PR TITLE
MUXUE-69: scope search results to readable modules

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2129,13 +2129,16 @@ export class AiManager {
   async searchWork(
     workId: string,
     query: string,
-    options: { type?: HybridSearchType; limit?: number; includeAgentHistory?: boolean } = {}
+    options: { type?: HybridSearchType; limit?: number; allowedTypes?: readonly HybridSearchType[] } = {}
   ): Promise<Record<string, unknown>[]> {
     this.store.getWork(workId);
     const normalizedQuery = normalizeWorkSearchQuery(query);
     if (!normalizedQuery) return [];
     const requestedTypes = options.type ? new Set<HybridSearchType>([options.type]) : new Set(HYBRID_SEARCH_TYPES);
-    if (options.includeAgentHistory === false) requestedTypes.delete("agent-history");
+    if (options.allowedTypes) {
+      const allowedTypes = new Set(options.allowedTypes);
+      for (const type of requestedTypes) if (!allowedTypes.has(type)) requestedTypes.delete(type);
+    }
     if (requestedTypes.size === 0) return [];
     const hasIndexedSourceTypes = [...requestedTypes].some((type) => type !== "chapter" && type !== "agent-history");
     if (requestedTypes.has("chapter") || hasIndexedSourceTypes) await this.ensureRelationshipSearchIndex(workId);
@@ -2145,7 +2148,7 @@ export class AiManager {
     const metadataDetails = new Map<string, Record<string, unknown>>();
 
     const metadataCandidates = [...requestedTypes].some((type) => type !== "agent-history")
-      ? this.store.search(workId, normalizedQuery).flatMap((item): HybridSearchCandidate[] => {
+      ? this.store.search(workId, normalizedQuery, requestedTypes).flatMap((item): HybridSearchCandidate[] => {
         const type = String(item.type);
         const itemId = String(item.id ?? "");
         if (!itemId || !accepts(type)) return [];
@@ -2320,13 +2323,17 @@ export class AiManager {
     const tokens = matchKind === "exact" ? relationshipCharacterTokens(query) : relationshipPinyinSearchTokens(query);
     if (tokens.length === 0) return [];
     const table = matchKind === "exact" ? "relationship_source_exact_fts" : "relationship_source_pinyin_fts";
+    const sourceTypes = [...requestedTypes].filter((type) => type !== "chapter" && type !== "agent-history");
+    if (sourceTypes.length === 0) return [];
+    const sourceTypePlaceholders = sourceTypes.map(() => "?").join(", ");
     const rows = this.store.db.all(
       `SELECT source.source_type, source.source_id FROM ${table} search_index
        JOIN relationship_source_search source ON source.id = search_index.rowid
-       WHERE source.work_id = ? AND ${table} MATCH ?
+       WHERE source.work_id = ? AND source.source_type IN (${sourceTypePlaceholders}) AND ${table} MATCH ?
        ORDER BY bm25(${table}), source.source_type, source.source_id
        LIMIT ?`,
       workId,
+      ...sourceTypes,
       ftsPhrase(tokens),
       limit
     );

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,7 +30,7 @@ import { EPUB_MIME_TYPE, epubContentDisposition } from "./epub-export.js";
 import { CREATABLE_ANALYSIS_TASK_TYPES, DRAFT_SETTING_MODULES, TASK_TYPES, type ContextScope, type TaskType } from "./domain.js";
 import { AppError } from "./errors.js";
 import { isOfficialGoogleVertexBaseUrl, parseGoogleServiceAccount } from "./google-vertex-auth.js";
-import { HYBRID_SEARCH_TYPES, MAXIMUM_WORK_SEARCH_QUERY_LENGTH } from "./hybrid-search.js";
+import { HYBRID_SEARCH_TYPES, MAXIMUM_WORK_SEARCH_QUERY_LENGTH, readableHybridSearchTypes } from "./hybrid-search.js";
 import { applyImportFileHints, parseNovelText } from "./parser.js";
 import { aiConversationTaskTypes, attachmentPermissionModules, RECYCLE_BIN_RETENTION_DAYS, Store, versionedEntityTypes } from "./store.js";
 import { paginated, parsePagination } from "./pagination.js";
@@ -2995,7 +2995,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     data(response, await ai.searchWork(request.params.workId, query.q, {
       type: query.type,
       limit: query.limit,
-      includeAgentHistory: permissions["ai-chat"] !== "none"
+      allowedTypes: readableHybridSearchTypes(permissions)
     }));
   });
   app.head("/api/works/:workId/export", (request, response) => {

--- a/src/hybrid-search.ts
+++ b/src/hybrid-search.ts
@@ -1,3 +1,5 @@
+import { canReadWorkModule, type WorkModulePermissions, type WorkPermissionModule } from "./work-permissions.js";
+
 export const HYBRID_SEARCH_TYPES = [
   "chapter",
   "setting",
@@ -25,6 +27,35 @@ export function normalizeWorkSearchQuery(value: string): string {
 
 export type HybridSearchType = typeof HYBRID_SEARCH_TYPES[number];
 export type HybridSearchMatchKind = "metadata" | "exact" | "phonetic";
+
+export const HYBRID_SEARCH_PERMISSION_MODULE_BY_TYPE = {
+  chapter: "prose",
+  setting: "settings",
+  character: "characters",
+  race: "races",
+  organization: "organizations",
+  "timeline-track": "timeline",
+  "timeline-event": "timeline",
+  relationship: "relationships",
+  "chapter-outline": "outlines",
+  foreshadow: "outlines",
+  review: "reviews",
+  "agent-history": "ai-chat"
+} as const satisfies Record<HybridSearchType, WorkPermissionModule>;
+
+export const HYBRID_SEARCH_PERMISSION_MODULES = [
+  ...new Set(HYBRID_SEARCH_TYPES.map((type) => HYBRID_SEARCH_PERMISSION_MODULE_BY_TYPE[type]))
+] satisfies WorkPermissionModule[];
+
+export function hybridSearchPermissionModule(type: unknown): WorkPermissionModule | null {
+  return typeof type === "string" && HYBRID_SEARCH_TYPES.includes(type as HybridSearchType)
+    ? HYBRID_SEARCH_PERMISSION_MODULE_BY_TYPE[type as HybridSearchType]
+    : null;
+}
+
+export function readableHybridSearchTypes(permissions: WorkModulePermissions): HybridSearchType[] {
+  return HYBRID_SEARCH_TYPES.filter((type) => canReadWorkModule(permissions, HYBRID_SEARCH_PERMISSION_MODULE_BY_TYPE[type]));
+}
 
 export type HybridSearchCandidate = {
   key: string;

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,7 @@ import {
 import { exportWorkDocx } from "./docx-export.js";
 import { createEpubArchive } from "./epub-export.js";
 import { AppError, notFound } from "./errors.js";
-import { normalizeWorkSearchQuery } from "./hybrid-search.js";
+import { normalizeWorkSearchQuery, type HybridSearchType } from "./hybrid-search.js";
 import { accountReference, logger } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
 import { currentRequestActor } from "./request-context.js";
@@ -9805,35 +9805,42 @@ export class Store {
     return [{ type: "unknown", scope }];
   }
 
-  search(workId: string, query: string): Record<string, unknown>[] {
+  search(workId: string, query: string, requestedTypes?: ReadonlySet<HybridSearchType>): Record<string, unknown>[] {
     this.getWork(workId);
     const normalizedQuery = normalizeWorkSearchQuery(query);
     if (!normalizedQuery) return [];
     const pattern = `%${escapeSqlLikePattern(normalizedQuery)}%`;
-    const chapters = this.db.all(
-      "SELECT id, title, content, volume_id FROM chapters WHERE work_id = ? AND deleted_at IS NULL AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\') LIMIT 50",
-      workId,
-      pattern,
-      pattern
-    );
-    const races = this.listRaces(workId).filter((race) => {
-      const lineage = race.lineage as Array<{ name: string }>;
-      const effectiveSettings = race.effectiveSettings as Array<{ value: string; sourceRaceName: string }>;
-      return [
-        race.name,
-        race.description,
-        ...(race.settings as string[]),
-        ...lineage.map((item) => item.name),
-        ...effectiveSettings.flatMap((item) => [item.value, item.sourceRaceName])
-      ].join("\n").toLocaleLowerCase("zh-CN").includes(normalizedQuery);
-    }).slice(0, 50);
-    const settings = this.db.all(
-      "SELECT id, title, content, category FROM settings WHERE work_id = ? AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\') LIMIT 50",
-      workId,
-      pattern,
-      pattern
-    );
-    const characters = this.db.all(
+    const accepts = (type: HybridSearchType): boolean => !requestedTypes || requestedTypes.has(type);
+    const chapters = accepts("chapter")
+      ? this.db.all(
+        "SELECT id, title, content, volume_id FROM chapters WHERE work_id = ? AND deleted_at IS NULL AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\') LIMIT 50",
+        workId,
+        pattern,
+        pattern
+      )
+      : [];
+    const races = accepts("race")
+      ? this.listRaces(workId).filter((race) => {
+        const lineage = race.lineage as Array<{ name: string }>;
+        const effectiveSettings = race.effectiveSettings as Array<{ value: string; sourceRaceName: string }>;
+        return [
+          race.name,
+          race.description,
+          ...(race.settings as string[]),
+          ...lineage.map((item) => item.name),
+          ...effectiveSettings.flatMap((item) => [item.value, item.sourceRaceName])
+        ].join("\n").toLocaleLowerCase("zh-CN").includes(normalizedQuery);
+      }).slice(0, 50)
+      : [];
+    const settings = accepts("setting")
+      ? this.db.all(
+        "SELECT id, title, content, category FROM settings WHERE work_id = ? AND (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\') LIMIT 50",
+        workId,
+        pattern,
+        pattern
+      )
+      : [];
+    const characters = accepts("character") ? this.db.all(
       `WITH RECURSIVE character_race_lineage(character_id, race_id, parent_race_id, name, path) AS (
          SELECT character.id, race.id, race.parent_race_id, race.name, race.name
          FROM characters character JOIN races race ON race.id = character.race_id
@@ -9857,15 +9864,17 @@ export class Store {
       pattern,
       pattern,
       pattern
-    );
-    const organizations = this.db.all(
-      "SELECT id, name, description, is_dissolved, settings_json FROM organizations WHERE work_id = ? AND (name LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR settings_json LIKE ? ESCAPE '\\') LIMIT 50",
-      workId,
-      pattern,
-      pattern,
-      pattern
-    );
-    const characterSections = this.searchCharacterProfileSections(workId, normalizedQuery, 30);
+    ) : [];
+    const organizations = accepts("organization")
+      ? this.db.all(
+        "SELECT id, name, description, is_dissolved, settings_json FROM organizations WHERE work_id = ? AND (name LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\' OR settings_json LIKE ? ESCAPE '\\') LIMIT 50",
+        workId,
+        pattern,
+        pattern,
+        pattern
+      )
+      : [];
+    const characterSections = accepts("character") ? this.searchCharacterProfileSections(workId, normalizedQuery, 30) : [];
     const snippet = (content: string): string => {
       const index = content.toLocaleLowerCase().indexOf(normalizedQuery);
       const start = Math.max(0, index - 40);

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID, scryptSync, timingSafeEqual } from
 import type { Request, RequestHandler, Response } from "express";
 import { Database, PLATFORM_AI_WORK_ID, type Row } from "./database.js";
 import { AppError, notFound } from "./errors.js";
+import { HYBRID_SEARCH_PERMISSION_MODULES, hybridSearchPermissionModule } from "./hybrid-search.js";
 import { sanitizeRequestPath } from "./http-logging.js";
 import { accountReference, logger } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
@@ -1086,10 +1087,10 @@ function workModuleRequirements(request: Request, write: boolean): WorkAuthoriza
       : { anyRead: [...aiInteractionModules] };
   }
   if (/^\/api\/works\/[^/]+\/search$/u.test(pathname)) {
-    const searchType = typeof request.query.type === "string" ? request.query.type : "";
-    return searchType === "agent-history"
-      ? { read: ["ai-chat"] }
-      : { read: [...contentPermissionModules] };
+    const permissionModule = hybridSearchPermissionModule(request.query.type);
+    return permissionModule
+      ? { read: [permissionModule] }
+      : { anyRead: [...HYBRID_SEARCH_PERMISSION_MODULES] };
   }
   if (/^\/api\/works\/[^/]+\/export$/u.test(pathname)) {
     return { read: exportReadPermissionModules(request.query.format) };

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -1574,12 +1574,17 @@ describe("用户、作品权限与操作者追踪 API", () => {
 
     await collaborator.agent.get(`/api/works/${workId}/audit-logs`).expect(403);
     await collaborator.agent.get(`/api/works/${workId}/unclassified-route`).expect(403);
-    await collaborator.agent.get(`/api/works/${workId}/search?q=边界`).expect(403);
-    const overlongSearchDenied = await collaborator.agent
+    const scopedSearch = await collaborator.agent.get(`/api/works/${workId}/search?q=边界`).expect(200);
+    expect(new Set(scopedSearch.body.data.map((item: { type: string }) => item.type))).toEqual(new Set([
+      "race",
+      "organization",
+      "review"
+    ]));
+    const overlongSearch = await collaborator.agent
       .get(`/api/works/${workId}/search`)
       .query({ q: "界".repeat(101) })
-      .expect(403);
-    expect(overlongSearchDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
+      .expect(400);
+    expect(overlongSearch.body.error.code).toBe("VALIDATION_ERROR");
     await collaborator.agent.get(`/api/works/${workId}/file-versions`).expect(403);
     const commentReadDenied = await collaborator.agent.get(`/api/works/${workId}/chapter-annotations`).expect(403);
     expect(commentReadDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
@@ -1656,6 +1661,98 @@ describe("用户、作品权限与操作者追踪 API", () => {
     const reviewReadDenied = await collaborator.agent.get(`/api/reviews/${reviewId}`).expect(403);
     expect(reviewReadDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
     expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("按成员可读模块限制显式与全局搜索并保持身份入口契约", async () => {
+    const admin = await register(runtime, "search_matrix_admin");
+    const owner = await register(runtime, "search_matrix_owner");
+    const proseReader = await register(runtime, "search_matrix_prose_reader");
+    const noAccessReader = await register(runtime, "search_matrix_no_access");
+    const work = await owner.agent.post("/api/works")
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "搜索权限矩阵作品" })
+      .expect(201);
+    const workId = String(work.body.data.id);
+    const volume = await owner.agent.post(`/api/works/${workId}/volumes`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "权限矩阵分卷" })
+      .expect(201);
+    const chapter = await owner.agent.post(`/api/works/${workId}/chapters`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ volumeId: volume.body.data.id, title: "权限矩阵正文", content: "权限矩阵命中只应展示正文。" })
+      .expect(201);
+    const character = await owner.agent.post(`/api/works/${workId}/characters`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ name: "权限矩阵保密角色", profile: { secret: "权限矩阵命中不可泄露人物档案" } })
+      .expect(201);
+    const noPermissions = {
+      prose: "none",
+      drafts: "none",
+      settings: "none",
+      characters: "none",
+      races: "none",
+      organizations: "none",
+      timeline: "none",
+      relationships: "none",
+      outlines: "none",
+      reviews: "none",
+      "ai-chat": "none",
+      "ai-analysis": "none",
+      "ai-settings": "none"
+    };
+    await owner.agent.post(`/api/works/${workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ userId: proseReader.user.userId, permissions: { ...noPermissions, prose: "read" } })
+      .expect(201);
+    await owner.agent.post(`/api/works/${workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ userId: noAccessReader.user.userId, permissions: noPermissions })
+      .expect(201);
+
+    await request(runtime.app).get(`/api/works/${workId}/search`).query({ q: "权限矩阵" }).expect(401);
+    const chapterSearch = await proseReader.agent.get(`/api/works/${workId}/search`)
+      .query({ q: "权限矩阵", type: "chapter" })
+      .expect(200);
+    expect(chapterSearch.body.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: chapter.body.data.id, type: "chapter" })
+    ]));
+    const characterDenied = await proseReader.agent.get(`/api/works/${workId}/search`)
+      .query({ q: "权限矩阵", type: "character" })
+      .expect(403);
+    expect(characterDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");
+    expect(JSON.stringify(characterDenied.body)).not.toContain("权限矩阵保密角色");
+
+    const globalSearch = await proseReader.agent.get(`/api/works/${workId}/search`)
+      .query({ q: "权限矩阵" })
+      .expect(200);
+    expect(globalSearch.body.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: chapter.body.data.id, type: "chapter" })
+    ]));
+    expect(globalSearch.body.data.every((item: { type: string }) => item.type === "chapter")).toBe(true);
+    expect(JSON.stringify(globalSearch.body.data)).not.toContain(String(character.body.data.id));
+    expect(JSON.stringify(globalSearch.body.data)).not.toContain("权限矩阵保密角色");
+
+    const emptyPermissionSearch = await noAccessReader.agent.get(`/api/works/${workId}/search`)
+      .query({ q: "权限矩阵" })
+      .expect(403);
+    expect(emptyPermissionSearch.body.error.code).toBe("WORK_MODULE_READ_DENIED");
+    await owner.agent.get(`/api/works/${workId}/search`).query({ q: "权限矩阵", type: "character" }).expect(200);
+    await admin.agent.get(`/api/works/${workId}/search`).query({ q: "权限矩阵", type: "character" }).expect(200);
+
+    const proseReaderKeyReset = await proseReader.agent.post("/api/auth/api-key/reset")
+      .set("X-CSRF-Token", proseReader.csrfToken)
+      .send({})
+      .expect(200);
+    const proseReaderKey = String(proseReaderKeyReset.body.data.apiKey);
+    const apiKeyGlobalSearch = await request(runtime.app).get(`/api/works/${workId}/search`)
+      .set("Authorization", `Bearer ${proseReaderKey}`)
+      .query({ q: "权限矩阵" })
+      .expect(200);
+    expect(apiKeyGlobalSearch.body.data.every((item: { type: string }) => item.type === "chapter")).toBe(true);
+    await request(runtime.app).get(`/api/works/${workId}/search`)
+      .set("Authorization", `Bearer ${proseReaderKey}`)
+      .query({ q: "权限矩阵", type: "character" })
+      .expect(403);
   });
 
   it("JSON 导出拒绝缺少审核读取权限的协作者且正文格式保持可用", async () => {
@@ -1977,6 +2074,13 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(historyOnlySearch.body.data).toEqual(expect.arrayContaining([
       expect.objectContaining({ type: "agent-history", conversationId: historyOnlyConversation.body.data.id })
     ]));
+    const historyOnlyGlobalSearch = await historyOnly.agent
+      .get(`/api/works/${workId}/search?q=正文权限之外`)
+      .expect(200);
+    expect(historyOnlyGlobalSearch.body.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "agent-history", conversationId: historyOnlyConversation.body.data.id })
+    ]));
+    expect(historyOnlyGlobalSearch.body.data.every((item: { type: string }) => item.type === "agent-history")).toBe(true);
     await chatOnly.agent.get(`/api/works/${workId}/models`).expect(200);
     const chatTasksDenied = await chatOnly.agent.get(`/api/works/${workId}/tasks`).expect(403);
     expect(chatTasksDenied.body.error.code).toBe("WORK_MODULE_READ_DENIED");

--- a/tests/unit/hybrid-search.test.ts
+++ b/tests/unit/hybrid-search.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  HYBRID_SEARCH_PERMISSION_MODULE_BY_TYPE,
   buildHybridSearchSnippet,
   documentParagraphLineRange,
   fuseHybridSearchChannels,
+  hybridSearchPermissionModule,
   normalizeWorkSearchQuery,
+  readableHybridSearchTypes,
   type HybridSearchCandidate
 } from "../../src/hybrid-search.js";
+import { emptyWorkModulePermissions } from "../../src/work-permissions.js";
 
 function candidate(key: string, matchKind: HybridSearchCandidate["matchKind"], overrides: Partial<HybridSearchCandidate> = {}): HybridSearchCandidate {
   return {
@@ -43,6 +47,28 @@ describe("作品搜索输入边界", () => {
     expect(normalizeWorkSearchQuery("\nＡ北港\n议会\n")).toBe("a北港\n议会");
     expect(normalizeWorkSearchQuery("界".repeat(100))).toHaveLength(100);
     expect(normalizeWorkSearchQuery(`${"界".repeat(100)}外`)).toBe("界".repeat(100));
+  });
+});
+
+describe("作品搜索权限映射", () => {
+  it("按搜索类型解析唯一的作品模块并列出当前可读类型", () => {
+    expect(HYBRID_SEARCH_PERMISSION_MODULE_BY_TYPE).toMatchObject({
+      chapter: "prose",
+      character: "characters",
+      "timeline-track": "timeline",
+      "timeline-event": "timeline",
+      "chapter-outline": "outlines",
+      foreshadow: "outlines",
+      review: "reviews",
+      "agent-history": "ai-chat"
+    });
+    expect(hybridSearchPermissionModule("character")).toBe("characters");
+    expect(hybridSearchPermissionModule("unknown")).toBeNull();
+
+    const permissions = emptyWorkModulePermissions();
+    permissions.prose = "read";
+    permissions["ai-chat"] = "write";
+    expect(readableHybridSearchTypes(permissions)).toEqual(["chapter", "agent-history"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- map every work search type to its single read-permission module
- authorize explicit searches by type and global searches by any readable search module
- restrict metadata and FTS candidates before loading result details or generating snippets
- preserve `agent-history`, owner, admin, API Key, unauthenticated, and validation contracts

## Testing

- `npm run check` (187 test files, 946 tests passed; typecheck and build passed)
- focused authorization and hybrid-search suites (53 tests passed)

Closes MUXUE-69
