### PR TITLE
MUXUE-73: index planned foreshadow payoff lookups

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -7,9 +7,9 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态。
+// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询。
 export const ENTITY_VERSION_BASELINE_MIGRATION_VERSION = 82;
-export const DATABASE_SCHEMA_VERSION = 92;
+export const DATABASE_SCHEMA_VERSION = 93;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -814,6 +814,7 @@ export class Database {
       CREATE INDEX IF NOT EXISTS idx_organizations_work ON organizations(work_id, name);
       CREATE INDEX IF NOT EXISTS idx_memberships_organization ON character_organization_memberships(organization_id, character_id);
       CREATE INDEX IF NOT EXISTS idx_foreshadows_work ON foreshadows(work_id, status, importance);
+      CREATE INDEX IF NOT EXISTS idx_foreshadows_work_payoff_status ON foreshadows(work_id, planned_payoff_chapter_id, status);
       CREATE INDEX IF NOT EXISTS idx_foreshadow_occurrences_chapter ON foreshadow_occurrences(chapter_id, role);
       CREATE INDEX IF NOT EXISTS idx_continuation_guards_suggestion ON continuation_guard_runs(suggestion_id, created_at DESC);
     `);
@@ -3579,6 +3580,18 @@ export class Database {
         }
         this.run("CREATE INDEX IF NOT EXISTS idx_ai_conversations_favorite ON ai_conversations(work_id, is_favorite, updated_at DESC, created_at DESC)");
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (92, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    if (!applied.has(93)) {
+      this.transaction(() => {
+        this.run("CREATE INDEX IF NOT EXISTS idx_foreshadows_work_payoff_status ON foreshadows(work_id, planned_payoff_chapter_id, status)");
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (93, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -823,6 +823,27 @@ describe("书架、别名、大纲伏笔和一致性守卫 API", () => {
       versions: runtime.database.get("SELECT COUNT(*) AS count FROM entity_versions")?.count
     }).toEqual(beforeRead);
 
+    const sortedPayoffA = await request(runtime.app).post(`/api/works/${workId}/foreshadows`).send({
+      title: "潮门密钥",
+      status: "planned",
+      plannedPayoffChapterId: chapters[2].id
+    }).expect(201);
+    const sortedPayoffB = await request(runtime.app).post(`/api/works/${workId}/foreshadows`).send({
+      title: "港口暗号",
+      status: "planted",
+      plannedPayoffChapterId: chapters[2].id
+    }).expect(201);
+    const sorted = await request(runtime.app).get(`/api/works/${workId}/outline-board?sort=foreshadows`).expect(200);
+    expect(sorted.body.data.volumes[0].chapters.map((chapter: { id: string }) => chapter.id)).toEqual([
+      chapters[2].id,
+      chapters[0].id,
+      chapters[1].id
+    ]);
+    expect(sorted.body.data.volumes[0].chapters[0].foreshadows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: sortedPayoffA.body.data.id, roles: [], plannedPayoff: true }),
+      expect.objectContaining({ id: sortedPayoffB.body.data.id, roles: [], plannedPayoff: true })
+    ]));
+
     const otherWork = await seedWork(runtime, "隔离作品大纲");
     await request(runtime.app).put(`/api/chapters/${otherWork.chapters[0].id}/outline`).send({ goal: "CROSS_WORK_OUTLINE_SECRET" }).expect(200);
     const isolated = await request(runtime.app).get(`/api/works/${workId}/outline-board`).expect(200);

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -1364,4 +1364,114 @@ describe("数据库版本化迁移", () => {
     expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
     migrated.close();
   });
+
+  it("迁移 93 为既有库补建伏笔计划回收章节索引并优化直接关联查询", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-foreshadow-payoff-index-existing-"));
+    roots.push(root);
+    const filename = join(root, "foreshadow-payoff-index-existing.db");
+    const current = new Database(filename);
+    const timestamp = "2026-08-15T00:00:00.000Z";
+    current.run(
+      `INSERT INTO works (id, title, created_at, updated_at)
+       VALUES ('work-payoff-index', '伏笔索引迁移', ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO volumes (id, work_id, title, sort_order, created_at, updated_at)
+       VALUES ('volume-payoff-index', 'work-payoff-index', '第一卷', 0, ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO chapters (id, work_id, volume_id, title, sort_order, created_at, updated_at)
+       VALUES ('chapter-payoff-index', 'work-payoff-index', 'volume-payoff-index', '第一章', 0, ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run(
+      `INSERT INTO foreshadows
+         (id, work_id, title, status, importance, planned_payoff_chapter_id, created_at, updated_at)
+       VALUES ('foreshadow-before-index', 'work-payoff-index', '迁移前伏笔', 'planted', 'high',
+         'chapter-payoff-index', ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    current.run("DROP INDEX idx_foreshadows_work_payoff_status");
+    current.run("DELETE FROM schema_migrations WHERE version = 93");
+    current.close();
+
+    const migrated = new Database(filename);
+    expect(migrated.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 93")).toEqual({ count: 1 });
+    expect(migrated.all("PRAGMA index_xinfo('idx_foreshadows_work_payoff_status')")
+      .filter((column) => column.key === 1)
+      .map((column) => column.name)).toEqual(["work_id", "planned_payoff_chapter_id", "status"]);
+    expect(migrated.get("SELECT title FROM foreshadows WHERE id = 'foreshadow-before-index'")).toEqual({ title: "迁移前伏笔" });
+
+    const statusFilterPlan = migrated.all(
+      `EXPLAIN QUERY PLAN SELECT chapter.id FROM chapters chapter
+       WHERE chapter.work_id = ? AND EXISTS (
+         SELECT 1 FROM foreshadows foreshadow
+         WHERE foreshadow.work_id = chapter.work_id
+           AND foreshadow.planned_payoff_chapter_id = chapter.id
+           AND foreshadow.status IN ('planned', 'planted')
+       )`,
+      "work-payoff-index"
+    );
+    expect(statusFilterPlan.some((step) => String(step.detail).includes(
+      "USING COVERING INDEX idx_foreshadows_work_payoff_status (work_id=? AND planned_payoff_chapter_id=? AND status=?)"
+    ))).toBe(true);
+
+    const searchPlan = migrated.all(
+      `EXPLAIN QUERY PLAN SELECT chapter.id FROM chapters chapter
+       WHERE chapter.work_id = ? AND EXISTS (
+         SELECT 1 FROM foreshadows foreshadow
+         WHERE foreshadow.work_id = chapter.work_id
+           AND foreshadow.planned_payoff_chapter_id = chapter.id
+           AND lower(foreshadow.title) LIKE ? ESCAPE '\\'
+       )`,
+      "work-payoff-index",
+      "%迁移前伏笔%"
+    );
+    expect(searchPlan.some((step) => String(step.detail).includes(
+      "USING INDEX idx_foreshadows_work_payoff_status (work_id=? AND planned_payoff_chapter_id=?)"
+    ))).toBe(true);
+
+    const associationPlan = migrated.all(
+      `EXPLAIN QUERY PLAN SELECT chapter.id, foreshadow.id
+       FROM chapters chapter
+       JOIN foreshadows foreshadow ON foreshadow.planned_payoff_chapter_id = chapter.id
+       WHERE chapter.id IN (?) AND chapter.work_id = ? AND chapter.deleted_at IS NULL
+         AND foreshadow.work_id = ?`,
+      "chapter-payoff-index",
+      "work-payoff-index",
+      "work-payoff-index"
+    );
+    expect(associationPlan.some((step) => String(step.detail).includes(
+      "USING INDEX idx_foreshadows_work_payoff_status (work_id=? AND planned_payoff_chapter_id=?)"
+    ))).toBe(true);
+    expect(migrated.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
+    migrated.close();
+  });
+
+  it("迁移 93 在空库预建索引后可幂等登记并重启", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-foreshadow-payoff-index-fresh-"));
+    roots.push(root);
+    const filename = join(root, "foreshadow-payoff-index-fresh.db");
+
+    const first = new Database(filename);
+    expect(first.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 93")).toEqual({ count: 1 });
+    expect(first.all("PRAGMA index_list(foreshadows)")
+      .filter((index) => index.name === "idx_foreshadows_work_payoff_status")).toHaveLength(1);
+    first.close();
+
+    const restarted = new Database(filename);
+    expect(restarted.get("SELECT COUNT(*) AS count FROM schema_migrations WHERE version = 93")).toEqual({ count: 1 });
+    expect(restarted.all("PRAGMA index_list(foreshadows)")
+      .filter((index) => index.name === "idx_foreshadows_work_payoff_status")).toHaveLength(1);
+    expect(restarted.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(restarted.all("PRAGMA foreign_key_check")).toEqual([]);
+    restarted.close();
+  });
 });


### PR DESCRIPTION
## Summary
- add schema migration 93 with a three-column planned payoff lookup index
- verify status filtering, direct-title search, and batch association plans use the index
- preserve outline-board filtering, sorting, deduplication, and ownership semantics with regression coverage

## Verification
- `npm run typecheck`
- `npm run test:database-upgrade`
- `npx vitest run tests/unit/database-migration.test.ts --maxWorkers=1`
- `npx vitest run tests/integration/feature-suite-api.test.ts --maxWorkers=1`
- `npm test`
- `npm run build`

Closes MUXUE-73

Follow-up for the remaining association-count sort scan: MUXUE-75