### PR TITLE
chore(release): bump version to 0.7.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.9";
+export const APP_VERSION = "0.7.10";


### PR DESCRIPTION
## 变更

将 Scriverse 版本从 `0.7.9` 更新为 `0.7.10`。

## 同步来源

- `package.json`
- `package-lock.json` 顶层版本
- `package-lock.json` 根包版本
- `src/version.ts` 的 `APP_VERSION`

## 发布审计

`develop` 相对 `main` 的改动没有涉及 CLI 命令、API 契约、认证权限、导入导出格式，因此无需额外同步 CLI。

## 验证

- `tests/unit/version.test.ts` 通过。
- 提交前已执行 `git diff --check`。
