### PR TITLE
fix(ui): align tool call copy feedback

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2012,9 +2012,14 @@ function formatAiToolCallTime(value) {
   }).format(date);
 }
 
+const AI_TOOL_CALL_COPY_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"></path></svg>';
+const AI_TOOL_CALL_COPIED_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="m5 12 4 4L19 6"></path></svg>';
+
 function setAiToolCallCopyButtonState(button, copied) {
   const label = button.dataset.copyLabel ?? "代码块";
-  button.dataset.copyState = copied ? "copied" : "idle";
+  const nextState = copied ? "copied" : "idle";
+  if (button.dataset.copyState !== nextState) button.innerHTML = copied ? AI_TOOL_CALL_COPIED_ICON : AI_TOOL_CALL_COPY_ICON;
+  button.dataset.copyState = nextState;
   button.classList.toggle("is-copied", copied);
   button.setAttribute("aria-label", copied ? `${label}已复制` : `复制${label}`);
   button.title = copied ? "已复制" : `复制${label}`;

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-novel-tree-indent-v1&feature=ai-tool-call-copy-v1">
+    <link rel="stylesheet" href="/styles.css?v=20260816-novel-tree-indent-v1&feature=ai-tool-call-copy-feedback-v2">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
@@ -1164,6 +1164,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260815-ai-stream-persistence-v4&feature=ai-tool-call-copy-v1"></script>
+    <script type="module" src="/app.js?v=20260815-ai-stream-persistence-v4&feature=ai-tool-call-copy-feedback-v2"></script>
   </body>
 </html>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -2585,7 +2585,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .ai-tool-call-detail section { min-width: 0; }
 .ai-tool-call-detail h3 { margin: 0 0 7px; color: var(--muted); font-size: 10px; font-weight: 600; }
 .ai-tool-call-code-block { position: relative; min-width: 0; }
-.ai-tool-call-detail pre { min-height: 120px; max-height: 32vh; overflow: auto; margin: 0; padding: 30px 12px 12px; border: 1px solid var(--line); border-radius: 5px; background: var(--paper-deep); color: var(--ink); font: 10px/1.55 var(--font-latin), monospace; white-space: pre-wrap; word-break: break-word; }
+.ai-tool-call-detail pre { min-height: 120px; max-height: 32vh; overflow: auto; margin: 0; padding: 12px 44px 12px 12px; border: 1px solid var(--line); border-radius: 5px; background: var(--paper-deep); color: var(--ink); font: 10px/1.55 var(--font-latin), monospace; white-space: pre-wrap; word-break: break-word; }
 .ai-tool-call-copy-button { position: absolute; z-index: 1; top: 6px; right: 6px; display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; min-height: 0; padding: 0; border: 1px solid transparent; border-radius: 4px; background: color-mix(in srgb, var(--paper-deep) 86%, var(--ink)); color: var(--muted); }
 .ai-tool-call-copy-button svg { width: 13px; height: 13px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.7; }
 .ai-tool-call-copy-button:hover, .ai-tool-call-copy-button:focus-visible, .ai-tool-call-copy-button.is-copied { border-color: color-mix(in srgb, var(--accent) 55%, var(--line)); background: color-mix(in srgb, var(--accent) 12%, var(--paper-deep)); color: var(--accent-dark); outline: none; }

--- a/tests/system/ai-tool-call-ui.test.ts
+++ b/tests/system/ai-tool-call-ui.test.ts
@@ -49,6 +49,8 @@ describe("AI 工具调用记录界面", () => {
     expect(application).toContain('`${resultDetails.characterCount.toLocaleString("zh-CN")} 字符`');
     expect(application).toContain("async function copyAiToolCallCode(button)");
     expect(application).toContain("await copyAiRawMarkdown(target.textContent)");
+    expect(application).toContain("const AI_TOOL_CALL_COPIED_ICON");
+    expect(application).toContain("button.innerHTML = copied ? AI_TOOL_CALL_COPIED_ICON : AI_TOOL_CALL_COPY_ICON");
     expect(application).toContain('data-ai-tool-call-copy');
     expect(styles).toContain(".ai-tool-call-summary::after { content: \"查看详情\";");
     expect(styles).toContain(".ai-process-details > summary");
@@ -57,6 +59,8 @@ describe("AI 工具调用记录界面", () => {
     expect(styles).toContain(".ai-tool-call-info { display: grid;");
     expect(styles).toContain(".ai-tool-call-copy-button { position: absolute;");
     expect(styles).toContain(".ai-tool-call-code-block { position: relative;");
+    expect(styles).toContain("padding: 12px 44px 12px 12px;");
+    expect(styles).not.toContain("padding: 30px 12px 12px;");
     expect(styles).not.toContain("ai-stream-cursor");
     expect(styles).not.toContain(".is-streaming .message-body:empty::after");
   });

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-novel-tree-indent-v1');
     expect(page.text).toContain('/app.js?v=20260815-ai-stream-persistence-v4');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260815-ai-stream-persistence-v4&feature=ai-tool-call-copy-v1"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260815-ai-stream-persistence-v4&feature=ai-tool-call-copy-feedback-v2"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');


### PR DESCRIPTION
## 变更

- 修复 AI 工具调用详情中复制按钮把代码文字向下顶开的布局问题。
- 为代码块保留右侧安全空间，避免复制按钮覆盖代码。
- 复制成功后切换为 SVG 勾选图标，短暂反馈后恢复复制图标。

## 根因

- 代码块之前使用额外的顶部内边距给右上角按钮让位，导致正文整体下移。

## 验证

- `npm test`：193 个测试文件、979 个测试通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。
- 内置浏览器已验证 1280×720 和 390×844；参数与返回值均可复制，复制反馈图标正常，控制台无错误。
