### PR TITLE
chore(release): bump version to 0.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.7",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.7",
+      "version": "0.7.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.7",
+  "version": "0.7.9",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.7";
+export const APP_VERSION = "0.7.9";


### PR DESCRIPTION
将应用版本来源统一更新至 0.7.9，作为下一次补丁版本发布准备。

验证：
- `npm exec vitest run tests/unit/version.test.ts --maxWorkers=1`
- `git diff --check`