### PR TITLE
docs(github): add bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report / 缺陷报告
+about: Report a reproducible problem / 报告可复现的问题
+title: "[Bug] "
+labels: "bug"
+assignees: ""
+---
+
+## Problem Summary / 问题概述
+
+<!-- Briefly describe the problem in one or two sentences.
+请用一到两句话简要描述问题。 -->
+
+## Steps to Reproduce / 复现步骤
+
+1.
+2.
+3.
+
+## Expected Behavior / 预期行为
+
+<!-- What did you expect to happen?
+你原本期望发生什么？ -->
+
+## Actual Behavior / 实际行为
+
+<!-- What happened instead? Include the exact error message if available.
+实际发生了什么？如有错误信息，请提供完整内容。 -->
+
+## Environment / 环境信息
+
+- Scriverse version / Scriverse 版本:
+- Operating system / 操作系统:
+- Browser and version (if applicable) / 浏览器及版本（如适用）:
+- Installation or deployment method / 安装或部署方式:
+
+## Logs, Screenshots, or Recordings / 日志、截图或录屏
+
+<!-- Remove any sensitive information before posting.
+发布前请移除敏感信息。 -->
+
+```text
+Paste relevant logs here / 在此粘贴相关日志
+```
+
+## Additional Context / 补充信息
+
+<!-- Add any other context, workarounds, or related issues.
+补充其他背景、临时解决方法或相关 issue。 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request / 功能请求
+about: Suggest an idea or improvement / 提议新功能或改进
+title: "[Feature] "
+labels: "enhancement"
+assignees: ""
+---
+
+## Problem or Opportunity / 问题或机会
+
+<!-- What problem would this feature solve, or what opportunity would it address?
+这个功能要解决什么问题，或应对什么机会？ -->
+
+## Proposed Solution / 建议方案
+
+<!-- Describe the behavior or solution you would like.
+请描述你希望实现的行为或方案。 -->
+
+## Alternatives Considered / 备选方案
+
+<!-- Describe any alternative solutions or workarounds you have considered.
+请描述你考虑过的其他方案或临时解决方法。 -->
+
+## Use Case / 使用场景
+
+<!-- Explain who would use this feature and how it would help.
+请说明谁会使用这个功能，以及它能带来什么帮助。 -->
+
+## Additional Context / 补充信息
+
+<!-- Add mockups, examples, references, or related issues if available.
+如有可用的原型图、示例、参考资料或相关 issue，请附上。 -->


### PR DESCRIPTION
## 变更内容

- 新增中英双语 Bug Report 模板。
- 新增中英双语 Feature Request 模板。
- 覆盖复现步骤、预期与实际行为、环境、日志、使用场景和备选方案。

## 影响

统一 GitHub Issue 的缺陷报告和功能请求信息收集格式，降低沟通成本。

## 验证

- `git diff --check` 通过。
- 模板 front matter 和 Markdown 内容已检查。

## 关联

- Commit `9a749860`
