### PR TITLE
fix(ui): restore checkbox visibility and increase chapter indent

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-checkbox-v1&feature=ai-tool-call-copy-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260816-novel-tree-indent-v1&feature=ai-tool-call-copy-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260815-ai-history-favorite-v3&feature=ai-tool-call-copy-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-checkbox-v1&feature=ai-tool-call-copy-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1303,7 +1303,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .chapter-add-button { flex: none; }
 .volume-chapters { display: block; }
 .volume-node.is-collapsed .volume-chapters { display: none; }
-.chapter-node { display: grid; grid-template-columns: minmax(0, 1fr) max-content; gap: 8px; width: calc(100% + 6px); padding: 9px 8px 9px 20px; border: 0; background: transparent; border-radius: 4px; text-align: left; font-size: 12px; }
+.chapter-node { display: grid; grid-template-columns: minmax(0, 1fr) max-content; gap: 8px; width: calc(100% + 6px); padding: 9px 8px 9px 24px; border: 0; background: transparent; border-radius: 4px; text-align: left; font-size: 12px; }
 .chapter-node:hover, .chapter-node.active { background: var(--row-active); }
 .chapter-node[draggable="true"] { cursor: grab; }
 .chapter-node.is-dragging { opacity: .42; cursor: grabbing; }

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -2940,7 +2940,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .dialog-fields .task-scope-option.hidden { display: none; }
 .task-scope-option:hover, .task-scope-option:has(input:focus-visible) { border-color: color-mix(in srgb, var(--accent) 54%, var(--line)); }
 .task-scope-option input { position: absolute; width: 1px !important; min-width: 1px; height: 1px; padding: 0; border: 0; opacity: 0; }
-.task-scope-checkbox { display: inline-grid; width: 18px; height: 18px; place-items: center; border: 1px solid var(--line-strong); border-radius: 4px; background: var(--surface); transition: border-color .15s ease, background-color .15s ease, box-shadow .15s ease; }
+.task-scope-checkbox { display: inline-grid; width: 18px; height: 18px; place-items: center; border: 1px solid var(--line); border-radius: 4px; background: var(--surface); transition: border-color .15s ease, background-color .15s ease, box-shadow .15s ease; }
 .task-scope-checkbox::after { width: 8px; height: 5px; border: solid #fff; border-width: 0 0 2px 2px; content: ""; opacity: 0; transform: translateY(-1px) rotate(-45deg) scale(.7); transition: opacity .12s ease, transform .12s ease; }
 .task-scope-option strong { overflow: hidden; color: var(--ink); font-size: 10px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
 .task-scope-option-copy { display: grid; gap: 2px; min-width: 0; }

--- a/tests/system/ai-user-message-mentions-ui.test.ts
+++ b/tests/system/ai-user-message-mentions-ui.test.ts
@@ -10,7 +10,7 @@ describe("AI 用户消息角色引用横幅", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application).toContain('/ai-mentions.js?v=20260811-user-message-mentions-v1');
     expect(application).toContain("persistedUserMessage.createdAt, persistedUserMessage.metadata, persistedUserMessage.id");

--- a/tests/system/ai-user-message-mentions-ui.test.ts
+++ b/tests/system/ai-user-message-mentions-ui.test.ts
@@ -10,7 +10,7 @@ describe("AI 用户消息角色引用横幅", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application).toContain('/ai-mentions.js?v=20260811-user-message-mentions-v1');
     expect(application).toContain("persistedUserMessage.createdAt, persistedUserMessage.metadata, persistedUserMessage.id");

--- a/tests/system/analysis-scope-ui.test.ts
+++ b/tests/system/analysis-scope-ui.test.ts
@@ -96,7 +96,7 @@ describe("AI 分析范围交互", () => {
     expect(styles).toContain(".task-scope-options { display: grid; align-content: start; gap: 6px;");
     expect(styles).toContain(".task-scope-panel-grid { display: grid;");
     expect(styles).toContain(".task-scope-selected-list { display: grid;");
-    expect(styles).toContain(".task-scope-checkbox { display: inline-grid;");
+    expect(styles).toContain(".task-scope-checkbox { display: inline-grid; width: 18px; height: 18px; place-items: center; border: 1px solid var(--line);");
     expect(styles).toContain(".task-scope-author-note-banner {");
     expect(styles).toContain(".dialog-fields .task-scope-search input { min-height: 34px;");
     expect(styles).toContain(".relationship-character-bubble {");

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -330,7 +330,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/index.css?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(styles.text).toContain('.brand-mark { display: grid; place-items: center; width: 34px; height: 34px; color: #fff; border-radius: 3px; font-weight: 700; }');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -330,7 +330,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('/vendor/vditor/dist/index.css?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/js/icons/ant.js?v=3.11.2');
     expect(page.text).toContain('/vendor/vditor/dist/index.min.js?v=3.11.2');
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(styles.text).toContain('.brand-mark { display: grid; place-items: center; width: 34px; height: 34px; color: #fff; border-radius: 3px; font-weight: 700; }');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('if (state.chapter?.id === route.chapterId && $("#editor-view").classList.contains("hidden")) await selectChapter(state.chapter.id);');
@@ -763,7 +763,7 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".module-nav .ai-analysis-entry");
     expect(styles.text).toContain(".module-nav .ai-analysis-entry,\n.module-nav .ai-analysis-entry:hover,\n.module-nav .ai-analysis-entry.active { background: transparent;");
     expect(styles.text).toContain("#module-more-button { grid-column: 2;");
-    expect(styles.text).toContain('.chapter-node { display: grid; grid-template-columns: minmax(0, 1fr) max-content; gap: 8px; width: calc(100% + 6px); padding: 9px 8px 9px 20px;');
+    expect(styles.text).toContain('.chapter-node { display: grid; grid-template-columns: minmax(0, 1fr) max-content; gap: 8px; width: calc(100% + 6px); padding: 9px 8px 9px 24px;');
     expect(styles.text).toContain('.record-markdown-preview { display: -webkit-box;');
     expect(styles.text).toContain('-webkit-line-clamp: 12;');
     expect(styles.text).toContain('.module-header-actions > [data-module-header-action] { order: 1; }');

--- a/tests/system/character-extraction-preview-ui.test.ts
+++ b/tests/system/character-extraction-preview-ui.test.ts
@@ -11,7 +11,7 @@ describe("角色抽取结果入库预览界面", () => {
       readFile(join(publicPath, "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application).toContain("function renderCharacterExtractionPreview(task, result)");
     expect(application).toContain("function renderCharacterExtractionEditor(preview)");

--- a/tests/system/character-extraction-preview-ui.test.ts
+++ b/tests/system/character-extraction-preview-ui.test.ts
@@ -11,7 +11,7 @@ describe("角色抽取结果入库预览界面", () => {
       readFile(join(publicPath, "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application).toContain("function renderCharacterExtractionPreview(task, result)");
     expect(application).toContain("function renderCharacterExtractionEditor(preview)");

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
   });
 });

--- a/tests/system/entity-lifecycle-ui.test.ts
+++ b/tests/system/entity-lifecycle-ui.test.ts
@@ -28,7 +28,7 @@ describe("实体存续状态界面", () => {
     expect(application.text).toContain('entityLifecycleBadge(item.isExtinct, "已灭绝")');
     expect(application.text).toContain('entityLifecycleBadge(item.isDissolved, "已解散")');
     expect(styles.text).toContain(".entity-lifecycle-badge");
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
   });
 });

--- a/tests/system/foreshadow-reminder-ui.test.ts
+++ b/tests/system/foreshadow-reminder-ui.test.ts
@@ -20,7 +20,7 @@ describe("编辑器伏笔提醒界面", () => {
       request(runtime.app).get("/foreshadow-reminder.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(page.text).toContain('id="chapter-foreshadow-reminder" class="chapter-foreshadow-reminder hidden"');
     expect(page.text).toContain('aria-live="polite" aria-labelledby="chapter-foreshadow-reminder-title"');

--- a/tests/system/foreshadow-reminder-ui.test.ts
+++ b/tests/system/foreshadow-reminder-ui.test.ts
@@ -20,7 +20,7 @@ describe("编辑器伏笔提醒界面", () => {
       request(runtime.app).get("/foreshadow-reminder.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(page.text).toContain('id="chapter-foreshadow-reminder" class="chapter-foreshadow-reminder hidden"');
     expect(page.text).toContain('aria-live="polite" aria-labelledby="chapter-foreshadow-reminder-title"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260815-ai-stream-persistence-v4&feature=ai-tool-call-copy-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -23,7 +23,7 @@ describe("知识模块布局切换", () => {
     const application = await request(runtime.app).get("/app.js").expect(200);
     const layoutModule = await request(runtime.app).get("/module-layout.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(page.text).toContain('<script type="module" src="/app.js?v=20260815-ai-stream-persistence-v4&feature=ai-tool-call-copy-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');

--- a/tests/system/outline-board-ui.test.ts
+++ b/tests/system/outline-board-ui.test.ts
@@ -20,7 +20,7 @@ describe("章节大纲看板界面", () => {
       request(runtime.app).get("/outline-board.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('/outline-board.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('outlineBoardRequestPath(workId, outlineBoardFilters');

--- a/tests/system/outline-board-ui.test.ts
+++ b/tests/system/outline-board-ui.test.ts
@@ -20,7 +20,7 @@ describe("章节大纲看板界面", () => {
       request(runtime.app).get("/outline-board.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('/outline-board.js?v=20260813-outline-board-page-v1');
     expect(application.text).toContain('outlineBoardRequestPath(workId, outlineBoardFilters');

--- a/tests/system/reading-preview-ui.test.ts
+++ b/tests/system/reading-preview-ui.test.ts
@@ -22,7 +22,7 @@ describe("沉浸式阅读预览界面", () => {
     const readingState = await request(runtime.app).get("/reading-preview.js").expect(200);
     const pageRoute = await request(runtime.app).get("/page-route.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(page.text).toContain('id="reader-open-button" class="module-nav-secondary hidden"');
     expect(page.text).toMatch(/id="module-more-button"[\s\S]*id="reader-open-button"[\s\S]*data-module="comments"/u);

--- a/tests/system/reading-preview-ui.test.ts
+++ b/tests/system/reading-preview-ui.test.ts
@@ -22,7 +22,7 @@ describe("沉浸式阅读预览界面", () => {
     const readingState = await request(runtime.app).get("/reading-preview.js").expect(200);
     const pageRoute = await request(runtime.app).get("/page-route.js").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(page.text).toContain('id="reader-open-button" class="module-nav-secondary hidden"');
     expect(page.text).toMatch(/id="module-more-button"[\s\S]*id="reader-open-button"[\s\S]*data-module="comments"/u);

--- a/tests/system/recycle-bin-ui.test.ts
+++ b/tests/system/recycle-bin-ui.test.ts
@@ -46,7 +46,7 @@ describe("作品与正文回收站界面", () => {
     expect(styles.text).toContain(".shelf-header-actions");
     expect(styles.text).toContain(".recycle-bin-section-list");
     expect(styles.text).toContain(".recycle-bin-card { grid-template-columns: minmax(0, 1fr);");
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
   });
 });

--- a/tests/system/recycle-bin-ui.test.ts
+++ b/tests/system/recycle-bin-ui.test.ts
@@ -46,7 +46,7 @@ describe("作品与正文回收站界面", () => {
     expect(styles.text).toContain(".shelf-header-actions");
     expect(styles.text).toContain(".recycle-bin-section-list");
     expect(styles.text).toContain(".recycle-bin-card { grid-template-columns: minmax(0, 1fr);");
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
   });
 });

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,7 +23,7 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');

--- a/tests/system/relationship-graph-search-ui.test.ts
+++ b/tests/system/relationship-graph-search-ui.test.ts
@@ -23,7 +23,7 @@ describe("人物关系图搜索界面", () => {
     const graph = await request(runtime.app).get("/relationship-graph.js").expect(200);
     const styles = await request(runtime.app).get("/styles.css").expect(200);
 
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('/relationship-graph.js?v=20260809-galaxy-size-threshold-v1');
     expect(graph.text).toContain('export function searchRelationshipNodes(nodes, query, limit = 8)');

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -44,7 +44,7 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
 
     expect(application.text).toContain('/s3-backup-ui.js?v=20260810-backup-encryption-v1');

--- a/tests/system/s3-backup-ui.test.ts
+++ b/tests/system/s3-backup-ui.test.ts
@@ -44,7 +44,7 @@ describe("S3 系统备份界面", () => {
     expect(page.text).toContain('id="s3-backup-retention-count"');
     expect(page.text).toContain('id="s3-backup-run-all"');
     expect(page.text).toContain('id="s3-backup-runs"');
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
 
     expect(application.text).toContain('/s3-backup-ui.js?v=20260810-backup-encryption-v1');

--- a/tests/system/setting-filters-ui.test.ts
+++ b/tests/system/setting-filters-ui.test.ts
@@ -20,7 +20,7 @@ describe("设定筛选界面", () => {
       request(runtime.app).get("/setting-filters.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('/setting-filters.js?v=20260810-setting-inline-filters-v1');
     expect(application.text).toContain('const settingFilters = { keyword: "", category: "", lockState: "all" };');

--- a/tests/system/setting-filters-ui.test.ts
+++ b/tests/system/setting-filters-ui.test.ts
@@ -20,7 +20,7 @@ describe("设定筛选界面", () => {
       request(runtime.app).get("/setting-filters.js").expect(200)
     ]);
 
-    expect(page.text).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page.text).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
     expect(application.text).toContain('/setting-filters.js?v=20260810-setting-inline-filters-v1');
     expect(application.text).toContain('const settingFilters = { keyword: "", category: "", lockState: "all" };');

--- a/tests/system/ui-text-selection.test.ts
+++ b/tests/system/ui-text-selection.test.ts
@@ -9,7 +9,7 @@ describe("界面文本选中行为", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260815-ai-history-favorite-v3');
+    expect(page).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
     expect(styles).toContain("body { user-select: none; }");
     expect(styles).toContain('body :is(input, textarea, select, [contenteditable="true"], .reader-content, .message-body, .record-markdown-preview, .knowledge-markdown-block, .vditor-reset, pre, code) { user-select: text; }');
   });

--- a/tests/system/ui-text-selection.test.ts
+++ b/tests/system/ui-text-selection.test.ts
@@ -9,7 +9,7 @@ describe("界面文本选中行为", () => {
       readFile(join(process.cwd(), "src", "public", "styles.css"), "utf8")
     ]);
 
-    expect(page).toContain('/styles.css?v=20260816-task-scope-checkbox-v1');
+    expect(page).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(styles).toContain("body { user-select: none; }");
     expect(styles).toContain('body :is(input, textarea, select, [contenteditable="true"], .reader-content, .message-body, .record-markdown-preview, .knowledge-markdown-block, .vditor-reset, pre, code) { user-select: text; }');
   });


### PR DESCRIPTION
## 变更内容

- 修复 AI 分析范围面板自绘 checkbox 在浅色和深色主题下边框不可见的问题。
- 将正文条目相对分卷标题的左侧缩进从 20px 调整为 24px。
- 同步静态资源缓存版本和系统 UI 断言。

## 根因

checkbox 边框引用了未定义的 `--line-strong`，导致边框声明失效；目录正文与分卷之间的层级间距偏小。

## 验证

- `npx vitest run tests/system/author-journey.test.ts`
- `npm test`：193 个测试文件、979 个测试通过
- `npm run typecheck`
- `npm run build`
- 内置浏览器验证桌面浅色、深色及 390×844 窄屏布局，无横向溢出。