### PR TITLE
build(release): bump version to 0.7.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.7.11";
+export const APP_VERSION = "0.7.12";


### PR DESCRIPTION
## 变更

- 将主应用版本从 0.7.11 统一更新为 0.7.12。
- 同步 package.json、package-lock.json 顶层及根包版本、src/version.ts。

## 验证

- tests/unit/version.test.ts
- npm run check：191 个测试文件、970 个测试通过，生产构建成功。

无数据库迁移、CLI 或部署变更。