### PR TITLE
chore(release): bump version to 0.7.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.10";
+export const APP_VERSION = "0.7.11";


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 顶层与根包、`src/version.ts` 同步 bump 到 `0.7.11`。

## 验证

- 相关回归测试：4 个测试文件、102 个测试通过。
- `npm run typecheck` 通过。
- `npm test`：190 个测试文件、961 个测试通过。
- `npm run build` 通过。
- `npm run check` 通过。
- 隔离数据库健康检查返回 `status: ok`，`PRAGMA integrity_check` 返回 `ok`，`PRAGMA foreign_key_check` 无结果。

## 发布审计

- `develop` 相对 `main` 的 CLI 契约审计完成，本次变更无需同步 CLI。
- 版本提交仅包含三个版本来源文件，无数据库或用户数据变更。
