### PR TITLE
fix(ui): refresh analysis queue before closing dialog

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -13778,7 +13778,7 @@ async function openTaskDialog() {
     }
     taskListPage = 1;
     toast("分析任务已创建，已进入任务队列");
-    void refreshAnalysisTaskViewsAfterCreate(workId);
+    await refreshAnalysisTaskViewsAfterCreate(workId);
   }, "AI 分析", {
     large: true,
     submitLabel: "创建任务",

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1173,6 +1173,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1"></script>
   </body>
 </html>

--- a/tests/system/analysis-scope-ui.test.ts
+++ b/tests/system/analysis-scope-ui.test.ts
@@ -90,10 +90,11 @@ describe("AI 分析范围交互", () => {
     expect(application).toContain('pendingLabel: "创建中…"');
     expect(application).toContain('pendingMessage: "正在创建分析任务，请稍候"');
     expect(application).toContain('errorPrefix: "任务创建失败："');
-    expect(application).toContain('toast("分析任务已创建，已进入任务队列");\n    void refreshAnalysisTaskViewsAfterCreate(workId)');
+    expect(application).toContain('toast("分析任务已创建，已进入任务队列");\n    await refreshAnalysisTaskViewsAfterCreate(workId)');
     expect(application).toContain('async function refreshAnalysisTaskViewsAfterCreate(workId)');
     expect(application).toContain('renderTasks(1, { refresh: true })');
     expect(application).toContain('toast(`任务已创建，但列表刷新失败：${error.message}`, "error")');
+    expect(page).toContain('feature=analysis-task-queue-refresh-v1');
     expect(page).toContain('id="dialog-submit-status"');
     expect(page).toContain('class="dialog-submit-progress" role="progressbar"');
     expect(styles).toContain(".task-chapter-field.is-disabled { opacity: .48; }");

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');


### PR DESCRIPTION
## 变更内容

- 创建 AI 分析任务成功后，等待任务列表与后台任务中心完成主动刷新，再结束提交状态并关闭弹框
- 更新前端静态资源缓存标识与对应回归断言

## 根因

任务创建成功后的刷新调用使用了 `void`，通用弹框因此先结束提交并关闭；列表请求仍在后台执行，用户只能等待下一轮轮询才看到新任务。

## 用户影响

任务提交框关闭时，AI 分析列表和待执行队列计数已经包含刚创建的任务，不再出现 3–5 秒的视觉延迟。

## 验证

- `npm run typecheck`
- `npm test`：197 个测试文件、1007 项测试通过
- `npm run build`
- 内置浏览器桌面 1600×900 与窄屏 390×844 验收通过
- 隔离服务健康检查通过
- SQLite `integrity_check` 通过且无外键异常
