### PR TITLE
feat(ai): add stoppable chat send control

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -557,12 +557,24 @@ function aiInteractionBusy() {
   return aiRequestManager.hasActive(activeAiChatTab()?.id) || aiConversationNavigationPending !== null;
 }
 
+function aiSendButtonIconMarkup(stateName) {
+  return stateName === "stop"
+    ? '<svg class="ai-send-button-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="6" y="6" width="12" height="12" rx="1.5"></rect></svg>'
+    : '<svg class="ai-send-button-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M21 3 9.5 14.5M21 3l-7 18-4.5-6.5L3 10l18-7Z"></path></svg>';
+}
+
 function syncAiRequestControls() {
   const sending = aiRequestManager.hasActive(activeAiChatTab()?.id);
   const switching = aiConversationNavigationPending !== null;
   const button = $("#ai-send");
-  button.disabled = sending || switching;
-  button.textContent = sending ? "发送中" : switching ? "切换中" : "发送";
+  const stateName = sending ? "stop" : switching ? "switching" : "send";
+  const label = sending ? "终止当前回复" : switching ? "正在切换对话" : "发送消息";
+  button.disabled = switching;
+  button.dataset.state = stateName;
+  button.classList.toggle("is-stop", sending);
+  button.setAttribute("aria-label", label);
+  button.title = label;
+  button.innerHTML = aiSendButtonIconMarkup(stateName);
   syncAiTaskOptions();
   renderAiRoleplayCharacterSelect();
 }
@@ -571,6 +583,18 @@ function cancelActiveAiRequest(reason) {
   const cancelled = aiRequestManager.cancel(reason, activeAiChatTab()?.id);
   syncAiRequestControls();
   return cancelled;
+}
+
+function activateAiSendControl() {
+  const tab = activeAiChatTab();
+  if (aiRequestManager.hasActive(tab?.id)) {
+    if (cancelActiveAiRequest("用户已终止当前回复")) {
+      toast("已终止当前回复，可以重新发送");
+      $("#ai-prompt").focus();
+    }
+    return;
+  }
+  void sendAi();
 }
 
 function beginAiConversationNavigation(reason, action = "切换会话") {
@@ -3148,13 +3172,29 @@ async function persistAiRequestInterruption(request, interruption = null) {
   const partialContent = typeof interruption?.content === "string" && interruption.content.trim()
     ? interruption.content
     : null;
+  const cancellationMessage = request.signal.reason instanceof Error
+    ? request.signal.reason.message
+    : "AI 请求已取消";
+  const cancelledByClient = request.signal.reason?.code === "AI_REQUEST_CANCELLED";
+  const metadata = cancelledByClient
+    ? {
+        ...(partialContent ? interruption.metadata : {}),
+        interrupted: true,
+        interruptionCode: "AI_REQUEST_CANCELLED",
+        interruptionMessage: cancellationMessage.slice(0, 500)
+      }
+    : interruption?.metadata ?? {
+        interrupted: true,
+        interruptionCode: "AI_REQUEST_CANCELLED",
+        interruptionMessage: cancellationMessage.slice(0, 500)
+      };
   try {
     const message = await persistAiConversationMessage(
       request.conversationId,
       "assistant",
-      partialContent ?? "调用失败：生成已取消，尚未收到可保留的回复内容。",
+      partialContent ?? "生成已终止，尚未收到可保留的回复内容。",
       [],
-      partialContent ? interruption.metadata : {},
+      metadata,
       { requestId: aiAssistantRequestId(request) }
     );
     updateAiConversationSummaryFromMessage(message);
@@ -3850,6 +3890,7 @@ function aiStreamInterruptionLabel(code) {
   if (code === "AI_STREAM_NETWORK_ERROR") return "网络中断";
   if (code === "AI_STREAM_UPSTREAM_CLOSED") return "流被关闭";
   if (code === "AI_STREAM_REQUEST_CANCELLED") return "请求已取消";
+  if (code === "AI_REQUEST_CANCELLED") return "已终止";
   return "生成中断";
 }
 
@@ -14304,6 +14345,7 @@ async function sendAiWithOptions({ ignoreContextWarning = false } = {}) {
   if (!state.work) return toast("请先选择作品", "error");
   const tab = activeAiChatTab();
   if (!tab) return toast("Agent 对话页签尚未就绪", "error");
+  if (aiRequestManager.hasActive(tab.id)) return;
   const composerSnapshot = captureAiPromptComposer();
   const instruction = composerSnapshot.text.trim();
   if (!instruction) return toast("请输入指令", "error");
@@ -14451,7 +14493,20 @@ async function sendAiWithOptions({ ignoreContextWarning = false } = {}) {
   } catch (error) {
     const request = requestHolder.snapshot;
     if (isAiRequestCancellation(error, request) || !aiRequestTargetsCurrentState(request)) {
-      await persistAiRequestInterruption(request, error?.streamInterruption);
+      const persistedInterruption = await persistAiRequestInterruption(request, error?.streamInterruption);
+      const userStoppedCurrentReply = request.signal.reason instanceof Error
+        && request.signal.reason.message === "用户已终止当前回复";
+      if (userStoppedCurrentReply && persistedInterruption && isActiveAiChatTab(tab)) {
+        appendMessage(
+          "assistant",
+          persistedInterruption.content,
+          [],
+          persistedInterruption.createdAt,
+          persistedInterruption.metadata,
+          persistedInterruption.id,
+          { tab }
+        );
+      }
       return;
     }
     if (error?.code === "AI_CONVERSATION_RESPONSE_IN_PROGRESS") {
@@ -16697,7 +16752,7 @@ $("#ai-context-meter").addEventListener("click", () => {
   setAiContextDistributionVisible($("#ai-context-popover").classList.contains("hidden"));
 });
 $("#ai-context-popover-close").addEventListener("click", () => setAiContextDistributionVisible(false));
-$("#ai-send").addEventListener("click", sendAi);
+$("#ai-send").addEventListener("click", activateAiSendControl);
 $("#ai-conversation-switcher").addEventListener("click", () => {
   setAiConversationSwitcherVisible($("#ai-conversation-switcher-menu").classList.contains("hidden"));
 });
@@ -16894,7 +16949,7 @@ $("#ai-prompt").addEventListener("keydown", (event) => {
   }
   if (shouldSendAiPrompt(event)) {
     event.preventDefault();
-    if (!$("#ai-send").disabled) void sendAi();
+    if (!$("#ai-send").disabled && !aiRequestManager.hasActive(activeAiChatTab()?.id)) void sendAi();
   }
 });
 $(".quick-actions").addEventListener("click", (event) => {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
@@ -374,7 +374,7 @@
                 <header class="ai-context-popover-header"><div><strong id="ai-context-popover-title">Token 分布</strong><small id="ai-context-popover-description">按当前模型上下文窗口计算</small></div><button id="ai-context-popover-close" class="ai-context-popover-close" type="button" aria-label="关闭 Token 分布">×</button></header>
                 <div id="ai-context-distribution" class="ai-context-distribution" role="list" aria-label="当前 Token 分布"></div>
               </section>
-              <button id="ai-send" class="ai-send-button" type="button" aria-label="发送消息">发送</button>
+              <button id="ai-send" class="ai-send-button" type="button" data-state="send" aria-label="发送消息" title="发送消息"><svg class="ai-send-button-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M21 3 9.5 14.5M21 3l-7 18-4.5-6.5L3 10l18-7Z"></path></svg></button>
             </div>
           </div>
         </div>
@@ -1173,6 +1173,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2"></script>
   </body>
 </html>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -2708,8 +2708,14 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .ai-context-distribution-row[data-key="skills"] { --distribution-color: var(--muted); }
 .ai-context-distribution-row[data-key="context"] { --distribution-color: var(--green); }
 .ai-context-distribution-row[data-key="left"] { --distribution-color: color-mix(in srgb, var(--muted) 55%, transparent); }
-.ai-send-button { min-width: 54px; height: 32px; padding: 0 11px; border: 0; border-radius: 4px; background: var(--accent); color: #fff; font-size: 10px; font-weight: 600; box-shadow: 0 4px 12px rgba(139,61,44,.2); }
-.ai-send-button:hover { background: var(--accent-dark); }.ai-send-button:disabled { cursor: wait; opacity: .62; }
+.ai-send-button { display: grid; flex: 0 0 32px; place-items: center; width: 32px; min-width: 32px; height: 32px; padding: 0; border: 0; border-radius: 4px; background: var(--accent); color: #fff; box-shadow: 0 4px 12px rgba(139,61,44,.2); }
+.ai-send-button:hover, .ai-send-button:focus-visible { background: var(--accent-dark); outline: 0; }
+.ai-send-button:focus-visible { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 24%, transparent), 0 4px 12px rgba(139,61,44,.2); }
+.ai-send-button.is-stop { background: var(--ink); box-shadow: 0 4px 12px color-mix(in srgb, var(--ink) 22%, transparent); }
+.ai-send-button.is-stop:hover, .ai-send-button.is-stop:focus-visible { background: color-mix(in srgb, var(--ink) 84%, var(--accent)); }
+.ai-send-button:disabled { cursor: wait; opacity: .62; }
+.ai-send-button-icon { width: 17px; height: 17px; overflow: visible; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
+.ai-send-button.is-stop .ai-send-button-icon { width: 15px; height: 15px; fill: currentColor; stroke: none; }
 .ai-citations { display: grid; gap: 6px; max-height: 190px; overflow-y: auto; margin-bottom: 8px; }
 .ai-citation-card { display: grid; grid-template-columns: minmax(0, 1fr) auto; border: 1px solid var(--line); border-radius: 5px; background: var(--paper); overflow: hidden; }
 .ai-citation-main { min-width: 0; padding: 8px 9px; border: 0; background: transparent; text-align: left; }
@@ -3944,7 +3950,6 @@ body { font-size: var(--ui-font-size); }
 .ai-context-popover-header strong { font-size: calc(12px * var(--ai-font-scale)); }
 .ai-context-popover-header small, .ai-context-distribution-label { font-size: calc(10px * var(--ai-font-scale)); }
 .ai-context-distribution-label small, .ai-context-distribution-label strong { font-size: calc(9px * var(--ai-font-scale)); }
-.ai-send-button { font-size: calc(10px * var(--ai-font-scale)); }
 .ai-citation-main strong { font-size: calc(10px * var(--ai-font-scale)); }
 .ai-citation-main small, .ai-citation-main span, .message-citations span, .user-message-mentions { font-size: calc(9px * var(--ai-font-scale)); }
 .ai-history-item strong { font-size: calc(14px * var(--ai-font-scale)); }

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -2228,12 +2228,20 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(settingsAfter.body.data.titleGenerationModelId).toBe(modelId);
   });
 
-  it("浏览器中断流式连接会取消上游且保留已收到的助手正文", async () => {
+  it("浏览器中断流式连接会取消上游并保留此前完整 turn 与已收到的助手正文", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: [] }).expect(200);
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = String(conversation.body.data.id);
+    await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({
+      role: "user",
+      content: "此前完整问题"
+    }).expect(201);
+    await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({
+      role: "assistant",
+      content: "此前完整回答"
+    }).expect(201);
     let upstreamAborted = false;
     fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
@@ -2306,15 +2314,19 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamRequest).toMatchObject({ status: "cancelled", assistant_message_id: expect.any(String) });
 
     const reloaded = await request(runtime.app).get(`/api/ai-conversations/${conversationId}`).expect(200);
-    expect(reloaded.body.data.title).toBe("切换对话时取消旧流");
+    expect(reloaded.body.data.title).toBe("此前完整问题");
     expect(reloaded.body.data.messages.map((message: { role: string; content: string }) => ({ role: message.role, content: message.content }))).toEqual([
+      { role: "user", content: "此前完整问题" },
+      { role: "assistant", content: "此前完整回答" },
       { role: "user", content: "切换对话时取消旧流" },
       { role: "assistant", content: "不应落库的部分回复" }
     ]);
     expect(runtime.database.get("SELECT COUNT(*) AS count FROM ai_suggestions WHERE work_id = ?", workId)).toEqual({ count: 0 });
 
-    fetchMock.mockImplementation(async (input) => {
+    let resumedMessages: Array<{ role?: string; content?: string }> = [];
+    fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
+      resumedMessages = (JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ role?: string; content?: string }> }).messages ?? [];
       return new Response('data: {"choices":[{"delta":{"content":"取消后恢复"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n', {
         status: 200,
         headers: { "Content-Type": "text/event-stream" }
@@ -2330,6 +2342,19 @@ describe("AI 供应商、模型与建议 API", () => {
       })
       .expect(200);
     expect(resumed.text).toContain("event: complete");
+    expect(resumedMessages).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: "user", content: "此前完整问题" }),
+      expect.objectContaining({ role: "assistant", content: "此前完整回答" })
+    ]));
+    const resumedHistory = await request(runtime.app).get(`/api/ai-conversations/${conversationId}`).expect(200);
+    expect(resumedHistory.body.data.messages.map((message: { role: string; content: string }) => ({ role: message.role, content: message.content }))).toEqual([
+      { role: "user", content: "此前完整问题" },
+      { role: "assistant", content: "此前完整回答" },
+      { role: "user", content: "切换对话时取消旧流" },
+      { role: "assistant", content: "不应落库的部分回复" },
+      { role: "user", content: "取消后继续" },
+      { role: "assistant", content: "取消后恢复" }
+    ]);
   });
 
   it("客户端完成回调重试使用用户消息请求键避免重复 assistant 消息", async () => {

--- a/tests/system/ai-send-control-ui.test.ts
+++ b/tests/system/ai-send-control-ui.test.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("AI 对话发送与终止按钮", () => {
+  it("空闲时显示纸飞机并在生成期间切换为可用的终止按钮", async () => {
+    const publicPath = join(process.cwd(), "src", "public");
+    const [application, page, styles] = await Promise.all([
+      readFile(join(publicPath, "app.js"), "utf8"),
+      readFile(join(publicPath, "index.html"), "utf8"),
+      readFile(join(publicPath, "styles.css"), "utf8")
+    ]);
+
+    expect(page).toContain('id="ai-send" class="ai-send-button" type="button" data-state="send" aria-label="发送消息" title="发送消息"');
+    expect(page).toContain('class="ai-send-button-icon"');
+    expect(application).toContain("function aiSendButtonIconMarkup(stateName)");
+    expect(application).toContain('const stateName = sending ? "stop" : switching ? "switching" : "send";');
+    expect(application).toContain("button.disabled = switching;");
+    expect(application).toContain('button.classList.toggle("is-stop", sending);');
+    expect(application).toContain('const label = sending ? "终止当前回复" : switching ? "正在切换对话" : "发送消息";');
+    expect(styles).toContain(".ai-send-button-icon { width: 17px; height: 17px;");
+    expect(styles).toContain(".ai-send-button.is-stop");
+  });
+
+  it("点击终止只取消当前页签请求并恢复重新发送能力", async () => {
+    const publicPath = join(process.cwd(), "src", "public");
+    const [application, page] = await Promise.all([
+      readFile(join(publicPath, "app.js"), "utf8"),
+      readFile(join(publicPath, "index.html"), "utf8")
+    ]);
+
+    expect(application).toContain("function activateAiSendControl()");
+    expect(application).toContain('cancelActiveAiRequest("用户已终止当前回复")');
+    expect(application).toContain('toast("已终止当前回复，可以重新发送")');
+    expect(application).toContain('$("#ai-send").addEventListener("click", activateAiSendControl);');
+    expect(application).toContain("if (aiRequestManager.hasActive(tab.id)) return;");
+    expect(application).toContain('request.signal.reason.message === "用户已终止当前回复"');
+    expect(application).toContain('const cancelledByClient = request.signal.reason?.code === "AI_REQUEST_CANCELLED";');
+    expect(application).toContain('if (code === "AI_REQUEST_CANCELLED") return "已终止";');
+    expect(page).toContain("&feature=ai-send-control-v2");
+  });
+});

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -838,7 +838,9 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".left-actions { display: block; margin: 0 0 15px; }");
     expect(styles.text).toContain(".file-button { min-height: 30px; font-size: 11px;");
     expect(styles.text).toContain(".panel-heading { display: flex; align-items: center; gap: 8px; padding: 15px 0 9px 7px;");
-    expect(application.text).toContain('button.textContent = sending ? "发送中" : switching ? "切换中" : "发送";');
+    expect(application.text).toContain('const stateName = sending ? "stop" : switching ? "switching" : "send";');
+    expect(application.text).toContain('button.disabled = switching;');
+    expect(application.text).toContain('button.classList.toggle("is-stop", sending);');
     expect(application.text).toContain('content: normalizeParagraphSpacing($("#chapter-content").value)');
     expect(application.text).toContain("collapseChapterInputBlankLines(event.currentTarget)");
     expect(application.text).toContain("function openVolumeDialog(item)");

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');


### PR DESCRIPTION
## 变更

- 将聊天框文字发送按钮替换为纸飞机图标，并补充键盘焦点与无障碍状态。
- 生成期间原位切换为终止按钮，只取消当前对话页签的请求。
- 终止后保留已生成的部分回复、此前完整的 Agent turn 和同一会话历史，可立即继续发送。
- 增加发送/终止 UI 与流中断持久化回归覆盖。

## 验证

- `npm run typecheck`
- `npm test`：197 个测试文件、1007 项测试通过
- `npm run build`
- 内置浏览器桌面 `1600×900` 与窄屏 `390×844` 验收通过
- 真实验证终止、刷新后重开同一历史会话、继续发送和上下文保留
- 服务健康检查与隔离 SQLite `integrity_check` / `foreign_key_check` 通过