### PR TITLE
MUXUE-70: index chapter paragraph line ranges

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -65,7 +65,7 @@ import {
   HYBRID_SEARCH_TYPES,
   MAXIMUM_WORK_SEARCH_QUERY_LENGTH,
   buildHybridSearchSnippet,
-  documentParagraphLineRange,
+  documentParagraphLineRangesFromLines,
   fuseHybridSearchChannels,
   normalizeWorkSearchQuery,
   type DocumentParagraphLineRange,
@@ -454,8 +454,39 @@ const RELATIONSHIP_MAX_FUZZY_SOURCES = 200;
 const RELATIONSHIP_MAX_FUZZY_SCAN_CHARACTERS = 4_000_000;
 const RELATIONSHIP_MAX_FUZZY_MATCHES = 600;
 const RELATIONSHIP_MAX_SOURCE_MATCHES = 256;
-const HYBRID_CHAPTER_LINE_RANGE_FALLBACK_LIMIT = 20;
 const RELATIONSHIP_PREFILTER_DISABLE_HINT = "请取消勾选“分析前按人物名称和拼音过滤来源”后重新预览";
+
+type HybridChapterLineRangeFallbackChapter = {
+  chapterVersion: number;
+  lines: string[];
+  ranges: DocumentParagraphLineRange[];
+};
+
+type HybridChapterLineRangeFallbackState = {
+  chapters: Map<string, HybridChapterLineRangeFallbackChapter | null>;
+  attemptedCandidates: number;
+  chapterLoads: number;
+  repairedCandidates: number;
+  invalidCandidateRows: number;
+  missingChapters: number;
+  chapterVersionMismatches: number;
+  missingParagraphRanges: number;
+  paragraphContentMismatches: number;
+};
+
+function createHybridChapterLineRangeFallbackState(): HybridChapterLineRangeFallbackState {
+  return {
+    chapters: new Map(),
+    attemptedCandidates: 0,
+    chapterLoads: 0,
+    repairedCandidates: 0,
+    invalidCandidateRows: 0,
+    missingChapters: 0,
+    chapterVersionMismatches: 0,
+    missingParagraphRanges: 0,
+    paragraphContentMismatches: 0
+  };
+}
 
 function relationshipCandidateLimitMessage(message: string): string {
   return `${message}；${RELATIONSHIP_PREFILTER_DISABLE_HINT}`;
@@ -2148,6 +2179,7 @@ export class AiManager {
     const channelLimit = Math.min(200, Math.max(50, resultLimit * 4));
     const accepts = (type: string): type is HybridSearchType => requestedTypes.has(type as HybridSearchType);
     const metadataDetails = new Map<string, Record<string, unknown>>();
+    const chapterLineRangeFallbackState = createHybridChapterLineRangeFallbackState();
 
     const metadataCandidates = [...requestedTypes].some((type) => type !== "agent-history")
       ? this.store.search(workId, normalizedQuery, requestedTypes).flatMap((item): HybridSearchCandidate[] => {
@@ -2171,14 +2203,19 @@ export class AiManager {
       : [];
 
     const exactCandidates = [
-      ...(requestedTypes.has("chapter") ? this.hybridChapterMatches(workId, normalizedQuery, "exact", channelLimit) : []),
+      ...(requestedTypes.has("chapter")
+        ? this.hybridChapterMatches(workId, normalizedQuery, "exact", channelLimit, chapterLineRangeFallbackState)
+        : []),
       ...(hasIndexedSourceTypes ? this.hybridIndexedSourceMatches(workId, normalizedQuery, "exact", requestedTypes, channelLimit) : []),
       ...(requestedTypes.has("agent-history") ? this.hybridAgentHistoryMatches(workId, normalizedQuery, channelLimit) : [])
     ];
     const phoneticCandidates = [
-      ...(requestedTypes.has("chapter") ? this.hybridChapterMatches(workId, normalizedQuery, "phonetic", channelLimit) : []),
+      ...(requestedTypes.has("chapter")
+        ? this.hybridChapterMatches(workId, normalizedQuery, "phonetic", channelLimit, chapterLineRangeFallbackState)
+        : []),
       ...(hasIndexedSourceTypes ? this.hybridIndexedSourceMatches(workId, normalizedQuery, "phonetic", requestedTypes, channelLimit) : [])
     ];
+    this.logHybridChapterLineRangeFallback(workId, chapterLineRangeFallbackState);
     return fuseHybridSearchChannels([
       { weight: 1.4, candidates: metadataCandidates },
       { weight: 1, candidates: exactCandidates },
@@ -2242,7 +2279,8 @@ export class AiManager {
     workId: string,
     query: string,
     matchKind: Extract<HybridSearchMatchKind, "exact" | "phonetic">,
-    limit: number
+    limit: number,
+    fallbackState: HybridChapterLineRangeFallbackState
   ): HybridSearchCandidate[] {
     let rows: Row[];
     if (matchKind === "phonetic") {
@@ -2305,7 +2343,6 @@ export class AiManager {
       );
     }
     const seen = new Set<string>();
-    const fallbackState = { used: 0 };
     return rows.flatMap((row): HybridSearchCandidate[] => {
       const chapterId = String(row.chapter_id ?? "");
       const key = `chapter:${chapterId}`;
@@ -2329,7 +2366,7 @@ export class AiManager {
   private hybridChapterLineRange(
     workId: string,
     row: Row,
-    fallbackState: { used: number }
+    fallbackState: HybridChapterLineRangeFallbackState
   ): DocumentParagraphLineRange | null {
     const chapterVersion = Number(row.chapter_version);
     const rangeVersion = Number(row.range_chapter_version);
@@ -2346,29 +2383,56 @@ export class AiManager {
     ) {
       return { startLine, endLine };
     }
-    if (fallbackState.used >= HYBRID_CHAPTER_LINE_RANGE_FALLBACK_LIMIT) return null;
-    fallbackState.used += 1;
+    fallbackState.attemptedCandidates += 1;
     const chapterId = String(row.chapter_id ?? "");
     const paragraphOrder = Number(row.paragraph_order);
     const paragraphId = Number(row.paragraph_id);
     if (!chapterId || !Number.isSafeInteger(paragraphOrder) || paragraphOrder < 0 || !Number.isSafeInteger(paragraphId) || paragraphId < 1) {
+      fallbackState.invalidCandidateRows += 1;
       return null;
     }
-    const chapter = this.store.db.get<{ content: string; version_no: number }>(
-      "SELECT content, version_no FROM chapters WHERE id = ? AND work_id = ? AND deleted_at IS NULL",
-      chapterId,
-      workId
-    );
-    if (!chapter || Number(chapter.version_no) !== chapterVersion) return null;
-    const currentRange = documentParagraphLineRange(chapter.content, paragraphOrder);
-    if (!currentRange) return null;
-    const currentParagraph = chapter.content
-      .replace(/\r\n?/gu, "\n")
-      .split("\n")
+    let cachedChapter = fallbackState.chapters.get(chapterId);
+    if (!fallbackState.chapters.has(chapterId)) {
+      fallbackState.chapterLoads += 1;
+      const chapter = this.store.db.get<{ content: string; version_no: number }>(
+        "SELECT content, version_no FROM chapters WHERE id = ? AND work_id = ? AND deleted_at IS NULL",
+        chapterId,
+        workId
+      );
+      if (!chapter) {
+        fallbackState.chapters.set(chapterId, null);
+        cachedChapter = null;
+      } else {
+        const lines = chapter.content.replace(/\r\n?/gu, "\n").split("\n");
+        cachedChapter = {
+          chapterVersion: Number(chapter.version_no),
+          lines,
+          ranges: documentParagraphLineRangesFromLines(lines)
+        };
+        fallbackState.chapters.set(chapterId, cachedChapter);
+      }
+    }
+    if (!cachedChapter) {
+      fallbackState.missingChapters += 1;
+      return null;
+    }
+    if (cachedChapter.chapterVersion !== chapterVersion) {
+      fallbackState.chapterVersionMismatches += 1;
+      return null;
+    }
+    const currentRange = cachedChapter.ranges[paragraphOrder];
+    if (!currentRange) {
+      fallbackState.missingParagraphRanges += 1;
+      return null;
+    }
+    const currentParagraph = cachedChapter.lines
       .slice(currentRange.startLine - 1, currentRange.endLine)
       .join("\n")
       .trim();
-    if (currentParagraph !== String(row.paragraph_content ?? "")) return null;
+    if (currentParagraph !== String(row.paragraph_content ?? "")) {
+      fallbackState.paragraphContentMismatches += 1;
+      return null;
+    }
     this.store.db.run(
       `INSERT INTO chapter_paragraph_line_ranges (paragraph_id, chapter_version, start_line, end_line)
        VALUES (?, ?, ?, ?)
@@ -2381,7 +2445,30 @@ export class AiManager {
       currentRange.startLine,
       currentRange.endLine
     );
+    fallbackState.repairedCandidates += 1;
     return currentRange;
+  }
+
+  private logHybridChapterLineRangeFallback(workId: string, state: HybridChapterLineRangeFallbackState): void {
+    if (state.attemptedCandidates === 0) return;
+    const fields = {
+      workId,
+      attemptedCandidates: state.attemptedCandidates,
+      chapterLoads: state.chapterLoads,
+      repairedCandidates: state.repairedCandidates,
+      invalidCandidateRows: state.invalidCandidateRows,
+      missingChapters: state.missingChapters,
+      chapterVersionMismatches: state.chapterVersionMismatches,
+      missingParagraphRanges: state.missingParagraphRanges,
+      paragraphContentMismatches: state.paragraphContentMismatches
+    };
+    const failedCandidates = state.invalidCandidateRows
+      + state.missingChapters
+      + state.chapterVersionMismatches
+      + state.missingParagraphRanges
+      + state.paragraphContentMismatches;
+    if (failedCandidates > 0) logger.warn("search.chapter_line_range_fallback", fields);
+    else logger.info("search.chapter_line_range_fallback", fields);
   }
 
   private hybridIndexedSourceMatches(

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -68,6 +68,7 @@ import {
   documentParagraphLineRange,
   fuseHybridSearchChannels,
   normalizeWorkSearchQuery,
+  type DocumentParagraphLineRange,
   type HybridSearchCandidate,
   type HybridSearchMatchKind,
   type HybridSearchType
@@ -453,6 +454,7 @@ const RELATIONSHIP_MAX_FUZZY_SOURCES = 200;
 const RELATIONSHIP_MAX_FUZZY_SCAN_CHARACTERS = 4_000_000;
 const RELATIONSHIP_MAX_FUZZY_MATCHES = 600;
 const RELATIONSHIP_MAX_SOURCE_MATCHES = 256;
+const HYBRID_CHAPTER_LINE_RANGE_FALLBACK_LIMIT = 20;
 const RELATIONSHIP_PREFILTER_DISABLE_HINT = "请取消勾选“分析前按人物名称和拼音过滤来源”后重新预览";
 
 function relationshipCandidateLimitMessage(message: string): string {
@@ -2244,10 +2246,13 @@ export class AiManager {
       const tokens = relationshipPinyinSearchTokens(query);
       if (tokens.length === 0) return [];
       rows = this.store.db.all(
-        `SELECT paragraph.chapter_id, paragraph.paragraph_order, paragraph.content AS paragraph_content,
-                chapter.title AS chapter_title, chapter.content AS chapter_content, volume.title AS volume_title
+        `SELECT paragraph.id AS paragraph_id, paragraph.chapter_id, paragraph.paragraph_order,
+                paragraph.content AS paragraph_content, line_range.chapter_version AS range_chapter_version,
+                line_range.start_line, line_range.end_line, chapter.version_no AS chapter_version,
+                chapter.title AS chapter_title, volume.title AS volume_title
          FROM chapter_paragraph_pinyin_fts pinyin
          JOIN chapter_paragraph_search paragraph ON paragraph.id = pinyin.rowid
+         LEFT JOIN chapter_paragraph_line_ranges line_range ON line_range.paragraph_id = paragraph.id
          JOIN chapters chapter ON chapter.id = paragraph.chapter_id
          JOIN volumes volume ON volume.id = chapter.volume_id
          WHERE paragraph.work_id = ? AND chapter.deleted_at IS NULL
@@ -2260,10 +2265,13 @@ export class AiManager {
       );
     } else if ([...query].length < 3) {
       rows = this.store.db.all(
-        `SELECT paragraph.chapter_id, paragraph.paragraph_order, paragraph.content AS paragraph_content,
-                chapter.title AS chapter_title, chapter.content AS chapter_content, volume.title AS volume_title
+        `SELECT paragraph.id AS paragraph_id, paragraph.chapter_id, paragraph.paragraph_order,
+                paragraph.content AS paragraph_content, line_range.chapter_version AS range_chapter_version,
+                line_range.start_line, line_range.end_line, chapter.version_no AS chapter_version,
+                chapter.title AS chapter_title, volume.title AS volume_title
          FROM chapter_paragraph_short_terms term
          JOIN chapter_paragraph_search paragraph ON paragraph.id = term.paragraph_id
+         LEFT JOIN chapter_paragraph_line_ranges line_range ON line_range.paragraph_id = paragraph.id
          JOIN chapters chapter ON chapter.id = paragraph.chapter_id
          JOIN volumes volume ON volume.id = chapter.volume_id
          WHERE paragraph.work_id = ? AND chapter.deleted_at IS NULL AND term.term = ?
@@ -2275,10 +2283,13 @@ export class AiManager {
       );
     } else {
       rows = this.store.db.all(
-        `SELECT paragraph.chapter_id, paragraph.paragraph_order, paragraph.content AS paragraph_content,
-                chapter.title AS chapter_title, chapter.content AS chapter_content, volume.title AS volume_title
+        `SELECT paragraph.id AS paragraph_id, paragraph.chapter_id, paragraph.paragraph_order,
+                paragraph.content AS paragraph_content, line_range.chapter_version AS range_chapter_version,
+                line_range.start_line, line_range.end_line, chapter.version_no AS chapter_version,
+                chapter.title AS chapter_title, volume.title AS volume_title
          FROM chapter_paragraph_search_fts fts
          JOIN chapter_paragraph_search paragraph ON paragraph.id = fts.rowid
+         LEFT JOIN chapter_paragraph_line_ranges line_range ON line_range.paragraph_id = paragraph.id
          JOIN chapters chapter ON chapter.id = paragraph.chapter_id
          JOIN volumes volume ON volume.id = chapter.volume_id
          WHERE paragraph.work_id = ? AND chapter.deleted_at IS NULL
@@ -2291,12 +2302,14 @@ export class AiManager {
       );
     }
     const seen = new Set<string>();
+    const fallbackState = { used: 0 };
     return rows.flatMap((row): HybridSearchCandidate[] => {
       const chapterId = String(row.chapter_id ?? "");
       const key = `chapter:${chapterId}`;
       if (!chapterId || seen.has(key)) return [];
+      const range = this.hybridChapterLineRange(workId, row, fallbackState);
+      if (!range) return [];
       seen.add(key);
-      const range = documentParagraphLineRange(String(row.chapter_content ?? ""), Number(row.paragraph_order));
       return [{
         key,
         type: "chapter",
@@ -2305,9 +2318,67 @@ export class AiManager {
         subtitle: String(row.volume_title ?? ""),
         snippet: buildHybridSearchSnippet(String(row.paragraph_content ?? ""), query),
         matchKind,
-        ...(range ?? {})
+        ...range
       }];
     });
+  }
+
+  private hybridChapterLineRange(
+    workId: string,
+    row: Row,
+    fallbackState: { used: number }
+  ): DocumentParagraphLineRange | null {
+    const chapterVersion = Number(row.chapter_version);
+    const rangeVersion = Number(row.range_chapter_version);
+    const startLine = Number(row.start_line);
+    const endLine = Number(row.end_line);
+    if (
+      Number.isSafeInteger(chapterVersion)
+      && chapterVersion >= 1
+      && rangeVersion === chapterVersion
+      && Number.isSafeInteger(startLine)
+      && Number.isSafeInteger(endLine)
+      && startLine >= 1
+      && endLine >= startLine
+    ) {
+      return { startLine, endLine };
+    }
+    if (fallbackState.used >= HYBRID_CHAPTER_LINE_RANGE_FALLBACK_LIMIT) return null;
+    fallbackState.used += 1;
+    const chapterId = String(row.chapter_id ?? "");
+    const paragraphOrder = Number(row.paragraph_order);
+    const paragraphId = Number(row.paragraph_id);
+    if (!chapterId || !Number.isSafeInteger(paragraphOrder) || paragraphOrder < 0 || !Number.isSafeInteger(paragraphId) || paragraphId < 1) {
+      return null;
+    }
+    const chapter = this.store.db.get<{ content: string; version_no: number }>(
+      "SELECT content, version_no FROM chapters WHERE id = ? AND work_id = ? AND deleted_at IS NULL",
+      chapterId,
+      workId
+    );
+    if (!chapter || Number(chapter.version_no) !== chapterVersion) return null;
+    const currentRange = documentParagraphLineRange(chapter.content, paragraphOrder);
+    if (!currentRange) return null;
+    const currentParagraph = chapter.content
+      .replace(/\r\n?/gu, "\n")
+      .split("\n")
+      .slice(currentRange.startLine - 1, currentRange.endLine)
+      .join("\n")
+      .trim();
+    if (currentParagraph !== String(row.paragraph_content ?? "")) return null;
+    this.store.db.run(
+      `INSERT INTO chapter_paragraph_line_ranges (paragraph_id, chapter_version, start_line, end_line)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(paragraph_id) DO UPDATE SET
+         chapter_version = excluded.chapter_version,
+         start_line = excluded.start_line,
+         end_line = excluded.end_line`,
+      paragraphId,
+      chapterVersion,
+      currentRange.startLine,
+      currentRange.endLine
+    );
+    return currentRange;
   }
 
   private hybridIndexedSourceMatches(

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,14 +1,15 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, statfsSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { documentParagraphLineRanges } from "./hybrid-search.js";
 import { logger, sanitizeError } from "./logger.js";
 import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentParagraphs } from "./utils.js";
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态。
+// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引。
 export const ENTITY_VERSION_BASELINE_MIGRATION_VERSION = 82;
-export const DATABASE_SCHEMA_VERSION = 90;
+export const DATABASE_SCHEMA_VERSION = 91;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -3529,6 +3530,44 @@ export class Database {
         const foreignKeys = this.all("PRAGMA foreign_key_check");
         if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (90, ?)", new Date().toISOString());
+      });
+    }
+    if (!applied.has(91)) {
+      this.transaction(() => {
+        this.run(`CREATE TABLE IF NOT EXISTS chapter_paragraph_line_ranges (
+          paragraph_id INTEGER PRIMARY KEY REFERENCES chapter_paragraph_search(id) ON DELETE CASCADE,
+          chapter_version INTEGER NOT NULL CHECK(chapter_version >= 1),
+          start_line INTEGER NOT NULL CHECK(start_line >= 1),
+          end_line INTEGER NOT NULL CHECK(end_line >= start_line)
+        ) WITHOUT ROWID`);
+        const insertRange = this.raw.prepare(
+          `INSERT INTO chapter_paragraph_line_ranges (paragraph_id, chapter_version, start_line, end_line)
+           VALUES (?, ?, ?, ?)`
+        );
+        const chapters = this.all<{ id: string; content: string; version_no: number }>(
+          `SELECT DISTINCT chapter.id, chapter.content, chapter.version_no
+           FROM chapters chapter
+           JOIN chapter_paragraph_search paragraph ON paragraph.chapter_id = chapter.id
+           ORDER BY chapter.id`
+        );
+        for (const chapter of chapters) {
+          const ranges = documentParagraphLineRanges(chapter.content);
+          const paragraphs = this.all<{ id: number; paragraph_order: number }>(
+            "SELECT id, paragraph_order FROM chapter_paragraph_search WHERE chapter_id = ? ORDER BY paragraph_order",
+            chapter.id
+          );
+          for (const paragraph of paragraphs) {
+            const range = ranges[paragraph.paragraph_order];
+            if (range) insertRange.run(paragraph.id, chapter.version_no, range.startLine, range.endLine);
+          }
+        }
+        const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+        if (integrity.some((row) => row.integrity_check !== "ok")) {
+          throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+        }
+        const foreignKeys = this.all("PRAGMA foreign_key_check");
+        if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (91, ?)", new Date().toISOString());
       });
     }
   }

--- a/src/hybrid-search.ts
+++ b/src/hybrid-search.ts
@@ -122,10 +122,11 @@ export function buildHybridSearchSnippet(value: string, query: string, maximumLe
   return `${start > 0 ? "…" : ""}${excerpt}${start + safeMaximum < compact.length ? "…" : ""}`;
 }
 
-export function documentParagraphLineRange(value: string, paragraphOrder: number): { startLine: number; endLine: number } | null {
-  if (!Number.isInteger(paragraphOrder) || paragraphOrder < 0) return null;
+export type DocumentParagraphLineRange = { startLine: number; endLine: number };
+
+export function documentParagraphLineRanges(value: string): DocumentParagraphLineRange[] {
   const lines = value.replace(/\r\n?/gu, "\n").split("\n");
-  const ranges: Array<{ startLine: number; endLine: number }> = [];
+  const ranges: DocumentParagraphLineRange[] = [];
   let start: number | null = null;
   for (let index = 0; index <= lines.length; index += 1) {
     const line = lines[index];
@@ -136,5 +137,10 @@ export function documentParagraphLineRange(value: string, paragraphOrder: number
       start = null;
     }
   }
-  return ranges[paragraphOrder] ?? null;
+  return ranges;
+}
+
+export function documentParagraphLineRange(value: string, paragraphOrder: number): DocumentParagraphLineRange | null {
+  if (!Number.isInteger(paragraphOrder) || paragraphOrder < 0) return null;
+  return documentParagraphLineRanges(value)[paragraphOrder] ?? null;
 }

--- a/src/hybrid-search.ts
+++ b/src/hybrid-search.ts
@@ -155,8 +155,7 @@ export function buildHybridSearchSnippet(value: string, query: string, maximumLe
 
 export type DocumentParagraphLineRange = { startLine: number; endLine: number };
 
-export function documentParagraphLineRanges(value: string): DocumentParagraphLineRange[] {
-  const lines = value.replace(/\r\n?/gu, "\n").split("\n");
+export function documentParagraphLineRangesFromLines(lines: readonly string[]): DocumentParagraphLineRange[] {
   const ranges: DocumentParagraphLineRange[] = [];
   let start: number | null = null;
   for (let index = 0; index <= lines.length; index += 1) {
@@ -169,6 +168,10 @@ export function documentParagraphLineRanges(value: string): DocumentParagraphLin
     }
   }
   return ranges;
+}
+
+export function documentParagraphLineRanges(value: string): DocumentParagraphLineRange[] {
+  return documentParagraphLineRangesFromLines(value.replace(/\r\n?/gu, "\n").split("\n"));
 }
 
 export function documentParagraphLineRange(value: string, paragraphOrder: number): DocumentParagraphLineRange | null {

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,7 @@ import {
 import { exportWorkDocx } from "./docx-export.js";
 import { createEpubArchive } from "./epub-export.js";
 import { AppError, notFound } from "./errors.js";
-import { normalizeWorkSearchQuery } from "./hybrid-search.js";
+import { documentParagraphLineRanges, normalizeWorkSearchQuery } from "./hybrid-search.js";
 import { accountReference, logger } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
 import { currentRequestActor } from "./request-context.js";
@@ -2915,6 +2915,7 @@ export class Store {
         timestamp,
         chapterId
       );
+      this.syncChapterParagraphSearchVersion(chapterId, versionNo);
       this.insertChapterVersionRow({
         workId: String(lockedChapter.workId),
         chapterId,
@@ -3169,6 +3170,7 @@ export class Store {
           const versionNo = Number(chapter.versionNo) + 1;
           const sortOrder = orderedByVolume.get(action.volumeId)?.indexOf(chapterId) ?? 0;
           this.db.run("UPDATE chapters SET version_no = ?, analysis_status = 'expired', updated_at = ? WHERE id = ?", versionNo, timestamp, chapterId);
+          this.syncChapterParagraphSearchVersion(chapterId, versionNo);
           this.insertChapterVersionRow({
             workId,
             chapterId,
@@ -3362,6 +3364,11 @@ export class Store {
   }
 
   private syncChapterParagraphSearch(workId: string, chapterId: string, content: string): void {
+    const chapterVersion = numberValue(
+      this.db.get("SELECT version_no FROM chapters WHERE id = ? AND work_id = ?", chapterId, workId) ?? {},
+      "version_no"
+    );
+    const ranges = documentParagraphLineRanges(content);
     this.db.run("DELETE FROM chapter_paragraph_search WHERE chapter_id = ?", chapterId);
     for (const [paragraphOrder, paragraph] of splitDocumentParagraphs(content).entries()) {
       const searchContent = normalizeDocumentSearchText(paragraph);
@@ -3374,6 +3381,17 @@ export class Store {
         paragraph,
         searchContent
       );
+      const range = ranges[paragraphOrder];
+      if (range) {
+        this.db.run(
+          `INSERT INTO chapter_paragraph_line_ranges (paragraph_id, chapter_version, start_line, end_line)
+           VALUES (?, ?, ?, ?)`,
+          inserted.lastInsertRowid,
+          chapterVersion,
+          range.startLine,
+          range.endLine
+        );
+      }
       for (const term of documentShortSearchTerms(searchContent)) {
         this.db.run(
           "INSERT INTO chapter_paragraph_short_terms (paragraph_id, term) VALUES (?, ?)",
@@ -3382,6 +3400,15 @@ export class Store {
         );
       }
     }
+  }
+
+  private syncChapterParagraphSearchVersion(chapterId: string, versionNo: number): void {
+    this.db.run(
+      `UPDATE chapter_paragraph_line_ranges SET chapter_version = ?
+       WHERE paragraph_id IN (SELECT id FROM chapter_paragraph_search WHERE chapter_id = ?)`,
+      versionNo,
+      chapterId
+    );
   }
 
   searchChapterParagraphs(workId: string, keyword: string, limit = 20): Array<{

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Runtime } from "../../src/app.js";
+import { logger } from "../../src/logger.js";
 import { createTestRuntime, seedChapter } from "../helpers.js";
 
 describe("作品混合检索", () => {
@@ -9,6 +10,7 @@ describe("作品混合检索", () => {
   afterEach(async () => {
     await runtime?.close();
     runtime = null;
+    vi.restoreAllMocks();
   });
 
   it("统一检索正文和全部知识类型并返回正文行号", async () => {
@@ -188,6 +190,100 @@ describe("作品混合检索", () => {
       .query({ q: "潮汐棱镜", type: "chapter" })
       .expect(200);
     expect(stale.body.data).toEqual([]);
+  });
+
+  it("旧索引回退验证超过二十个候选并按章节复用正文解析", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "超过上限验证正文。");
+    const workId = String(seeded.work.id);
+    const volumeId = String(seeded.volume.id);
+    for (let index = 2; index <= 25; index += 1) {
+      runtime.store.createChapter(workId, {
+        volumeId,
+        title: `第 ${index} 章`,
+        content: "超过上限验证正文。"
+      });
+    }
+    runtime.store.db.run(
+      `UPDATE chapter_paragraph_line_ranges SET chapter_version = chapter_version + 1
+       WHERE paragraph_id IN (SELECT id FROM chapter_paragraph_search WHERE work_id = ?)`,
+      workId
+    );
+    const getSpy = vi.spyOn(runtime.store.db, "get");
+    const infoSpy = vi.spyOn(logger, "info");
+
+    const response = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "超过上限验证", type: "chapter", limit: 50 })
+      .expect(200);
+
+    expect(response.body.data).toHaveLength(25);
+    expect(response.body.data.every((item: { startLine?: number; endLine?: number }) => item.startLine === 1 && item.endLine === 1)).toBe(true);
+    expect(getSpy.mock.calls.filter(([sql]) => String(sql).includes("SELECT content, version_no FROM chapters"))).toHaveLength(25);
+    expect(runtime.store.db.get(
+      `SELECT COUNT(*) AS count FROM chapter_paragraph_line_ranges line_range
+       JOIN chapter_paragraph_search paragraph ON paragraph.id = line_range.paragraph_id
+       JOIN chapters chapter ON chapter.id = paragraph.chapter_id
+       WHERE paragraph.work_id = ? AND line_range.chapter_version <> chapter.version_no`,
+      workId
+    )).toEqual({ count: 0 });
+    const fallbackLog = infoSpy.mock.calls.find(([event]) => event === "search.chapter_line_range_fallback");
+    expect(fallbackLog?.[1]).toMatchObject({
+      attemptedCandidates: 25,
+      chapterLoads: 25,
+      repairedCandidates: 25,
+      paragraphContentMismatches: 0
+    });
+    expect(JSON.stringify(fallbackLog)).not.toContain("超过上限验证正文");
+  });
+
+  it("同章重复回退只读取正文一次并记录不含正文的失败计数", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "缓存命中当前第一段。\n\n缓存命中当前第二段。");
+    const workId = String(seeded.work.id);
+    const chapterId = String(seeded.chapter.id);
+    const paragraphs = runtime.store.db.all<{ id: number; paragraph_order: number }>(
+      "SELECT id, paragraph_order FROM chapter_paragraph_search WHERE chapter_id = ? ORDER BY paragraph_order",
+      chapterId
+    );
+    runtime.store.db.run(
+      "UPDATE chapter_paragraph_search SET content = ?, search_content = ? WHERE id = ?",
+      "缓存命中过期第一段。",
+      "缓存命中过期第一段。",
+      paragraphs[0]?.id ?? 0
+    );
+    runtime.store.db.run(
+      `DELETE FROM chapter_paragraph_line_ranges
+       WHERE paragraph_id IN (SELECT id FROM chapter_paragraph_search WHERE chapter_id = ?)`,
+      chapterId
+    );
+    const getSpy = vi.spyOn(runtime.store.db, "get");
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const response = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "缓存命中", type: "chapter" })
+      .expect(200);
+
+    expect(response.body.data).toEqual([
+      expect.objectContaining({ id: chapterId, startLine: 3, endLine: 3, snippet: "缓存命中当前第二段。" })
+    ]);
+    expect(getSpy.mock.calls.filter(([sql]) => String(sql).includes("SELECT content, version_no FROM chapters"))).toHaveLength(1);
+    expect(runtime.store.db.get(
+      `SELECT COUNT(*) AS count FROM chapter_paragraph_line_ranges line_range
+       JOIN chapter_paragraph_search paragraph ON paragraph.id = line_range.paragraph_id
+       WHERE paragraph.chapter_id = ?`,
+      chapterId
+    )).toEqual({ count: 1 });
+    const fallbackLog = warnSpy.mock.calls.find(([event]) => event === "search.chapter_line_range_fallback");
+    expect(fallbackLog?.[1]).toMatchObject({
+      chapterLoads: 1,
+      repairedCandidates: 1,
+      paragraphContentMismatches: expect.any(Number)
+    });
+    expect(Number(fallbackLog?.[1]?.paragraphContentMismatches)).toBeGreaterThanOrEqual(1);
+    expect(JSON.stringify(fallbackLog)).not.toContain("缓存命中过期第一段");
+    expect(JSON.stringify(fallbackLog)).not.toContain("缓存命中当前第二段");
   });
 
   it("通过增量全文索引检索 Agent history，并支持短词和标题更新", async () => {

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 import type { Runtime } from "../../src/app.js";
 import { createTestRuntime, seedChapter } from "../helpers.js";
@@ -108,6 +108,86 @@ describe("作品混合检索", () => {
       .query({ q: "星港通行证", type: "setting" })
       .expect(200);
     expect(updated.body.data).toEqual([expect.objectContaining({ id: setting.id, type: "setting" })]);
+  });
+
+  it("三条正文搜索路径复用版本化行号索引并对缺失索引执行有界自修复", async () => {
+    runtime = createTestRuntime();
+    const longPrefix = Array.from({ length: 2_000 }, (_, index) => `铺垫行 ${index + 1}`).join("\n");
+    const content = `${longPrefix}\n\n潮汐棱镜第一次发光。\n仍在发光。\n\n北港灯塔。\n\n北港备用航线。`;
+    const seeded = await seedChapter(runtime, content);
+    const workId = String(seeded.work.id);
+    const chapterId = String(seeded.chapter.id);
+    const allSpy = vi.spyOn(runtime.store.db, "all");
+    const getSpy = vi.spyOn(runtime.store.db, "get");
+
+    const fullText = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "潮汐棱镜", type: "chapter" })
+      .expect(200);
+    const shortText = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "北港", type: "chapter" })
+      .expect(200);
+    const phonetic = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "beigang", type: "chapter" })
+      .expect(200);
+
+    expect(fullText.body.data).toEqual([
+      expect.objectContaining({ id: chapterId, startLine: 2_002, endLine: 2_003 })
+    ]);
+    expect(shortText.body.data).toEqual([
+      expect.objectContaining({ id: chapterId, startLine: 2_005, endLine: 2_005 })
+    ]);
+    expect(phonetic.body.data).toEqual([
+      expect.objectContaining({ id: chapterId, startLine: 2_005, endLine: 2_005, matchKinds: ["phonetic"] })
+    ]);
+    expect(shortText.body.data).toHaveLength(1);
+    const observedSql = [...allSpy.mock.calls, ...getSpy.mock.calls].map(([sql]) => String(sql));
+    expect(observedSql.some((sql) => sql.includes("chapter.content AS chapter_content"))).toBe(false);
+    expect(observedSql.some((sql) => sql.includes("SELECT content, version_no FROM chapters"))).toBe(false);
+
+    const targetParagraph = runtime.store.db.get<{ id: number }>(
+      "SELECT id FROM chapter_paragraph_search WHERE chapter_id = ? AND content LIKE ?",
+      chapterId,
+      "%潮汐棱镜%"
+    );
+    expect(targetParagraph).toBeDefined();
+    runtime.store.db.run("DELETE FROM chapter_paragraph_line_ranges WHERE paragraph_id = ?", Number(targetParagraph?.id));
+    getSpy.mockClear();
+    const repaired = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "潮汐棱镜", type: "chapter" })
+      .expect(200);
+    expect(repaired.body.data).toEqual([
+      expect.objectContaining({ id: chapterId, startLine: 2_002, endLine: 2_003 })
+    ]);
+    expect(getSpy.mock.calls.filter(([sql]) => String(sql).includes("SELECT content, version_no FROM chapters"))).toHaveLength(1);
+    expect(runtime.store.db.get(
+      "SELECT start_line, end_line FROM chapter_paragraph_line_ranges WHERE paragraph_id = ?",
+      Number(targetParagraph?.id)
+    )).toEqual({ start_line: 2_002, end_line: 2_003 });
+
+    const secondVolume = runtime.store.createVolume(workId, { title: "第二卷" });
+    const moved = runtime.store.moveChapter(chapterId, { volumeId: String(secondVolume.id), sortOrder: 0 });
+    expect(runtime.store.db.get(
+      `SELECT COUNT(*) AS count FROM chapter_paragraph_line_ranges line_range
+       JOIN chapter_paragraph_search paragraph ON paragraph.id = line_range.paragraph_id
+       WHERE paragraph.chapter_id = ? AND line_range.chapter_version <> ?`,
+      chapterId,
+      Number(moved.versionNo)
+    )).toEqual({ count: 0 });
+
+    runtime.store.db.run(
+      "UPDATE chapters SET content = ?, version_no = version_no + 1 WHERE id = ?",
+      "当前正文已经替换，不应命中旧索引。",
+      chapterId
+    );
+    const stale = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "潮汐棱镜", type: "chapter" })
+      .expect(200);
+    expect(stale.body.data).toEqual([]);
   });
 
   it("通过增量全文索引检索 Agent history，并支持短词和标题更新", async () => {

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -3183,6 +3183,31 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-Scriverse-API-Key", firstKey)
       .send({ content: "API Key 修改后的正文。", changeNote: "CLI 调整开场正文" })
       .expect(200);
+    await request(runtime.app)
+      .get(`/api/works/${adminWorkId}/search`)
+      .query({ q: "API Key 修改", type: "chapter" })
+      .expect(401);
+    await admin.agent
+      .get(`/api/works/${adminWorkId}/search`)
+      .query({ q: "API Key 修改", type: "chapter" })
+      .expect(200);
+    await admin.agent
+      .get(`/api/works/${writerWorkId}/search`)
+      .query({ q: "不存在的正文", type: "chapter" })
+      .expect(200);
+    const apiKeySearch = await request(runtime.app)
+      .get(`/api/works/${adminWorkId}/search`)
+      .set("Authorization", `Bearer ${firstKey}`)
+      .query({ q: "API Key 修改", type: "chapter" })
+      .expect(200);
+    expect(apiKeySearch.body.data).toEqual([
+      expect.objectContaining({ id: chapter.body.data.id, type: "chapter", startLine: 1, endLine: 1 })
+    ]);
+    await request(runtime.app)
+      .get(`/api/works/${writerWorkId}/search`)
+      .set("Authorization", `Bearer ${firstKey}`)
+      .query({ q: "API Key 修改", type: "chapter" })
+      .expect(403);
     const versions = await request(runtime.app).get(`/api/chapters/${chapter.body.data.id}/versions`)
       .set("Authorization", `Bearer ${firstKey}`)
       .expect(200);

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -257,6 +257,12 @@ describe("数据库版本化迁移", () => {
       "idx_presence_changes_saved_at"
     ]));
     expect(first.get("SELECT chapter_id, content FROM chapter_paragraph_search WHERE chapter_id = 'chapter-old'")).toEqual({ chapter_id: "chapter-old", content: "旧正文" });
+    expect(first.get(
+      `SELECT line_range.chapter_version, line_range.start_line, line_range.end_line
+       FROM chapter_paragraph_line_ranges line_range
+       JOIN chapter_paragraph_search paragraph ON paragraph.id = line_range.paragraph_id
+       WHERE paragraph.chapter_id = 'chapter-old'`
+    )).toEqual({ chapter_version: 1, start_line: 1, end_line: 1 });
     expect(first.all("PRAGMA index_list(chapter_paragraph_short_terms)").some(
       (index) => index.name === "idx_chapter_paragraph_short_terms_paragraph"
     )).toBe(true);

--- a/tests/unit/hybrid-search.test.ts
+++ b/tests/unit/hybrid-search.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildHybridSearchSnippet,
   documentParagraphLineRange,
+  documentParagraphLineRanges,
   fuseHybridSearchChannels,
   normalizeWorkSearchQuery,
   type HybridSearchCandidate
@@ -59,6 +60,11 @@ describe("混合检索摘要", () => {
 describe("正文段落行定位", () => {
   it("按空白行分段并返回一基行号", () => {
     const content = "第一行\n第二行\n\n  \n第三行\n第四行\n\n第五行";
+    expect(documentParagraphLineRanges(content)).toEqual([
+      { startLine: 1, endLine: 2 },
+      { startLine: 5, endLine: 6 },
+      { startLine: 8, endLine: 8 }
+    ]);
     expect(documentParagraphLineRange(content, 0)).toEqual({ startLine: 1, endLine: 2 });
     expect(documentParagraphLineRange(content, 1)).toEqual({ startLine: 5, endLine: 6 });
     expect(documentParagraphLineRange(content, 2)).toEqual({ startLine: 8, endLine: 8 });

--- a/tests/unit/hybrid-search.test.ts
+++ b/tests/unit/hybrid-search.test.ts
@@ -4,6 +4,7 @@ import {
   buildHybridSearchSnippet,
   documentParagraphLineRange,
   documentParagraphLineRanges,
+  documentParagraphLineRangesFromLines,
   fuseHybridSearchChannels,
   hybridSearchPermissionModule,
   normalizeWorkSearchQuery,
@@ -91,6 +92,7 @@ describe("正文段落行定位", () => {
       { startLine: 5, endLine: 6 },
       { startLine: 8, endLine: 8 }
     ]);
+    expect(documentParagraphLineRangesFromLines(content.split("\n"))).toEqual(documentParagraphLineRanges(content));
     expect(documentParagraphLineRange(content, 0)).toEqual({ startLine: 1, endLine: 2 });
     expect(documentParagraphLineRange(content, 1)).toEqual({ startLine: 5, endLine: 6 });
     expect(documentParagraphLineRange(content, 2)).toEqual({ startLine: 8, endLine: 8 });


### PR DESCRIPTION
## Summary

- add a versioned lightweight line-range index for chapter paragraphs
- reuse the same indexed line source for full-text, short-term, and pinyin search paths
- bound and self-repair legacy range fallbacks while rejecting stale paragraph mappings
- preserve chapter deduplication, snippets, ranking, and authorization boundaries

## Verification

- `npm run typecheck`
- `npx vitest run tests/unit/hybrid-search.test.ts tests/unit/database-migration.test.ts --maxWorkers=1`
- `npx vitest run tests/integration/hybrid-search.test.ts --maxWorkers=1`
- `npx vitest run tests/integration/user-auth-api.test.ts --maxWorkers=1 -t "模块权限默认拒绝未知路由|用户可重置 API Key"`
- `npm test` (187 files, 945 tests)
- `npm run build`
