### PR TITLE
MUXUE-78: keep stop control visible in dark mode

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -2711,8 +2711,6 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .ai-send-button { display: grid; flex: 0 0 32px; place-items: center; width: 32px; min-width: 32px; height: 32px; padding: 0; border: 0; border-radius: 4px; background: var(--accent); color: #fff; box-shadow: 0 4px 12px rgba(139,61,44,.2); }
 .ai-send-button:hover, .ai-send-button:focus-visible { background: var(--accent-dark); outline: 0; }
 .ai-send-button:focus-visible { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 24%, transparent), 0 4px 12px rgba(139,61,44,.2); }
-.ai-send-button.is-stop { background: var(--ink); box-shadow: 0 4px 12px color-mix(in srgb, var(--ink) 22%, transparent); }
-.ai-send-button.is-stop:hover, .ai-send-button.is-stop:focus-visible { background: color-mix(in srgb, var(--ink) 84%, var(--accent)); }
 .ai-send-button:disabled { cursor: wait; opacity: .62; }
 .ai-send-button-icon { width: 17px; height: 17px; overflow: visible; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
 .ai-send-button.is-stop .ai-send-button-icon { width: 15px; height: 15px; fill: currentColor; stroke: none; }

--- a/tests/system/ai-send-control-ui.test.ts
+++ b/tests/system/ai-send-control-ui.test.ts
@@ -19,7 +19,9 @@ describe("AI 对话发送与终止按钮", () => {
     expect(application).toContain('button.classList.toggle("is-stop", sending);');
     expect(application).toContain('const label = sending ? "终止当前回复" : switching ? "正在切换对话" : "发送消息";');
     expect(styles).toContain(".ai-send-button-icon { width: 17px; height: 17px;");
-    expect(styles).toContain(".ai-send-button.is-stop");
+    expect(styles).toContain(".ai-send-button.is-stop .ai-send-button-icon");
+    expect(styles).not.toContain(".ai-send-button.is-stop { background");
+    expect(styles).not.toContain(".ai-send-button.is-stop:hover");
   });
 
   it("点击终止只取消当前页签请求并恢复重新发送能力", async () => {
@@ -37,6 +39,6 @@ describe("AI 对话发送与终止按钮", () => {
     expect(application).toContain('request.signal.reason.message === "用户已终止当前回复"');
     expect(application).toContain('const cancelledByClient = request.signal.reason?.code === "AI_REQUEST_CANCELLED";');
     expect(application).toContain('if (code === "AI_REQUEST_CANCELLED") return "已终止";');
-    expect(page).toContain("&feature=ai-send-control-v2");
+    expect(page).toContain("&feature=ai-send-control-v3");
   });
 });

--- a/tests/unit/frontend-script-syntax.test.ts
+++ b/tests/unit/frontend-script-syntax.test.ts
@@ -22,5 +22,5 @@ describe("前端脚本", () => {
     for (const file of files) {
       await expect(execFileAsync(process.execPath, ["--check", file])).resolves.toBeDefined();
     }
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
Closes MUXUE-78

## What changed

- Removed the stop-state background overrides so the stop control inherits the same accent background, hover, focus, and shadow styles as the send control.
- Kept the stop-specific square icon styling and bumped the stylesheet cache key.
- Added regression assertions preventing a separate stop-state background from returning.
- Raised the frontend syntax test timeout to 15 seconds because checking every public JavaScript file now consistently exceeds Vitest's 5-second default.

## Root cause

The `.is-stop` selector replaced the accent background with `var(--ink)`. In dark mode that resolves to a light surface, leaving the white stop icon with insufficient contrast.

## Validation

- `npm test -- tests/system/ai-send-control-ui.test.ts tests/system/module-layout-toggle.test.ts`
- `npm test -- tests/unit/frontend-script-syntax.test.ts`
- `npm run check` — 197 test files and 1007 tests passed, plus typecheck and production build
- Browser verification in dark mode at 1280×720 and 390×844, including click/keyboard cancellation, focus restoration, layout/overflow, and a clean console
- Isolated SQLite `integrity_check` and `foreign_key_check` passed