### PR TITLE
MUXUE-75: preaggregate foreshadow sort counts

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -428,6 +428,30 @@ type ChapterOutlineBoardFilters = {
   sort: "tree" | "status" | "foreshadows" | "title";
 };
 
+export const chapterOutlineBoardForeshadowSortSql = {
+  cte: `WITH foreshadow_associations AS MATERIALIZED (
+    SELECT foreshadow.work_id, occurrence.chapter_id, foreshadow.id AS foreshadow_id, foreshadow.status
+    FROM foreshadows foreshadow
+    JOIN foreshadow_occurrences occurrence ON occurrence.foreshadow_id = foreshadow.id
+    WHERE foreshadow.work_id = ?
+    UNION
+    SELECT foreshadow.work_id, foreshadow.planned_payoff_chapter_id AS chapter_id,
+      foreshadow.id AS foreshadow_id, foreshadow.status
+    FROM foreshadows foreshadow
+    WHERE foreshadow.work_id = ? AND foreshadow.planned_payoff_chapter_id IS NOT NULL
+  ), foreshadow_association_counts AS MATERIALIZED (
+    SELECT association.work_id, association.chapter_id,
+      SUM(CASE WHEN association.status IN ('planned', 'planted') THEN 1 ELSE 0 END) AS unresolved_count,
+      COUNT(*) AS total_count
+    FROM foreshadow_associations association
+    GROUP BY association.work_id, association.chapter_id
+  )`,
+  join: `LEFT JOIN foreshadow_association_counts sorted_association
+    ON sorted_association.work_id = chapter.work_id AND sorted_association.chapter_id = chapter.id`,
+  order: `COALESCE(sorted_association.unresolved_count, 0) DESC,
+    COALESCE(sorted_association.total_count, 0) DESC`
+} as const;
+
 const CHAPTER_OUTLINE_BOARD_PREVIEW_LENGTH = 600;
 
 function chapterOutlineBoardLikePattern(value: string): string {
@@ -3806,27 +3830,18 @@ export class Store {
     }
     const whereSql = where.join(" AND ");
 
-    const associationCount = (statusSql = ""): string => `(
-      SELECT COUNT(*) FROM foreshadows sorted_foreshadow
-      WHERE sorted_foreshadow.work_id = chapter.work_id${statusSql}
-        AND (
-          sorted_foreshadow.planned_payoff_chapter_id = chapter.id
-          OR EXISTS (
-            SELECT 1 FROM foreshadow_occurrences sorted_occurrence
-            WHERE sorted_occurrence.foreshadow_id = sorted_foreshadow.id
-              AND sorted_occurrence.chapter_id = chapter.id
-          )
-        )
-    )`;
     const chapterTreeOrder = "chapter.sort_order, chapter.created_at, chapter.id";
     const chapterOrder = filters.sort === "status"
       ? `CASE WHEN outline.chapter_id IS NULL THEN 0 WHEN outline.status = 'draft' THEN 1 WHEN outline.status = 'ready' THEN 2 ELSE 3 END, ${chapterTreeOrder}`
       : filters.sort === "foreshadows"
-        ? `${associationCount(" AND sorted_foreshadow.status IN ('planned', 'planted')")} DESC, ${associationCount()} DESC, ${chapterTreeOrder}`
+        ? `${chapterOutlineBoardForeshadowSortSql.order}, ${chapterTreeOrder}`
         : filters.sort === "title"
           ? `chapter.title COLLATE NOCASE, ${chapterTreeOrder}`
           : chapterTreeOrder;
     const orderSql = `volume.sort_order, volume.created_at, volume.id, ${chapterOrder}`;
+    const foreshadowSortCte = filters.sort === "foreshadows" ? chapterOutlineBoardForeshadowSortSql.cte : "";
+    const foreshadowSortJoin = filters.sort === "foreshadows" ? chapterOutlineBoardForeshadowSortSql.join : "";
+    const foreshadowSortParams: SQLInputValue[] = filters.sort === "foreshadows" ? [workId, workId] : [];
 
     const total = numberValue(this.db.get(
       `SELECT COUNT(*) AS count
@@ -3837,7 +3852,8 @@ export class Store {
       ...whereParams
     ) ?? {}, "count");
     const pageRows = this.db.all(
-      `SELECT volume.id AS volume_id, volume.title AS volume_title, volume.sort_order AS volume_order,
+      `${foreshadowSortCte}
+       SELECT volume.id AS volume_id, volume.title AS volume_title, volume.sort_order AS volume_order,
        chapter.id AS chapter_id, chapter.title AS chapter_title, chapter.chapter_type,
        chapter.sort_order AS chapter_order,
        outline.chapter_id AS outline_chapter_id,
@@ -3849,9 +3865,11 @@ export class Store {
        FROM chapters chapter
        JOIN volumes volume ON volume.id = chapter.volume_id AND volume.work_id = chapter.work_id
        LEFT JOIN chapter_outlines outline ON outline.chapter_id = chapter.id
+       ${foreshadowSortJoin}
        WHERE ${whereSql}
        ORDER BY ${orderSql}
        LIMIT ? OFFSET ?`,
+      ...foreshadowSortParams,
       previewLength,
       previewLength,
       previewLength,

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Runtime } from "../../src/app.js";
+import { chapterOutlineBoardForeshadowSortSql } from "../../src/store.js";
 import { createTestRuntime } from "../helpers.js";
 
 const validPng = Buffer.from(
@@ -849,6 +850,189 @@ describe("书架、别名、大纲伏笔和一致性守卫 API", () => {
     const isolated = await request(runtime.app).get(`/api/works/${workId}/outline-board`).expect(200);
     expect(JSON.stringify(isolated.body.data)).not.toContain("CROSS_WORK_OUTLINE_SECRET");
     await request(runtime.app).get("/api/works/not-a-work/outline-board").expect(404);
+  });
+
+  it("按去重伏笔关联统计排序并保留作品、回收站、分页和章节树语义", async () => {
+    const { workId, volumeId, chapters } = await seedWork(runtime, "伏笔排序语义 fixture");
+    const fourthChapter = await request(runtime.app).post(`/api/works/${workId}/chapters`).send({
+      volumeId,
+      title: "第四章 并列",
+      content: ""
+    }).expect(201);
+
+    const shared = await request(runtime.app).post(`/api/works/${workId}/foreshadows`).send({
+      title: "同章多重关联",
+      status: "planned",
+      plannedPayoffChapterId: chapters[0].id,
+      occurrences: [
+        { chapterId: chapters[0].id, role: "setup" },
+        { chapterId: chapters[0].id, role: "reminder" }
+      ]
+    }).expect(201);
+    await request(runtime.app).post(`/api/works/${workId}/foreshadows`).send({
+      title: "第一章已回收",
+      status: "resolved",
+      occurrences: [{ chapterId: chapters[0].id, role: "payoff" }]
+    }).expect(201);
+    for (const [index, association] of [
+      { chapterId: chapters[1].id, status: "planned", plannedPayoff: false },
+      { chapterId: chapters[1].id, status: "planted", plannedPayoff: true },
+      { chapterId: chapters[2].id, status: "planned", plannedPayoff: false },
+      { chapterId: chapters[2].id, status: "resolved", plannedPayoff: false },
+      { chapterId: chapters[2].id, status: "abandoned", plannedPayoff: true },
+      { chapterId: fourthChapter.body.data.id, status: "planted", plannedPayoff: false },
+      { chapterId: fourthChapter.body.data.id, status: "resolved", plannedPayoff: true },
+      { chapterId: fourthChapter.body.data.id, status: "abandoned", plannedPayoff: false }
+    ].entries()) {
+      await request(runtime.app).post(`/api/works/${workId}/foreshadows`).send({
+        title: `排序伏笔 ${index + 1}`,
+        status: association.status,
+        ...(association.plannedPayoff
+          ? { plannedPayoffChapterId: association.chapterId }
+          : { occurrences: [{ chapterId: association.chapterId, role: "setup" }] })
+      }).expect(201);
+    }
+
+    const recycledVolume = await request(runtime.app).post(`/api/works/${workId}/volumes`).send({ title: "回收卷" }).expect(201);
+    const recycledChapter = await request(runtime.app).post(`/api/works/${workId}/chapters`).send({
+      volumeId: recycledVolume.body.data.id,
+      title: "回收卷章节",
+      content: ""
+    }).expect(201);
+    await request(runtime.app).post(`/api/works/${workId}/foreshadows`).send({
+      title: "回收卷高计数伏笔",
+      status: "planned",
+      plannedPayoffChapterId: recycledChapter.body.data.id
+    }).expect(201);
+    await request(runtime.app).delete(`/api/volumes/${recycledVolume.body.data.id}`).send({ expectedVersionNo: 1 }).expect(204);
+
+    const otherWork = await seedWork(runtime, "其他作品排序 fixture");
+    const timestamp = "2026-08-15T00:00:00.000Z";
+    runtime.database.run(
+      `INSERT INTO foreshadows
+         (id, work_id, title, status, importance, planned_payoff_chapter_id, created_at, updated_at)
+       VALUES (?, ?, ?, 'planned', 'high', ?, ?, ?)`,
+      "cross-work-sort-foreshadow",
+      otherWork.workId,
+      "跨作品关联不得计数",
+      chapters[0].id,
+      timestamp,
+      timestamp
+    );
+
+    const sorted = await request(runtime.app).get(`/api/works/${workId}/outline-board?sort=foreshadows`).expect(200);
+    expect(sorted.body.data.volumes.flatMap((volume: { chapters: Array<{ id: string }> }) => volume.chapters)
+      .map((chapter: { id: string }) => chapter.id)).toEqual([
+      chapters[1].id,
+      chapters[2].id,
+      fourthChapter.body.data.id,
+      chapters[0].id
+    ]);
+    expect(sorted.body.data.volumes[0].chapters[3].foreshadows.filter(
+      (foreshadow: { id: string }) => foreshadow.id === shared.body.data.id
+    )).toHaveLength(1);
+    expect(JSON.stringify(sorted.body.data)).not.toContain("回收卷章节");
+    expect(JSON.stringify(sorted.body.data)).not.toContain("跨作品关联不得计数");
+
+    const secondPage = await request(runtime.app)
+      .get(`/api/works/${workId}/outline-board?sort=foreshadows&page=2&limit=2`)
+      .expect(200);
+    expect(secondPage.body.data).toMatchObject({ page: 2, limit: 2, itemCount: 2, total: 4 });
+    expect(secondPage.body.data.volumes.flatMap((volume: { chapters: Array<{ id: string }> }) => volume.chapters)
+      .map((chapter: { id: string }) => chapter.id)).toEqual([
+      fourthChapter.body.data.id,
+      chapters[0].id
+    ]);
+  });
+
+  it("对两千章和两万伏笔预聚合一次关联并保持排序查询有界", async () => {
+    const work = await request(runtime.app).post("/api/works").send({ title: "伏笔排序性能 fixture" }).expect(201);
+    const workId = String(work.body.data.id);
+    const volume = await request(runtime.app).post(`/api/works/${workId}/volumes`).send({ title: "第一卷" }).expect(201);
+    const volumeId = String(volume.body.data.id);
+    const timestamp = "2026-08-15T00:00:00.000Z";
+    const insertChapter = runtime.database.raw.prepare(
+      `INSERT INTO chapters (id, work_id, volume_id, title, content, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, '', ?, ?, ?)`
+    );
+    const insertForeshadow = runtime.database.raw.prepare(
+      `INSERT INTO foreshadows
+         (id, work_id, title, status, importance, planned_payoff_chapter_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'medium', ?, ?, ?)`
+    );
+    const insertOccurrence = runtime.database.raw.prepare(
+      `INSERT INTO foreshadow_occurrences
+         (id, foreshadow_id, chapter_id, role, created_at, updated_at)
+       VALUES (?, ?, ?, 'setup', ?, ?)`
+    );
+    runtime.database.transaction(() => {
+      for (let index = 0; index < 2_000; index += 1) {
+        insertChapter.run(
+          `sort-perf-chapter-${index}`,
+          workId,
+          volumeId,
+          `第 ${index + 1} 章`,
+          index,
+          timestamp,
+          timestamp
+        );
+      }
+      const statuses = ["planned", "planted", "resolved", "abandoned"] as const;
+      for (let index = 0; index < 20_000; index += 1) {
+        const foreshadowId = `sort-perf-foreshadow-${index}`;
+        const payoffChapterId = `sort-perf-chapter-${index % 2_000}`;
+        const occurrenceChapterId = index % 2 === 0
+          ? payoffChapterId
+          : `sort-perf-chapter-${(index * 17 + 1) % 2_000}`;
+        insertForeshadow.run(
+          foreshadowId,
+          workId,
+          `性能伏笔 ${index + 1}`,
+          statuses[index % statuses.length]!,
+          payoffChapterId,
+          timestamp,
+          timestamp
+        );
+        insertOccurrence.run(
+          `sort-perf-occurrence-${index}`,
+          foreshadowId,
+          occurrenceChapterId,
+          timestamp,
+          timestamp
+        );
+      }
+    });
+
+    const plan = runtime.database.all(
+      `EXPLAIN QUERY PLAN ${chapterOutlineBoardForeshadowSortSql.cte}
+       SELECT chapter.id
+       FROM chapters chapter
+       JOIN volumes volume ON volume.id = chapter.volume_id AND volume.work_id = chapter.work_id
+       LEFT JOIN chapter_outlines outline ON outline.chapter_id = chapter.id
+       ${chapterOutlineBoardForeshadowSortSql.join}
+       WHERE chapter.work_id = ? AND chapter.deleted_at IS NULL AND volume.deleted_at IS NULL
+       ORDER BY volume.sort_order, volume.created_at, volume.id,
+         ${chapterOutlineBoardForeshadowSortSql.order}, chapter.sort_order, chapter.created_at, chapter.id
+       LIMIT ? OFFSET ?`,
+      workId,
+      workId,
+      workId,
+      31,
+      0
+    );
+    const planDetails = plan.map((step) => String(step.detail));
+    expect(planDetails.some((detail) => detail.includes("MATERIALIZE foreshadow_association_counts"))).toBe(true);
+    expect(planDetails.some((detail) => detail.includes("CORRELATED"))).toBe(false);
+    expect(planDetails.some((detail) => (
+      detail.includes("SEARCH foreshadow USING INDEX idx_foreshadows_work_payoff_status (work_id=?)")
+    ))).toBe(true);
+
+    const startedAt = performance.now();
+    const sorted = await request(runtime.app).get(`/api/works/${workId}/outline-board?sort=foreshadows`).expect(200);
+    const elapsedMs = performance.now() - startedAt;
+    expect(sorted.body.data).toMatchObject({ total: 2_000, itemCount: 30, hasMore: true });
+    expect(sorted.body.data.stats).toMatchObject({ foreshadowCount: 20_000, unresolvedForeshadowCount: 10_000 });
+    expect(elapsedMs).toBeLessThan(3_000);
   });
 
   it("对五千章大作品保持看板响应、查询耗时和当前页关联有界", async () => {


### PR DESCRIPTION
## Summary

- preaggregate occurrence and planned-payoff associations once per work
- deduplicate the same foreshadow linked to the same chapter through multiple paths
- preserve unresolved count, total count, volume tree order, recycle-bin filtering, work isolation, and pagination semantics
- add representative semantic, query-plan, and 2,000-chapter/20,000-foreshadow performance coverage

## Verification

- `npm run typecheck`
- `npx vitest run tests/integration/feature-suite-api.test.ts --maxWorkers=1` (65 passed)
- `npx vitest run tests/unit/database-migration.test.ts --maxWorkers=1 -t '迁移 93'` (2 passed)
- `npm test -- --reporter=dot` (191 files, 970 tests passed)
- `npm run build`
- production `/api/health`, `PRAGMA integrity_check`, and `PRAGMA foreign_key_check`
- local benchmark: 2,000 chapters and 20,000 foreshadows sorted in 56.9 ms

Closes MUXUE-75
