### PR TITLE
MUXUE-76: batch organization and foreshadow list queries

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -4282,20 +4282,31 @@ export class Store {
     ).map((item) => this.mapForeshadowOccurrence(item));
     const status = requiredString(row, "status");
     const plannedPayoffChapterId = optionalString(row, "planned_payoff_chapter_id");
+    const overdue = Boolean(currentChapterId && plannedPayoffChapterId && ["planned", "planted"].includes(status)
+      && this.chapterSequence(workId, plannedPayoffChapterId) < this.chapterSequence(workId, currentChapterId));
+    return this.mapForeshadow(row, occurrences, this.currentEntityVersionNo("foreshadow", foreshadowId), overdue);
+  }
+
+  private mapForeshadow(
+    row: Row,
+    occurrences: Record<string, unknown>[],
+    versionNo: number,
+    overdue: boolean
+  ): Record<string, unknown> {
+    const status = requiredString(row, "status");
     return {
       id: requiredString(row, "id"),
-      workId,
+      workId: requiredString(row, "work_id"),
       title: requiredString(row, "title"),
       description: requiredString(row, "description"),
       status,
       importance: requiredString(row, "importance"),
-      plannedPayoffChapterId,
+      plannedPayoffChapterId: optionalString(row, "planned_payoff_chapter_id"),
       resolutionNote: requiredString(row, "resolution_note"),
       unresolved: status === "planned" || status === "planted",
-      overdue: Boolean(currentChapterId && plannedPayoffChapterId && ["planned", "planted"].includes(status)
-        && this.chapterSequence(workId, plannedPayoffChapterId) < this.chapterSequence(workId, currentChapterId)),
+      overdue,
       occurrences,
-      versionNo: this.currentEntityVersionNo("foreshadow", foreshadowId),
+      versionNo,
       createdAt: requiredString(row, "created_at"),
       updatedAt: requiredString(row, "updated_at")
     };
@@ -4307,11 +4318,12 @@ export class Store {
     const where = status === "unresolved"
       ? "AND status IN ('planned', 'planted')"
       : status === "resolved" ? "AND status IN ('resolved', 'abandoned')" : "";
-    return this.db.all(
-      `SELECT id FROM foreshadows WHERE work_id = ? ${where}
+    const rows = this.db.all(
+      `SELECT * FROM foreshadows WHERE work_id = ? ${where}
        ORDER BY CASE importance WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END, created_at`,
       workId
-    ).map((row) => this.getForeshadow(requiredString(row, "id"), currentChapterId));
+    );
+    return this.mapForeshadowList(rows, currentChapterId);
   }
 
   listForeshadowsPage(workId: string, pagination: Pagination, status: "all" | "unresolved" | "resolved" = "all", currentChapterId?: string): PaginatedResult<Record<string, unknown>> {
@@ -4322,12 +4334,78 @@ export class Store {
       : status === "resolved" ? "AND status IN ('resolved', 'abandoned')" : "";
     const page = paginationSql(pagination);
     const rows = this.db.all(
-      `SELECT id FROM foreshadows WHERE work_id = ? ${where}
+      `SELECT * FROM foreshadows WHERE work_id = ? ${where}
        ORDER BY CASE importance WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END, created_at${page.sql}`,
       workId,
       ...page.params
     );
-    return paginated(rows.map((row) => this.getForeshadow(requiredString(row, "id"), currentChapterId)), pagination);
+    return paginated(this.mapForeshadowList(rows, currentChapterId), pagination);
+  }
+
+  private mapForeshadowList(rows: Row[], currentChapterId?: string): Record<string, unknown>[] {
+    if (rows.length === 0) return [];
+    const foreshadowIds = rows.map((row) => requiredString(row, "id"));
+    const batch = {
+      occurrences: new Map<string, Record<string, unknown>[]>(),
+      versions: this.currentEntityVersionNos("foreshadow", foreshadowIds),
+      chapterSequences: new Map<string, number>()
+    };
+    for (let offset = 0; offset < foreshadowIds.length; offset += ENTITY_LIST_BATCH_SIZE) {
+      const batchIds = foreshadowIds.slice(offset, offset + ENTITY_LIST_BATCH_SIZE);
+      const placeholders = batchIds.map(() => "?").join(", ");
+      const occurrences = this.db.all(
+        `SELECT fo.*, c.title AS chapter_title, c.volume_id, c.sort_order AS chapter_order,
+         v.title AS volume_title, v.sort_order AS volume_order
+         FROM foreshadow_occurrences fo
+         JOIN chapters c ON c.id = fo.chapter_id
+         JOIN volumes v ON v.id = c.volume_id
+         WHERE fo.foreshadow_id IN (${placeholders})
+         ORDER BY fo.foreshadow_id, v.sort_order, c.sort_order, fo.created_at`,
+        ...batchIds
+      );
+      for (const occurrence of occurrences) {
+        const foreshadowId = requiredString(occurrence, "foreshadow_id");
+        const grouped = batch.occurrences.get(foreshadowId) ?? [];
+        grouped.push(this.mapForeshadowOccurrence(occurrence));
+        batch.occurrences.set(foreshadowId, grouped);
+      }
+    }
+    if (currentChapterId) {
+      const chapterIds = [...new Set([
+        currentChapterId,
+        ...rows.map((row) => optionalString(row, "planned_payoff_chapter_id")).filter((chapterId): chapterId is string => Boolean(chapterId))
+      ])];
+      for (let offset = 0; offset < chapterIds.length; offset += ENTITY_LIST_BATCH_SIZE) {
+        const batchIds = chapterIds.slice(offset, offset + ENTITY_LIST_BATCH_SIZE);
+        const placeholders = batchIds.map(() => "?").join(", ");
+        const sequences = this.db.all(
+          `SELECT c.id, v.sort_order * 1000000 + c.sort_order AS sequence
+           FROM chapters c JOIN volumes v ON v.id = c.volume_id
+           WHERE c.id IN (${placeholders}) AND c.work_id = ?`,
+          ...batchIds,
+          requiredString(rows[0] ?? {}, "work_id")
+        );
+        for (const sequence of sequences) {
+          batch.chapterSequences.set(requiredString(sequence, "id"), numberValue(sequence, "sequence"));
+        }
+      }
+    }
+    const currentChapterSequence = currentChapterId
+      ? batch.chapterSequences.get(currentChapterId) ?? Number.MAX_SAFE_INTEGER
+      : Number.MAX_SAFE_INTEGER;
+    return rows.map((row) => {
+      const foreshadowId = requiredString(row, "id");
+      const status = requiredString(row, "status");
+      const plannedPayoffChapterId = optionalString(row, "planned_payoff_chapter_id");
+      const overdue = Boolean(currentChapterId && plannedPayoffChapterId && ["planned", "planted"].includes(status)
+        && (batch.chapterSequences.get(plannedPayoffChapterId) ?? Number.MAX_SAFE_INTEGER) < currentChapterSequence);
+      return this.mapForeshadow(
+        row,
+        batch.occurrences.get(foreshadowId) ?? [],
+        batch.versions.get(foreshadowId) ?? 0,
+        overdue
+      );
+    });
   }
 
   listChapterForeshadowReminders(workId: string, chapterId: string): Record<string, unknown>[] {

--- a/src/store.ts
+++ b/src/store.ts
@@ -53,7 +53,20 @@ type WorkListBatch = {
 };
 
 const WORK_LIST_BATCH_SIZE = 500;
+const ENTITY_LIST_BATCH_SIZE = 400;
 export const RECYCLE_BIN_RETENTION_DAYS = 30;
+
+type OrganizationMemberSummary = {
+  characterId: string;
+  name: string;
+  role: string;
+  note: string;
+};
+
+type OrganizationListBatch = {
+  members: Map<string, OrganizationMemberSummary[]>;
+  versions: Map<string, number>;
+};
 
 function recycleBinExpiresAt(deletedAt: string): string {
   return new Date(new Date(deletedAt).getTime() + RECYCLE_BIN_RETENTION_DAYS * 24 * 60 * 60_000).toISOString();
@@ -763,6 +776,22 @@ export class Store {
       entityId
     );
     return numberValue(row ?? {}, "version_no");
+  }
+
+  private currentEntityVersionNos(type: VersionedEntityType, entityIds: string[]): Map<string, number> {
+    const versions = new Map<string, number>();
+    for (let offset = 0; offset < entityIds.length; offset += ENTITY_LIST_BATCH_SIZE) {
+      const batchIds = entityIds.slice(offset, offset + ENTITY_LIST_BATCH_SIZE);
+      const placeholders = batchIds.map(() => "?").join(", ");
+      const rows = this.db.all(
+        `SELECT entity_id, MAX(version_no) AS version_no FROM entity_versions
+         WHERE entity_type = ? AND entity_id IN (${placeholders}) GROUP BY entity_id`,
+        type,
+        ...batchIds
+      );
+      for (const row of rows) versions.set(requiredString(row, "entity_id"), numberValue(row, "version_no"));
+    }
+    return versions;
   }
 
   private currentChapterVersionNo(chapterId: string): number {
@@ -5279,14 +5308,17 @@ export class Store {
 
   listOrganizations(workId: string, includeMarkdown = true): Record<string, unknown>[] {
     this.getWork(workId);
-    return this.db.all("SELECT * FROM organizations WHERE work_id = ? ORDER BY name", workId).map((row) => this.mapOrganization(row, includeMarkdown));
+    const rows = this.db.all("SELECT * FROM organizations WHERE work_id = ? ORDER BY name", workId);
+    const batch = this.organizationListBatch(rows);
+    return rows.map((row) => this.mapOrganization(row, includeMarkdown, batch));
   }
 
   listOrganizationsPage(workId: string, pagination: Pagination, includeMarkdown = true): PaginatedResult<Record<string, unknown>> {
     this.getWork(workId);
     const page = paginationSql(pagination);
     const rows = this.db.all(`SELECT * FROM organizations WHERE work_id = ? ORDER BY name${page.sql}`, workId, ...page.params);
-    return paginated(rows.map((row) => this.mapOrganization(row, includeMarkdown)), pagination);
+    const batch = this.organizationListBatch(rows);
+    return paginated(rows.map((row) => this.mapOrganization(row, includeMarkdown, batch)), pagination);
   }
 
   getOrganization(organizationId: string): Record<string, unknown> {
@@ -5412,23 +5444,57 @@ export class Store {
     return { mergeId, target: this.getOrganization(targetOrganizationId), source };
   }
 
-  private mapOrganization(row: Row, includeMarkdown = true): Record<string, unknown> {
+  private organizationListBatch(rows: Row[]): OrganizationListBatch {
+    const organizationIds = rows.map((row) => requiredString(row, "id"));
+    const batch: OrganizationListBatch = {
+      members: new Map(),
+      versions: this.currentEntityVersionNos("organization", organizationIds)
+    };
+    for (let offset = 0; offset < organizationIds.length; offset += ENTITY_LIST_BATCH_SIZE) {
+      const batchIds = organizationIds.slice(offset, offset + ENTITY_LIST_BATCH_SIZE);
+      const placeholders = batchIds.map(() => "?").join(", ");
+      const members = this.db.all(
+        `SELECT m.organization_id, c.id, c.name, m.role, m.note
+         FROM character_organization_memberships m
+         JOIN characters c ON c.id = m.character_id
+         WHERE m.organization_id IN (${placeholders}) ORDER BY m.organization_id, c.name`,
+        ...batchIds
+      );
+      for (const member of members) {
+        const organizationId = requiredString(member, "organization_id");
+        const grouped = batch.members.get(organizationId) ?? [];
+        grouped.push({
+          characterId: requiredString(member, "id"),
+          name: requiredString(member, "name"),
+          role: requiredString(member, "role"),
+          note: requiredString(member, "note")
+        });
+        batch.members.set(organizationId, grouped);
+      }
+    }
+    return batch;
+  }
+
+  private mapOrganization(row: Row, includeMarkdown = true, batch?: OrganizationListBatch): Record<string, unknown> {
+    const organizationId = requiredString(row, "id");
     const settingsSections = knowledgeSectionsFromStored(row.settings_sections_json, json<string[]>(requiredString(row, "settings_json"), []));
     const settings = settingsFromKnowledgeSections(settingsSections);
-    const members = this.db.all(
-      `SELECT c.id, c.name, m.role, m.note
-       FROM character_organization_memberships m
-       JOIN characters c ON c.id = m.character_id
-       WHERE m.organization_id = ? ORDER BY c.name`,
-      requiredString(row, "id")
-    ).map((member) => ({
-      characterId: requiredString(member, "id"),
-      name: requiredString(member, "name"),
-      role: requiredString(member, "role"),
-      note: requiredString(member, "note")
-    }));
+    const members = batch
+      ? batch.members.get(organizationId) ?? []
+      : this.db.all(
+        `SELECT c.id, c.name, m.role, m.note
+         FROM character_organization_memberships m
+         JOIN characters c ON c.id = m.character_id
+         WHERE m.organization_id = ? ORDER BY c.name`,
+        organizationId
+      ).map((member) => ({
+        characterId: requiredString(member, "id"),
+        name: requiredString(member, "name"),
+        role: requiredString(member, "role"),
+        note: requiredString(member, "note")
+      }));
     return {
-      id: requiredString(row, "id"),
+      id: organizationId,
       workId: requiredString(row, "work_id"),
       name: requiredString(row, "name"),
       description: requiredString(row, "description"),
@@ -5438,7 +5504,7 @@ export class Store {
         : { settings: [], settingsCount: settingsSections.length }),
       memberIds: members.map((member) => member.characterId),
       members,
-      versionNo: this.currentEntityVersionNo("organization", requiredString(row, "id")),
+      versionNo: batch ? batch.versions.get(organizationId) ?? 0 : this.currentEntityVersionNo("organization", organizationId),
       createdAt: requiredString(row, "created_at"),
       updatedAt: requiredString(row, "updated_at")
     };

--- a/tests/integration/foreshadow-list-batch.test.ts
+++ b/tests/integration/foreshadow-list-batch.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import { AppError } from "../../src/errors.js";
+import type { PaginatedResult, Pagination } from "../../src/pagination.js";
+import { createTestRuntime, createWork } from "../helpers.js";
+
+function countReadQueries<T>(runtime: Runtime, operation: () => T): {
+  result: T;
+  queryCount: number;
+  getSql: string[];
+  allSql: string[];
+} {
+  const getSpy = vi.spyOn(runtime.database, "get");
+  const allSpy = vi.spyOn(runtime.database, "all");
+  const result = operation();
+  const readResult = {
+    result,
+    queryCount: getSpy.mock.calls.length + allSpy.mock.calls.length,
+    getSql: getSpy.mock.calls.map(([sql]) => String(sql)),
+    allSql: allSpy.mock.calls.map(([sql]) => String(sql))
+  };
+  getSpy.mockRestore();
+  allSpy.mockRestore();
+  return readResult;
+}
+
+function pagination(page: number, limit: number): Pagination {
+  return { page, limit, offset: (page - 1) * limit };
+}
+
+function itemIds(page: PaginatedResult<Record<string, unknown>>): string[] {
+  return page.items.map((item) => String(item.id));
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("伏笔列表批量映射", () => {
+  it("批量读取详情并保持筛选、分页、occurrence、版本、逾期和作品边界", async () => {
+    const runtime = createTestRuntime();
+    try {
+      runtime.store.setRelationshipIndexQueuedHandler(null);
+      const workId = String((await createWork(runtime, "伏笔批量查询")).id);
+      const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+      const chapters = Array.from({ length: 4 }, (_, index) => runtime.store.createChapter(workId, {
+        volumeId: String(volume.id),
+        title: `第${index + 1}章`
+      }));
+      const chapterIds = chapters.map((chapter) => String(chapter.id));
+      const foreshadows = [
+        runtime.store.createForeshadow(workId, {
+          title: "高优先已埋设",
+          importance: "high",
+          status: "planted",
+          plannedPayoffChapterId: chapterIds[1],
+          occurrences: [
+            { chapterId: chapterIds[2] as string, role: "reminder", note: "后出现" },
+            { chapterId: chapterIds[0] as string, role: "setup", note: "先出现" }
+          ]
+        }),
+        runtime.store.createForeshadow(workId, {
+          title: "高优先已解决",
+          importance: "high",
+          status: "resolved",
+          plannedPayoffChapterId: chapterIds[0]
+        }),
+        runtime.store.createForeshadow(workId, {
+          title: "中优先待回收",
+          importance: "medium",
+          status: "planned",
+          plannedPayoffChapterId: chapterIds[3]
+        }),
+        runtime.store.createForeshadow(workId, { title: "中优先已放弃", importance: "medium", status: "abandoned" }),
+        runtime.store.createForeshadow(workId, { title: "低优先待回收", importance: "low", status: "planned" }),
+        runtime.store.createForeshadow(workId, { title: "低优先已解决", importance: "low", status: "resolved" })
+      ];
+      for (const [index, foreshadow] of foreshadows.entries()) {
+        runtime.database.run(
+          "UPDATE foreshadows SET created_at = ? WHERE id = ?",
+          new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+          foreshadow.id as string
+        );
+      }
+      const firstId = String(foreshadows[0]?.id);
+      runtime.store.updateForeshadow(firstId, { description: "更新后的伏笔说明" });
+
+      const otherWorkId = String((await createWork(runtime, "其他作品")).id);
+      const otherForeshadow = runtime.store.createForeshadow(otherWorkId, { title: "跨作品伏笔", status: "planned" });
+      const currentChapterId = chapterIds[2] as string;
+      const expected = foreshadows.map((foreshadow) => runtime.store.getForeshadow(String(foreshadow.id), currentChapterId));
+
+      const small = countReadQueries(runtime, () => runtime.store.listForeshadowsPage(workId, pagination(1, 1), "all"));
+      const large = countReadQueries(runtime, () => runtime.store.listForeshadowsPage(workId, pagination(1, 4), "all"));
+      const withCurrentSmall = countReadQueries(runtime, () => runtime.store.listForeshadowsPage(
+        workId,
+        pagination(1, 1),
+        "all",
+        currentChapterId
+      ));
+      const withCurrentLarge = countReadQueries(runtime, () => runtime.store.listForeshadowsPage(
+        workId,
+        pagination(1, 4),
+        "all",
+        currentChapterId
+      ));
+
+      expect(small.queryCount).toBe(6);
+      expect(large.queryCount).toBe(6);
+      expect(withCurrentSmall.queryCount).toBe(8);
+      expect(withCurrentLarge.queryCount).toBe(8);
+      expect([...withCurrentLarge.getSql, ...withCurrentLarge.allSql].filter((sql) => sql.includes("entity_id = ?"))).toEqual([]);
+      expect(withCurrentLarge.allSql.filter((sql) => sql.includes("fo.foreshadow_id IN ("))).toHaveLength(1);
+      expect(withCurrentLarge.allSql.filter((sql) => sql.includes("c.id IN ("))).toHaveLength(1);
+
+      const currentFirstPage = withCurrentLarge.result;
+      expect(currentFirstPage).toMatchObject({ page: 1, limit: 4, hasMore: true, nextPage: 2 });
+      expect(currentFirstPage.items).toEqual(expected.slice(0, 4));
+      expect(currentFirstPage.items[0]).toMatchObject({
+        id: firstId,
+        description: "更新后的伏笔说明",
+        unresolved: true,
+        overdue: true,
+        versionNo: 2
+      });
+      expect((currentFirstPage.items[0]?.occurrences as Array<Record<string, unknown>>).map((item) => item.chapterId))
+        .toEqual([chapterIds[0], chapterIds[2]]);
+      expect(currentFirstPage.items[1]).toMatchObject({ status: "resolved", unresolved: false, overdue: false, occurrences: [] });
+      expect(small.result.items[0]).toMatchObject({ overdue: false });
+
+      const unresolved = runtime.store.listForeshadowsPage(workId, pagination(1, 10), "unresolved", currentChapterId);
+      const resolved = runtime.store.listForeshadowsPage(workId, pagination(1, 10), "resolved", currentChapterId);
+      const secondPage = runtime.store.listForeshadowsPage(workId, pagination(2, 4), "all", currentChapterId);
+      const empty = countReadQueries(runtime, () => runtime.store.listForeshadowsPage(workId, pagination(5, 4), "all"));
+      expect(itemIds(unresolved)).toEqual([String(foreshadows[0]?.id), String(foreshadows[2]?.id), String(foreshadows[4]?.id)]);
+      expect(itemIds(resolved)).toEqual([String(foreshadows[1]?.id), String(foreshadows[3]?.id), String(foreshadows[5]?.id)]);
+      expect(itemIds(secondPage)).toEqual(expected.slice(4).map((item) => String(item.id)));
+      expect(empty.result).toMatchObject({ items: [], page: 5, limit: 4, hasMore: false, nextPage: null });
+      expect(empty.queryCount).toBe(4);
+      expect(expected.some((item) => item.id === otherForeshadow.id)).toBe(false);
+
+      try {
+        runtime.store.listForeshadowsPage(workId, pagination(1, 2), "all", String(
+          runtime.store.createChapter(
+            otherWorkId,
+            { volumeId: String(runtime.store.createVolume(otherWorkId, { title: "跨作品卷" }).id), title: "跨作品章" }
+          ).id
+        ));
+        throw new Error("跨作品 currentChapterId 应被拒绝");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect((error as AppError).code).toBe("CHAPTER_WORK_MISMATCH");
+      }
+    } finally {
+      await runtime.close();
+    }
+  });
+});

--- a/tests/integration/organization-list-batch.test.ts
+++ b/tests/integration/organization-list-batch.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import type { Pagination } from "../../src/pagination.js";
+import { createTestRuntime, createWork } from "../helpers.js";
+
+function countReadQueries<T>(runtime: Runtime, operation: () => T): {
+  result: T;
+  queryCount: number;
+  getSql: string[];
+  allSql: string[];
+} {
+  const getSpy = vi.spyOn(runtime.database, "get");
+  const allSpy = vi.spyOn(runtime.database, "all");
+  const result = operation();
+  const readResult = {
+    result,
+    queryCount: getSpy.mock.calls.length + allSpy.mock.calls.length,
+    getSql: getSpy.mock.calls.map(([sql]) => String(sql)),
+    allSql: allSpy.mock.calls.map(([sql]) => String(sql))
+  };
+  getSpy.mockRestore();
+  allSpy.mockRestore();
+  return readResult;
+}
+
+function pagination(page: number, limit: number): Pagination {
+  return { page, limit, offset: (page - 1) * limit };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("组织列表批量映射", () => {
+  it("批量读取组织成员和版本，并保持分页、Markdown 与空成员契约", async () => {
+    const runtime = createTestRuntime();
+    try {
+      runtime.store.setRelationshipIndexQueuedHandler(null);
+      const workId = String((await createWork(runtime, "组织批量查询")).id);
+      const memberB = runtime.store.createCharacter(workId, { name: "角色B" });
+      const memberA = runtime.store.createCharacter(workId, { name: "角色A" });
+      const created = [
+        runtime.store.createOrganization(workId, {
+          name: "组织A",
+          description: "第一版",
+          memberIds: [String(memberB.id), String(memberA.id)],
+          settingsSections: [{ title: "章程", contentMarkdown: "共同守望。" }]
+        }),
+        runtime.store.createOrganization(workId, { name: "组织B" }),
+        runtime.store.createOrganization(workId, { name: "组织C", memberIds: [String(memberA.id)] }),
+        runtime.store.createOrganization(workId, { name: "组织D" })
+      ];
+      const firstId = String(created[0]?.id);
+      runtime.store.updateOrganization(firstId, { description: "第二版" });
+      const details = new Map(created.map((organization) => {
+        const detail = runtime.store.getOrganization(String(organization.id));
+        return [String(detail.id), detail];
+      }));
+
+      const small = countReadQueries(runtime, () => runtime.store.listOrganizationsPage(workId, pagination(1, 1), true));
+      const large = countReadQueries(runtime, () => runtime.store.listOrganizationsPage(workId, pagination(1, 3), true));
+      const withoutMarkdown = countReadQueries(runtime, () => runtime.store.listOrganizationsPage(workId, pagination(1, 3), false));
+      const empty = countReadQueries(runtime, () => runtime.store.listOrganizationsPage(workId, pagination(3, 2), true));
+
+      expect(small.queryCount).toBe(6);
+      expect(large.queryCount).toBe(6);
+      expect(withoutMarkdown.queryCount).toBe(6);
+      expect(empty.queryCount).toBe(4);
+      expect([...small.getSql, ...small.allSql].filter((sql) => sql.includes("entity_id = ?"))).toEqual([]);
+      expect(small.allSql.filter((sql) => sql.includes("m.organization_id IN ("))).toHaveLength(1);
+      expect(small.allSql.filter((sql) => sql.includes("entity_id IN ("))).toHaveLength(1);
+
+      expect(small.result).toMatchObject({ page: 1, limit: 1, hasMore: true, nextPage: 2 });
+      expect(large.result).toMatchObject({ page: 1, limit: 3, hasMore: true, nextPage: 2 });
+      expect(empty.result).toMatchObject({ items: [], page: 3, limit: 2, hasMore: false, nextPage: null });
+      for (const item of large.result.items) expect(item).toEqual(details.get(String(item.id)));
+      expect(large.result.items[0]).toMatchObject({
+        id: firstId,
+        description: "第二版",
+        versionNo: 2,
+        memberIds: [String(memberA.id), String(memberB.id)],
+        members: [{ name: "角色A" }, { name: "角色B" }],
+        settings: ["共同守望。"],
+        settingsMarkdown: "共同守望。"
+      });
+      expect(large.result.items[1]).toMatchObject({ memberIds: [], members: [], versionNo: 1 });
+      expect(withoutMarkdown.result.items[0]).toMatchObject({ settings: [], settingsCount: 1 });
+      expect(withoutMarkdown.result.items[0]).not.toHaveProperty("settingsMarkdown");
+      expect(withoutMarkdown.result.items[0]).not.toHaveProperty("settingsSections");
+    } finally {
+      await runtime.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- batch organization members and entity versions for full and paginated organization lists
- batch foreshadow occurrences, entity versions, and chapter sequences while preserving status, ordering, pagination, and overdue semantics
- add isolated SQLite regression fixtures that compare batched list output with detail output and assert constant query counts

## Query counts

- organizations: 8/12/14 reads before for representative limits, now 6 reads regardless of page size or Markdown mode
- foreshadows without `currentChapterId`: 10/16/22 reads before, now 6 reads
- foreshadows with `currentChapterId`: 15/23/33 reads before, now 8 reads

## Validation

- `npm run typecheck`
- `npx vitest run tests/integration/organization-list-batch.test.ts --maxWorkers=1`
- `npx vitest run tests/integration/foreshadow-list-batch.test.ts --maxWorkers=1`
- `npx vitest run tests/integration/user-auth-api.test.ts -t "模块权限默认拒绝未知路由，并裁剪跨模块数据与关联写入" --maxWorkers=1`
- `npm test` (193 files, 970 tests)
- `npm run build`

No database migration is required.

Closes MUXUE-76
