### PR TITLE
MUXUE-72: optimize AI context reads

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -5367,11 +5367,7 @@ export class AiManager {
     if (name === "story_index") {
       const { offset, limit, cursor } = args as z.infer<typeof storyIndexArguments>;
       const work = this.store.getWork(workId);
-      const tree = this.store.getWorkTree(workId);
-      const summaries = new Map(this.store.listCurrentChapterInsights(workId).map((item) => [String(item.chapterId), String(item.summary)]));
-      const chapters = (tree.volumes as Record<string, unknown>[]).flatMap((volume) => (volume.chapters as Record<string, unknown>[]).map((chapter) => ({
-        id: String(chapter.id), volumeTitle: String(volume.title), title: String(chapter.title), versionNo: Number(chapter.versionNo), summary: summaries.get(String(chapter.id)) ?? ""
-      })));
+      const chapterPage = this.store.getStoryIndexChapterPage(workId, offset, limit);
       const workRecords = structuralToolResultRecords([{
         id: work.id,
         title: work.title,
@@ -5382,7 +5378,7 @@ export class AiManager {
         chapterCount: work.chapterCount,
         wordCount: work.wordCount
       }], maximumRecordChars).map((record) => ({ ...record, _toolResultSection: "work" }));
-      const chapterRecords = structuralToolResultRecords(chapters.slice(offset, offset + limit), maximumRecordChars)
+      const chapterRecords = structuralToolResultRecords(chapterPage.chapters, maximumRecordChars)
         .map((record) => ({ ...record, _toolResultSection: "chapter" }));
       const result = paginateToolResultRecords([...workRecords, ...chapterRecords], cursor, (page, pagination) => {
         const pageWork = page.flatMap((record) => {
@@ -5400,10 +5396,10 @@ export class AiManager {
           data: {
             ...(pageWork[0] ? { work: pageWork[0] } : {}),
             ...(pageWork.length > 1 ? { workFragments: pageWork } : {}),
-            totalChapters: chapters.length,
+            totalChapters: chapterPage.totalChapters,
             offset,
             chapters: pageChapters,
-            nextOffset: pagination.nextCursor === null && offset + limit < chapters.length ? offset + limit : null
+            nextOffset: pagination.nextCursor === null && offset + limit < chapterPage.totalChapters ? offset + limit : null
           },
           pagination
         };

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4349,23 +4349,33 @@ export class AiManager {
 
   private contextBudget(
     input: Pick<GenerateInput, "workId" | "taskType" | "instruction" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">,
-    model: ModelRow
+    model: ModelRow,
+    existingConversation?: AiConversationContext | null
   ): Record<string, unknown> {
     const contextWindow = numberValue(model, "context_window") || DEFAULT_CONTEXT_WINDOW;
     const preset = safeJsonObject(stringValue(model, "preset_json"));
     const configuredOutputTokens = typeof preset.max_tokens === "number" ? preset.max_tokens : DEFAULT_MAX_TOKENS;
     const outputReserveTokens = Math.max(MIN_OUTPUT_RESERVE_TOKENS, Math.min(configuredOutputTokens, Math.floor(contextWindow * 0.25), contextWindow - MIN_OUTPUT_RESERVE_TOKENS));
     const availableInputTokens = Math.max(256, contextWindow - outputReserveTokens - 512);
-    const conversation = input.conversationId
-      ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
-      : null;
+    const conversation = existingConversation === undefined
+      ? input.conversationId
+        ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
+        : null
+      : existingConversation;
     const renderedMemory = conversation?.summary ? renderConversationMemory(conversation.summary) : "";
     const conversationTokens = conversation
       ? estimateAiTokens(renderedMemory) + conversation.messages.reduce((total, message) => total + estimateAiTokens(message.content), 0)
       : 0;
     const conversationBudgetTokens = Math.max(256, Math.floor(availableInputTokens * 0.32));
     const instructionTokens = estimateAiTokens(input.instruction);
-    const functionTokens = estimateAiTokens(JSON.stringify(this.enabledAgentTools(input.workId, input.taskType, input.agentToolIds, input.conversationId)));
+    const roleplayCharacterId = this.roleplayCharacterIdFromConversation(input.workId, conversation);
+    const functionTokens = estimateAiTokens(JSON.stringify(this.enabledAgentTools(
+      input.workId,
+      input.taskType,
+      input.agentToolIds,
+      input.conversationId,
+      roleplayCharacterId
+    )));
     const workContextBudgetTokens = Math.max(256, availableInputTokens
       - Math.min(conversationTokens, conversationBudgetTokens)
       - Math.min(instructionTokens, Math.floor(availableInputTokens * 0.25))
@@ -4388,10 +4398,17 @@ export class AiManager {
   getContextUsage(input: Pick<GenerateInput, "workId" | "taskType" | "modelId" | "scope" | "instruction" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">): Record<string, unknown> {
     const { model } = this.resolveModel(input.workId, input.taskType, input.modelId);
     const budget = this.contextBudget(input, model);
+    const conversation = budget.conversation as AiConversationContext | null;
     const contextPlan = this.buildContextPlan(input, model, budget);
     const context = contextPlan.context;
-    const messages = this.buildMessages(input, context);
-    const tools = this.enabledAgentTools(input.workId, input.taskType, input.agentToolIds, input.conversationId);
+    const messages = this.buildMessages(input, context, conversation);
+    const tools = this.enabledAgentTools(
+      input.workId,
+      input.taskType,
+      input.agentToolIds,
+      input.conversationId,
+      this.roleplayCharacterIdFromConversation(input.workId, conversation)
+    );
     const contextWindow = numberValue(model, "context_window") || DEFAULT_CONTEXT_WINDOW;
     const messageTokens = messages.reduce((total, message) => total + estimateAiTokens(completionMessageText(message.content)), 0);
     const systemPromptTokens = estimateAiTokens(completionMessageText(messages[0]?.content));
@@ -4402,7 +4419,6 @@ export class AiManager {
     // 超窗时把可交互上下文压到剩余份额，保证五段分布之和始终等于 contextWindow。
     const contextInteractionTokens = Math.max(0, contextWindow - systemPromptTokens - functionTokens - skillsTokens - remainingTokens);
     const threshold = Math.min(90, Math.max(50, Number(this.store.getWorkAiSettings(input.workId).contextCompactThreshold) || 85));
-    const conversation = budget.conversation as AiConversationContext | null;
     const conversationUsagePercent = Number(budget.conversationUsagePercent) || 0;
     const configuredOutputTokens = Number(budget.configuredOutputTokens) || DEFAULT_MAX_TOKENS;
     const maxOutputUsagePercent = Math.min(100, Math.round(configuredOutputTokens / contextWindow * 100));
@@ -4507,8 +4523,7 @@ export class AiManager {
   ): Promise<Record<string, unknown>> {
     const inspection = this.inspectConversationContext(input);
     if (inspection.action === "ready") {
-      const conversation = this.store.getAiConversationContext(input.conversationId, input.workId);
-      if (conversation.warningPending) this.store.setAiConversationContextWarning(input.conversationId, false);
+      if (inspection.usage.contextWarningPending === true) this.store.setAiConversationContextWarning(input.conversationId, false);
       return inspection;
     }
     if (inspection.action === "warn" && !options.ignoreWarning) {
@@ -4577,7 +4592,7 @@ export class AiManager {
       input.excludeConversationMessageId
     );
     const { model } = this.resolveModel(input.workId, "chat", input.modelId);
-    const budget = this.contextBudget({ ...input, taskType: "chat", instruction: "" }, model);
+    const budget = this.contextBudget({ ...input, taskType: "chat", instruction: "" }, model, conversation);
     const recentTokenBudget = Math.max(128, Math.floor(Number(budget.conversationBudgetTokens) * 0.75));
     let retainedMessageCount = 0;
     let retainedTokens = 0;
@@ -4636,12 +4651,27 @@ export class AiManager {
     };
   }
 
-  private buildMessages(input: Pick<GenerateInput, "workId" | "taskType" | "instruction" | "extraSystemPrompt" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">, context: string): CompletionMessage[] {
-    const roleplayCharacterId = this.roleplayCharacterId(input.workId, input.conversationId);
+  private buildMessages(
+    input: Pick<GenerateInput, "workId" | "taskType" | "instruction" | "extraSystemPrompt" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">,
+    context: string,
+    existingConversation?: AiConversationContext | null
+  ): CompletionMessage[] {
+    const conversation = existingConversation === undefined
+      ? input.conversationId
+        ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
+        : null
+      : existingConversation;
+    const roleplayCharacterId = this.roleplayCharacterIdFromConversation(input.workId, conversation);
     const roleplayPrompt = roleplayCharacterId ? this.buildRoleplaySystemPrompt(roleplayCharacterId) : "";
     const platformPrompt = roleplayCharacterId ? "" : String(this.store.getPlatformAiSettings().systemPrompt ?? "").trim();
     const workPrompt = roleplayCharacterId ? "" : String(this.store.getWorkAiSettings(input.workId).systemPrompt ?? "").trim();
-    const enabledToolIds = this.enabledAgentToolIds(input.workId, input.taskType, input.agentToolIds, input.conversationId);
+    const enabledToolIds = this.enabledAgentToolIds(
+      input.workId,
+      input.taskType,
+      input.agentToolIds,
+      input.conversationId,
+      roleplayCharacterId
+    );
     const toolGuidance = enabledToolIds.includes("recall_self") || enabledToolIds.includes("recall_relationship")
       ? [
           `当前可用的内部记忆能力是：${enabledToolIds.join("、")}。不要向用户提及工具、调用过程、资料库或检索结果。`,
@@ -4725,9 +4755,6 @@ export class AiManager {
       input.instruction,
       { escape: false }
     );
-    const conversation = input.conversationId
-      ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
-      : null;
     if (!conversation) {
       return [
         { role: "system", content: systemPrompt },
@@ -4774,7 +4801,8 @@ export class AiManager {
     persistKeywordInjections = false
   ): ContextBuildPlan {
     const budget = existingBudget ?? this.contextBudget(input, model);
-    const roleplayCharacterId = this.roleplayCharacterId(input.workId, input.conversationId);
+    const conversation = budget.conversation as AiConversationContext | null;
+    const roleplayCharacterId = this.roleplayCharacterIdFromConversation(input.workId, conversation);
     const settings = this.store.getWorkAiSettings(input.workId);
     const configuredScope: ContextScope = {
       ...input.scope,
@@ -4867,14 +4895,20 @@ export class AiManager {
 
   private buildContext(
     input: Pick<GenerateInput, "workId" | "taskType" | "instruction" | "scope" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">,
-    model: ModelRow
+    model: ModelRow,
+    existingBudget?: Record<string, unknown>
   ): string {
-    return collapseAiBlankLines(this.buildContextPlan(input, model, undefined, true).context);
+    return collapseAiBlankLines(this.buildContextPlan(input, model, existingBudget, true).context);
   }
 
   private roleplayCharacterId(workId: string, conversationId?: string): string | null {
     if (!conversationId) return null;
     const conversation = this.store.getAiConversationContext(conversationId, workId);
+    return this.roleplayCharacterIdFromConversation(workId, conversation);
+  }
+
+  private roleplayCharacterIdFromConversation(workId: string, conversation: AiConversationContext | null): string | null {
+    if (!conversation) return null;
     if (conversation.roleplayCharacterId) {
       const permissions = this.store.getWork(workId).modulePermissions as WorkModulePermissions;
       if (!canReadWorkModule(permissions, "characters")) {
@@ -4915,9 +4949,17 @@ export class AiManager {
     ].join("\n");
   }
 
-  private enabledAgentToolIds(workId: string, taskType: TaskType, requestedToolIds?: AgentToolId[], conversationId?: string): AgentToolId[] {
+  private enabledAgentToolIds(
+    workId: string,
+    taskType: TaskType,
+    requestedToolIds?: AgentToolId[],
+    conversationId?: string,
+    roleplayCharacterIdOverride?: string | null
+  ): AgentToolId[] {
     if (taskType !== "chat" && requestedToolIds === undefined) return [];
-    const roleplayCharacterId = this.roleplayCharacterId(workId, conversationId);
+    const roleplayCharacterId = roleplayCharacterIdOverride === undefined
+      ? this.roleplayCharacterId(workId, conversationId)
+      : roleplayCharacterIdOverride;
     const permissions = this.store.getWork(workId).modulePermissions as WorkModulePermissions;
     if (roleplayCharacterId) {
       const requested = requestedToolIds ? new Set(requestedToolIds) : null;
@@ -4940,8 +4982,15 @@ export class AiManager {
       && this.canReadWithAgentTool(permissions, toolId));
   }
 
-  private enabledAgentTools(workId: string, taskType: TaskType, requestedToolIds?: AgentToolId[], conversationId?: string): Record<string, unknown>[] {
-    return this.enabledAgentToolIds(workId, taskType, requestedToolIds, conversationId).map((toolId) => AGENT_TOOL_DEFINITIONS[toolId]);
+  private enabledAgentTools(
+    workId: string,
+    taskType: TaskType,
+    requestedToolIds?: AgentToolId[],
+    conversationId?: string,
+    roleplayCharacterIdOverride?: string | null
+  ): Record<string, unknown>[] {
+    return this.enabledAgentToolIds(workId, taskType, requestedToolIds, conversationId, roleplayCharacterIdOverride)
+      .map((toolId) => AGENT_TOOL_DEFINITIONS[toolId]);
   }
 
   private canReadWithAgentTool(permissions: WorkModulePermissions, toolId: ConfiguredAgentToolId): boolean {
@@ -5634,7 +5683,10 @@ export class AiManager {
   }
 
   async generate(input: GenerateInput, onDelta?: (delta: string) => void): Promise<GenerateResult> {
-    const generationRoleplayCharacterId = this.roleplayCharacterId(input.workId, input.conversationId);
+    const conversation = input.conversationId
+      ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
+      : null;
+    const generationRoleplayCharacterId = this.roleplayCharacterIdFromConversation(input.workId, conversation);
     const { model, provider } = this.resolveModel(input.workId, input.taskType, input.modelId);
     const preset = safeJsonObject(stringValue(model, "preset_json"));
     const requestedParameters = {
@@ -5644,14 +5696,15 @@ export class AiManager {
     const configuredOutputTokens = Number(requestedParameters.max_tokens) || DEFAULT_MAX_TOKENS;
     const contextCompactThreshold = Math.min(90, Math.max(50, Number(this.store.getWorkAiSettings(input.workId).contextCompactThreshold) || 85));
     let effectiveInput = input;
-    let context = this.buildContext(effectiveInput, model);
-    let messages = this.buildMessages(effectiveInput, context);
+    let effectiveBudget = this.contextBudget(effectiveInput, model, conversation);
+    let context = this.buildContext(effectiveInput, model, effectiveBudget);
+    let messages = this.buildMessages(effectiveInput, context, conversation);
     const allowedToolIds = new Set(input.disableTools
       ? []
-      : this.enabledAgentToolIds(input.workId, input.taskType, input.agentToolIds, input.conversationId));
+      : this.enabledAgentToolIds(input.workId, input.taskType, input.agentToolIds, input.conversationId, generationRoleplayCharacterId));
     let tools = input.disableTools
       ? []
-      : this.enabledAgentTools(input.workId, input.taskType, input.agentToolIds, input.conversationId);
+      : this.enabledAgentTools(input.workId, input.taskType, input.agentToolIds, input.conversationId, generationRoleplayCharacterId);
     let parameters: Record<string, unknown>;
     try {
       parameters = this.constrainParametersForContext(model, messages, requestedParameters, tools);
@@ -5659,8 +5712,9 @@ export class AiManager {
       if (!(error instanceof AppError) || error.code !== "CONTEXT_WINDOW_EXCEEDED") throw error;
       if (tools.length === 0) throw initialContextWindowError(error, provider, model);
       effectiveInput = { ...input, agentToolIds: [] };
-      context = this.buildContext(effectiveInput, model);
-      messages = this.buildMessages(effectiveInput, context);
+      effectiveBudget = this.contextBudget(effectiveInput, model, conversation);
+      context = this.buildContext(effectiveInput, model, effectiveBudget);
+      messages = this.buildMessages(effectiveInput, context, conversation);
       tools = [];
       allowedToolIds.clear();
       try {

--- a/src/store.ts
+++ b/src/store.ts
@@ -7603,21 +7603,51 @@ export class Store {
     const conversation = this.db.get("SELECT * FROM ai_conversations WHERE id = ?", conversationId);
     if (!conversation) throw notFound("AI 对话");
     if (requiredString(conversation, "work_id") !== workId) throw new AppError(400, "CONVERSATION_WORK_MISMATCH", "AI 对话不属于当前作品");
-    const rows = this.db.all(
-      "SELECT id, role, content, metadata_json FROM ai_conversation_messages WHERE conversation_id = ? ORDER BY created_at, rowid",
+    const countRow = this.db.get(
+      "SELECT COUNT(*) AS count FROM ai_conversation_messages WHERE conversation_id = ?",
       conversationId
     );
-    const compactedMessageCount = Math.min(rows.length, Math.max(0, numberValue(conversation, "compacted_message_count")));
+    const totalMessageCount = numberValue(countRow ?? {}, "count");
+    const compactedMessageCount = Math.min(totalMessageCount, Math.max(0, numberValue(conversation, "compacted_message_count")));
+    const tailMessageCount = totalMessageCount - compactedMessageCount;
+    let rows: Row[] = [];
+    if (tailMessageCount > 0 && compactedMessageCount === 0) {
+      rows = this.db.all(
+        `SELECT id, role, content, metadata_json FROM ai_conversation_messages
+         WHERE conversation_id = ? ORDER BY created_at, rowid LIMIT ?`,
+        conversationId,
+        tailMessageCount
+      );
+    } else if (tailMessageCount > 0) {
+      const boundary = this.db.get(
+        `SELECT created_at, rowid FROM ai_conversation_messages
+         WHERE conversation_id = ? ORDER BY created_at, rowid LIMIT 1 OFFSET ?`,
+        conversationId,
+        compactedMessageCount - 1
+      );
+      if (boundary) {
+        rows = this.db.all(
+          `SELECT id, role, content, metadata_json FROM ai_conversation_messages
+           WHERE conversation_id = ?
+             AND (created_at > ? OR (created_at = ? AND rowid > ?))
+           ORDER BY created_at, rowid LIMIT ?`,
+          conversationId,
+          requiredString(boundary, "created_at"),
+          requiredString(boundary, "created_at"),
+          numberValue(boundary, "rowid"),
+          tailMessageCount
+        );
+      }
+    }
     return {
       workId,
       roleplayCharacterId: optionalString(conversation, "roleplay_character_id"),
       summary: requiredString(conversation, "compacted_summary"),
       compactedMessageCount,
-      totalMessageCount: rows.length,
+      totalMessageCount,
       warningPending: Boolean(optionalString(conversation, "context_warning_at")),
       injectedEntities: parseAiInjectedEntities(optionalString(conversation, "injected_entities_json") ?? EMPTY_AI_INJECTED_ENTITIES),
-      messages: rows.slice(compactedMessageCount)
-        .filter((message) => requiredString(message, "id") !== excludeMessageId)
+      messages: rows.filter((message) => requiredString(message, "id") !== excludeMessageId)
         .map((message) => ({
           id: requiredString(message, "id"),
           role: requiredString(message, "role") === "assistant" ? "assistant" : "user",

--- a/src/store.ts
+++ b/src/store.ts
@@ -579,6 +579,17 @@ export type AiConversationTitleContext = {
   messages: Array<{ role: "user" | "assistant"; content: string }>;
 };
 
+export type StoryIndexChapterPage = {
+  totalChapters: number;
+  chapters: Array<{
+    id: string;
+    volumeTitle: string;
+    title: string;
+    versionNo: number;
+    summary: string;
+  }>;
+};
+
 type RestorableFileSnapshotChapter = {
   title: string;
   content: string;
@@ -1923,6 +1934,62 @@ export class Store {
       chapters: chaptersByVolume.get(requiredString(row, "id")) ?? []
     }));
     return { ...work, volumes, directoryPage: pageResult };
+  }
+
+  getStoryIndexChapterPage(workId: string, offset: number, limit: number): StoryIndexChapterPage {
+    const work = this.getWork(workId);
+    const permissions = work.modulePermissions as WorkModulePermissions;
+    if (permissions.prose === "none") return { totalChapters: 0, chapters: [] };
+    const countRow = this.db.get(
+      `SELECT COUNT(*) AS count FROM chapters chapter
+       JOIN volumes volume ON volume.id = chapter.volume_id
+       WHERE chapter.work_id = ? AND chapter.deleted_at IS NULL AND volume.deleted_at IS NULL`,
+      workId
+    );
+    const chapterRows = this.db.all(
+      `SELECT chapter.id, chapter.title, chapter.version_no, volume.title AS volume_title
+       FROM chapters chapter
+       JOIN volumes volume ON volume.id = chapter.volume_id
+       WHERE chapter.work_id = ? AND chapter.deleted_at IS NULL AND volume.deleted_at IS NULL
+       ORDER BY volume.sort_order, volume.created_at, chapter.sort_order, chapter.created_at
+       LIMIT ? OFFSET ?`,
+      workId,
+      limit,
+      offset
+    );
+    const chapterIds = chapterRows.map((row) => requiredString(row, "id"));
+    const summaries = new Map<string, string>();
+    if (chapterIds.length > 0) {
+      const placeholders = chapterIds.map(() => "?").join(", ");
+      const insightRows = this.db.all(
+        `SELECT insight.chapter_id, insight.summary
+         FROM chapter_insights insight
+         JOIN chapters chapter ON chapter.id = insight.chapter_id AND chapter.version_no = insight.chapter_version
+         WHERE chapter.work_id = ? AND insight.chapter_id IN (${placeholders})
+           AND NOT EXISTS (
+             SELECT 1 FROM chapter_insights newer
+             WHERE newer.chapter_id = insight.chapter_id
+               AND newer.chapter_version = insight.chapter_version
+               AND (newer.created_at > insight.created_at OR (newer.created_at = insight.created_at AND newer.id > insight.id))
+           )`,
+        workId,
+        ...chapterIds
+      );
+      for (const row of insightRows) summaries.set(requiredString(row, "chapter_id"), requiredString(row, "summary"));
+    }
+    return {
+      totalChapters: numberValue(countRow ?? {}, "count"),
+      chapters: chapterRows.map((row) => {
+        const chapterId = requiredString(row, "id");
+        return {
+          id: chapterId,
+          volumeTitle: requiredString(row, "volume_title"),
+          title: requiredString(row, "title"),
+          versionNo: numberValue(row, "version_no"),
+          summary: summaries.get(chapterId) ?? ""
+        };
+      })
+    };
   }
 
   listFileVersions(workId: string): Record<string, unknown>[] {

--- a/tests/e2e/real-ai-agent-tools.ts
+++ b/tests/e2e/real-ai-agent-tools.ts
@@ -153,18 +153,21 @@ const mockAi = createServer(async (incoming, outgoing) => {
         toolCalls(outgoing, [{ id: "multi-index", name: "story_index", arguments: { limit: 1 } }]);
         return;
       }
-      if (results.size === 1) {
+      if (results.has("multi-read")) {
+        const readData = object(object(results.get("multi-read")).data);
+        assert.match(String(object(array(readData.chapters)[0]).content), /林舟启动跃迁/u);
+        multiTurnVerified = true;
+        completion(outgoing, { content: "已先定位章节，再根据正文确认林舟启动了跃迁。" });
+        return;
+      }
+      if (results.has("multi-index")) {
         const indexData = object(object(results.get("multi-index")).data);
         const firstChapter = object(array(indexData.chapters)[0]);
         assert.equal(firstChapter.id, chapterIds[0]);
         toolCalls(outgoing, [{ id: "multi-read", name: "read_chapters", arguments: { chapterIds: [String(firstChapter.id)], include: "content" } }]);
         return;
       }
-      const readData = object(object(results.get("multi-read")).data);
-      assert.match(String(object(array(readData.chapters)[0]).content), /林舟启动跃迁/u);
-      multiTurnVerified = true;
-      completion(outgoing, { content: "已先定位章节，再根据正文确认林舟启动了跃迁。" });
-      return;
+      throw new Error("Expected multi-turn tool results were not found.");
     }
     if (joined.includes("结构化中文长期记忆")) {
       assert.equal(body.tools, undefined);
@@ -269,9 +272,13 @@ try {
   const model = await api<JsonObject>("POST", `/providers/${String(provider.id)}/models`, {
     displayName: "E2E Agent Model",
     modelId: "e2e-agent-model",
-    contextWindow: 32_768
+    contextWindow: 32_768,
+    preset: { max_tokens: 4_096 }
   });
   const modelId = String(model.id);
+  await api("PATCH", `/works/${workId}/ai-settings`, {
+    agentTools: ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts"]
+  });
 
   const matrix = await api<JsonObject>("POST", `/works/${workId}/suggestions`, {
     taskType: "chat",
@@ -380,9 +387,18 @@ try {
   assert.equal(contextUsage.compactRecommended, true);
   assert.equal(Number(contextUsage.usagePercent) >= 50, true);
   assert.equal(contextUsage.contextWarningPending, true);
-  const compacted = await api<JsonObject>("POST", `/ai-conversations/${conversationId}/context/prepare`, prepareBody);
-  assert.equal(compacted.action, "compacted");
-  assert.equal(object(compacted.compaction).compactedMessageCount, 2);
+  const ignored = await api<JsonObject>("POST", `/ai-conversations/${conversationId}/context/prepare`, {
+    ...prepareBody,
+    ignoreContextWarning: true
+  });
+  assert.equal(ignored.action, "ready");
+  assert.equal(ignored.reason, "warning_ignored");
+  const compacted = await api<JsonObject>("POST", `/ai-conversations/${conversationId}/compact`, {
+    modelId,
+    scope: prepareBody.scope
+  });
+  assert.equal(compacted.changed, true);
+  assert.equal(compacted.compactedMessageCount, 2);
   assert.equal(compactRequestVerified, true);
   const current = await api<JsonObject>("POST", `/ai-conversations/${conversationId}/messages`, { role: "user", content: "E2E_AFTER_COMPACT" });
   const followup = await fetch(`${baseUrl}/api/works/${workId}/chat/stream`, {

--- a/tests/integration/ai-context-compact.test.ts
+++ b/tests/integration/ai-context-compact.test.ts
@@ -344,6 +344,41 @@ describe("AI 对话上下文压缩", () => {
     expect(compacted.body.data.memoryItemCount).toBeGreaterThan(0);
   });
 
+  it("上下文估算和压缩复用同一份未压缩尾部快照", async () => {
+    const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
+    const conversationId = conversation.body.data.id;
+    for (let index = 0; index < 12; index += 1) {
+      await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `第 ${index + 1} 条对话，记录跃迁计划。`
+      }).expect(201);
+    }
+    const contextSpy = vi.spyOn(runtime.store, "getAiConversationContext");
+
+    const usage = runtime.ai.getContextUsage({
+      workId,
+      taskType: "chat",
+      modelId,
+      scope: { type: "chapter", chapterId },
+      instruction: "继续整理跃迁计划。",
+      conversationId
+    });
+
+    expect(usage).toMatchObject({ conversationTokens: expect.any(Number), compactedMessageCount: 0 });
+    expect(Number(usage.conversationTokens)).toBeGreaterThan(0);
+    expect(contextSpy).toHaveBeenCalledTimes(1);
+
+    contextSpy.mockClear();
+    const compacted = await runtime.ai.compactConversation({
+      workId,
+      modelId,
+      scope: { type: "chapter", chapterId },
+      conversationId
+    });
+    expect(compacted).toMatchObject({ compactedMessageCount: 4, retainedMessageCount: 8, changed: true });
+    expect(contextSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("正文区块过长时降级正文并标记上下文兜底", async () => {
     runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 16_384, modelId);
     runtime.store.saveChapter(chapterId, { content: `当前章节开头。${"非常长的章节正文。".repeat(2_000)}当前章节结尾。` });

--- a/tests/unit/store-ai-conversation-context.test.ts
+++ b/tests/unit/store-ai-conversation-context.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import { createTestRuntime } from "../helpers.js";
+
+describe("AI 对话上下文按需读取", () => {
+  let runtime: Runtime | null = null;
+
+  afterEach(async () => {
+    await runtime?.close();
+    runtime = null;
+  });
+
+  function createConversation(): { workId: string; conversationId: string } {
+    runtime = createTestRuntime();
+    const work = runtime.store.createWork({ title: "上下文读取测试", author: "测试作者" });
+    const conversation = runtime.store.createAiConversation(String(work.id));
+    return { workId: String(work.id), conversationId: String(conversation.id) };
+  }
+
+  it("覆盖空历史和未压缩历史并保持消息顺序", () => {
+    const { workId, conversationId } = createConversation();
+    const empty = runtime!.store.getAiConversationContext(conversationId, workId);
+    expect(empty).toMatchObject({ totalMessageCount: 0, compactedMessageCount: 0, messages: [] });
+
+    const first = runtime!.store.addAiConversationMessage(conversationId, { role: "user", content: "第一条" });
+    const second = runtime!.store.addAiConversationMessage(conversationId, { role: "assistant", content: "第二条" });
+    const allSpy = vi.spyOn(runtime!.database, "all");
+
+    const context = runtime!.store.getAiConversationContext(conversationId, workId);
+
+    expect(context).toMatchObject({ totalMessageCount: 2, compactedMessageCount: 0 });
+    expect(context.messages.map((message) => ({ id: message.id, role: message.role, content: message.content }))).toEqual([
+      { id: first.id, role: "user", content: "第一条" },
+      { id: second.id, role: "assistant", content: "第二条" }
+    ]);
+    const tailCall = allSpy.mock.calls.find(([sql]) => String(sql).includes("ORDER BY created_at, rowid LIMIT ?"));
+    expect(tailCall?.slice(1)).toEqual([conversationId, 2]);
+  });
+
+  it("以压缩边界为游标只读取未压缩尾部，追加消息后不遗漏或重复", () => {
+    const { workId, conversationId } = createConversation();
+    const hugeOldContent = `旧消息：${"不会进入上下文。".repeat(50_000)}`;
+    const messages = Array.from({ length: 6 }, (_, index) => runtime!.store.addAiConversationMessage(conversationId, {
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: index < 4 ? `${hugeOldContent}${index}` : `尾部消息 ${index + 1}`
+    }));
+    const sharedTimestamp = "2020-01-01T00:00:00.000Z";
+    runtime!.database.run(
+      "UPDATE ai_conversation_messages SET created_at = ? WHERE conversation_id = ?",
+      sharedTimestamp,
+      conversationId
+    );
+    runtime!.database.run(
+      "UPDATE ai_conversations SET compacted_summary = ?, compacted_message_count = ? WHERE id = ?",
+      JSON.stringify({ constraints: [{ text: "旧消息已压缩", sourceMessageIds: messages.slice(0, 4).map((message) => String(message.id)) }] }),
+      4,
+      conversationId
+    );
+    const getSpy = vi.spyOn(runtime!.database, "get");
+    const allSpy = vi.spyOn(runtime!.database, "all");
+
+    const context = runtime!.store.getAiConversationContext(conversationId, workId);
+
+    expect(context).toMatchObject({ totalMessageCount: 6, compactedMessageCount: 4 });
+    expect(context.messages.map((message) => message.content)).toEqual(["尾部消息 5", "尾部消息 6"]);
+    expect(JSON.stringify(context.messages)).not.toContain("不会进入上下文");
+    const boundaryCall = getSpy.mock.calls.find(([sql]) => String(sql).includes("SELECT created_at, rowid"));
+    expect(boundaryCall?.slice(1)).toEqual([conversationId, 3]);
+    const tailCall = allSpy.mock.calls.find(([sql]) => String(sql).includes("AND (created_at > ?"));
+    expect(tailCall?.[1]).toBe(conversationId);
+    expect(tailCall?.at(-1)).toBe(2);
+
+    const appended = runtime!.store.addAiConversationMessage(conversationId, { role: "user", content: "并发追加的尾部消息" });
+    const appendedContext = runtime!.store.getAiConversationContext(conversationId, workId);
+    expect(appendedContext).toMatchObject({ totalMessageCount: 7, compactedMessageCount: 4 });
+    expect(appendedContext.messages.map((message) => message.id)).toEqual([messages[4]?.id, messages[5]?.id, appended.id]);
+
+    const fullHistory = runtime!.store.getAiConversation(conversationId);
+    expect(fullHistory.messageCount).toBe(7);
+    expect((fullHistory.messages as Array<Record<string, unknown>>)[0]?.content).toContain("不会进入上下文");
+  });
+});

--- a/tests/unit/store-story-index.test.ts
+++ b/tests/unit/store-story-index.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import { createTestRuntime } from "../helpers.js";
+
+describe("story_index 目录读取", () => {
+  let runtime: Runtime | null = null;
+
+  afterEach(async () => {
+    await runtime?.close();
+    runtime = null;
+  });
+
+  it("只读取当前页目录字段和当前页摘要，不加载长篇正文", () => {
+    runtime = createTestRuntime();
+    const work = runtime.store.createWork({ title: "长篇目录", author: "测试作者" });
+    const firstVolume = runtime.store.createVolume(String(work.id), { title: "第一卷" });
+    const secondVolume = runtime.store.createVolume(String(work.id), { title: "第二卷" });
+    const hugeContent = "正文内容".repeat(100_000);
+    const chapters = [
+      runtime.store.createChapter(String(work.id), { volumeId: String(firstVolume.id), title: "第一章", content: hugeContent }),
+      runtime.store.createChapter(String(work.id), { volumeId: String(firstVolume.id), title: "第二章", content: hugeContent }),
+      runtime.store.createChapter(String(work.id), { volumeId: String(secondVolume.id), title: "第三章", content: hugeContent }),
+      runtime.store.createChapter(String(work.id), { volumeId: String(secondVolume.id), title: "第四章", content: hugeContent })
+    ];
+    const timestamp = new Date().toISOString();
+    for (const [index, chapter] of chapters.entries()) {
+      runtime.database.run(
+        `INSERT INTO chapter_insights (
+           id, chapter_id, chapter_version, summary, events_json, characters_json,
+           settings_json, evidence_json, uncertainties_json, status, created_at
+         ) VALUES (?, ?, ?, ?, '[]', '[]', '[]', '[]', '[]', 'review', ?)`,
+        `story-index-insight-${index}`,
+        String(chapter.id),
+        Number(chapter.versionNo),
+        `第 ${index + 1} 章摘要`,
+        timestamp
+      );
+    }
+    const allSpy = vi.spyOn(runtime.database, "all");
+
+    const page = runtime.store.getStoryIndexChapterPage(String(work.id), 1, 2);
+
+    expect(page).toEqual({
+      totalChapters: 4,
+      chapters: [
+        { id: chapters[1]?.id, volumeTitle: "第一卷", title: "第二章", versionNo: 1, summary: "第 2 章摘要" },
+        { id: chapters[2]?.id, volumeTitle: "第二卷", title: "第三章", versionNo: 1, summary: "第 3 章摘要" }
+      ]
+    });
+    expect(JSON.stringify(page)).not.toContain("正文内容");
+
+    const chapterPageCall = allSpy.mock.calls.find(([sql]) => String(sql).includes("SELECT chapter.id, chapter.title"));
+    expect(chapterPageCall).toBeDefined();
+    expect(String(chapterPageCall?.[0])).not.toMatch(/chapter\.content|SELECT\s+\*/iu);
+    expect(chapterPageCall?.slice(1)).toEqual([work.id, 2, 1]);
+
+    const insightCall = allSpy.mock.calls.find(([sql]) => String(sql).includes("SELECT insight.chapter_id, insight.summary"));
+    expect(insightCall?.slice(1)).toEqual([work.id, chapters[1]?.id, chapters[2]?.id]);
+    expect(insightCall?.slice(1)).not.toContain(chapters[0]?.id);
+    expect(insightCall?.slice(1)).not.toContain(chapters[3]?.id);
+  });
+});


### PR DESCRIPTION
## Summary

- implement SVE-4-006 by paging `story_index` directory fields and loading insights only for the returned chapter IDs
- implement SVE-4-007 by reading conversation counts, compaction boundaries, and uncompacted tails separately
- reuse one conversation-tail snapshot across context estimation, message building, generation, and compaction
- keep full conversation history APIs unchanged and add regression coverage for ordering, boundaries, appends, and large fixtures

## Verification

- `npm run typecheck`
- `npm run test:unit` (500 tests)
- integration suite split into bounded Vitest groups (374 tests)
- `npm run test:system` (77 tests)
- `npm run build`
- isolated SQLite `PRAGMA integrity_check` and `PRAGMA foreign_key_check`
- isolated production health check at `/api/health`

The aggregate `npm test` process was interrupted by the local resource limit without a Vitest assertion failure; the same 951 unit, integration, and system tests passed in bounded invocations.
