### PR TITLE
MUXUE-79: validate relationship source filters before task creation

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -700,6 +700,26 @@ type RelationshipLocalSourceSelection = {
   candidates: RelationshipVariantCandidate[];
 };
 
+type RelationshipSourcePreview = {
+  preFilterRelationshipSources: boolean;
+  chapterCount: number;
+  settingCount: number;
+  sourceCount: number;
+  totalCharacters: number;
+  estimatedBatchCount: number;
+  sources: Array<{
+    sourceType: string;
+    sourceId: string;
+    title: string;
+    version: string;
+    characterCount: number;
+    matchType: "exact" | "fuzzy" | "scope";
+  }>;
+  indexGeneration: number | null;
+  selectionSummary: RelationshipSourceSelection["summary"] | null;
+  verificationCallCount: number;
+};
+
 function traceRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
@@ -3608,11 +3628,12 @@ export class AiManager {
     };
   }
 
-  createTask(workId: string, input: {
+  async createTask(workId: string, input: {
     taskType: string;
     scope?: Record<string, unknown>;
     modelId?: string;
-  }): Record<string, unknown> {
+    rerunOfTaskId?: string;
+  }): Promise<Record<string, unknown>> {
     this.store.getWork(workId);
     const modelPurpose = this.analysisTaskModelPurpose(input.taskType);
     const defaultRow = this.store.db.get(
@@ -3622,26 +3643,50 @@ export class AiManager {
     );
     const modelId = input.modelId ?? (defaultRow ? stringValue(defaultRow, "model_id") : undefined);
     if (modelId) this.resolveModel(workId, modelPurpose, modelId);
-    const relationshipScope = input.taskType === "relationship-analysis" && input.scope
-      ? input.scope as ContextScope
+    const scope = { ...(input.scope ?? { type: "book" }) };
+    const relationshipScope = input.taskType === "relationship-analysis"
+      ? scope as ContextScope
       : null;
+    let relationshipSourceSelection: RelationshipSourceSelection | null = null;
     if (relationshipScope && Array.isArray(relationshipScope.relationshipSourceRefs)) {
       this.validateRelationshipSourceRefs(workId, relationshipScope, relationshipScope.relationshipSourceRefs);
     }
     if (modelId) {
       const contextPreview = this.previewAnalysisTaskContext(workId, {
         taskType: input.taskType,
-        scope: input.scope,
+        scope,
         modelId
       });
       if (contextPreview.allowed !== true) {
         throw new AppError(413, "AI_CONTEXT_TOO_LARGE", String(contextPreview.message), contextPreview);
       }
     }
-    return this.store.createTask(workId, {
-      taskType: input.taskType,
-      ...(input.scope ? { scope: input.scope } : {}),
-      ...(modelId ? { modelId } : {})
+    if (relationshipScope
+      && Array.isArray(relationshipScope.characterIds)
+      && relationshipScope.characterIds.length > 0
+      && relationshipScope.preFilterRelationshipSources !== false
+      && relationshipScope.relationshipSourceRefs === undefined) {
+      const prepared = await this.prepareRelationshipSourcePreview(workId, relationshipScope, modelId);
+      const preview = prepared.preview;
+      relationshipSourceSelection = prepared.sourceSelection;
+      relationshipScope.relationshipSourceRefs = preview.sources.map((source) => ({
+        sourceType: source.sourceType,
+        sourceId: source.sourceId,
+        sourceVersion: source.version
+      }));
+      this.validateRelationshipSourceRefs(workId, relationshipScope, relationshipScope.relationshipSourceRefs);
+    }
+    return this.store.db.transaction(() => {
+      if (relationshipScope && relationshipSourceSelection) {
+        relationshipSourceSelection.summary.reviewIds = this.createRelationshipVariantReviews(workId, relationshipSourceSelection);
+        relationshipScope.relationshipSourceSelectionSummary = { ...relationshipSourceSelection.summary };
+      }
+      return this.store.createTask(workId, {
+        taskType: input.taskType,
+        scope,
+        ...(modelId ? { modelId } : {}),
+        ...(input.rerunOfTaskId ? { rerunOfTaskId: input.rerunOfTaskId } : {})
+      });
     });
   }
 
@@ -4146,7 +4191,7 @@ export class AiManager {
     });
   }
 
-  rerunTask(taskId: string, modelOverrideId?: string): Record<string, unknown> {
+  async rerunTask(taskId: string, modelOverrideId?: string): Promise<Record<string, unknown>> {
     const original = this.store.getTask(taskId);
     const originalTaskType = String(original.taskType);
     if (HISTORICAL_ANALYSIS_TASK_TYPES.some((taskType) => taskType === originalTaskType)) {
@@ -4162,6 +4207,7 @@ export class AiManager {
     const {
       targetCharacters: _targetCharacters,
       relationshipSourceRefs: _relationshipSourceRefs,
+      relationshipSourceSelectionSummary: _relationshipSourceSelectionSummary,
       ...scope
     } = originalScope;
     const originalModel = original.model && typeof original.model === "object" && !Array.isArray(original.model)
@@ -4170,7 +4216,7 @@ export class AiManager {
     const originalModelId = typeof originalModel?.id === "string" ? originalModel.id : undefined;
     const modelId = modelOverrideId ?? originalModelId;
     if (modelId) this.resolveModel(String(original.workId), this.analysisTaskModelPurpose(String(original.taskType)), modelId);
-    const rerun = this.store.createTask(String(original.workId), {
+    const rerun = await this.createTask(String(original.workId), {
       taskType: originalTaskType,
       scope,
       ...(modelId ? { modelId } : {}),
@@ -4743,7 +4789,10 @@ export class AiManager {
           throw error;
         }
       }
-      const failedStatus = error instanceof AppError && error.code === "UNSUPPORTED_TASK_TYPE" ? "failed" : "partial";
+      const failedStatus = error instanceof AppError
+        && ["UNSUPPORTED_TASK_TYPE", "RELATIONSHIP_MATCH_CANDIDATES_EXCEEDED"].includes(error.code)
+        ? "failed"
+        : "partial";
       this.store.updateTask(taskId, { status: failedStatus, progress: 100, failures: [failure] });
       logger.error("ai.task.failed", { taskId, workId, durationMs: Number(process.hrtime.bigint() - startedAt) / 1_000_000, error: aiErrorForLog(error) });
       throw error;
@@ -8952,6 +9001,51 @@ export class AiManager {
     };
   }
 
+  private createRelationshipVariantReviews(workId: string, sourceSelection: RelationshipSourceSelection): string[] {
+    const acceptedVariants = sourceSelection.variantDecisions.filter((decision) => decision.verdict === "same" && decision.confidence >= 0.8);
+    const reviewIds = new Set<string>();
+    for (const decision of acceptedVariants) {
+      const observedIndex = decision.snippet.indexOf(decision.observed);
+      const quote = observedIndex < 0
+        ? decision.snippet.slice(0, 160)
+        : decision.snippet.slice(Math.max(0, observedIndex - 60), Math.min(decision.snippet.length, observedIndex + decision.observed.length + 60));
+      const dedupeKey = this.store.hashContent([
+        decision.targetCharacterId,
+        normalizeRelationshipSearchText(decision.observed),
+        decision.sourceType,
+        decision.sourceId,
+        decision.sourceVersion
+      ].join("|"));
+      const review = this.store.createReviewItem(workId, {
+        itemType: "character-name-variant",
+        dedupeKey,
+        severity: "medium",
+        title: `疑似人物名错字：${decision.observed} → ${decision.targetName}`,
+        description: `AI 判断来源“${decision.sourceTitle}”中的“${decision.observed}”可能指向人物“${decision.targetName}”。`,
+        entityRefs: [{
+          characterId: decision.targetCharacterId,
+          sourceType: decision.sourceType,
+          sourceId: decision.sourceId,
+          sourceVersion: decision.sourceVersion
+        }],
+        evidence: [{
+          sourceType: decision.sourceType,
+          sourceId: decision.sourceId,
+          sourceTitle: decision.sourceTitle,
+          sourceVersion: decision.sourceVersion,
+          observed: decision.observed,
+          quote,
+          confidence: decision.confidence,
+          reason: decision.reason
+        }],
+        suggestion: `请核对“${decision.observed}”是否为“${decision.targetName}”的错别字；确认后再修改原文或登记别名。`,
+        status: "pending"
+      });
+      reviewIds.add(String(review.id));
+    }
+    return [...reviewIds];
+  }
+
   private relationshipSettingSource(workId: string, sourceType: string, sourceId: string): RelationshipSettingSource | null {
     const cleanStrings = (value: unknown): unknown => {
       if (typeof value === "string") return collapseAiBlankLines(value);
@@ -9373,7 +9467,11 @@ export class AiManager {
     return String(Number(version?.version_no ?? 0));
   }
 
-  async previewRelationshipSources(workId: string, scope: ContextScope, modelId?: string): Promise<Record<string, unknown>> {
+  private async prepareRelationshipSourcePreview(
+    workId: string,
+    scope: ContextScope,
+    modelId?: string
+  ): Promise<{ preview: RelationshipSourcePreview; sourceSelection: RelationshipSourceSelection | null }> {
     const characters = this.store.listCharacters(workId);
     if (characters.length < 2) throw new AppError(409, "CHARACTERS_REQUIRED", "人物关系分析至少需要两个角色档案");
     const selectedCharacterIds = new Set(scope.characterIds ?? []);
@@ -9395,8 +9493,8 @@ export class AiManager {
       ?? (scope.type === "settings" || scope.includeAllSettings === true
         ? this.relationshipSettingSources(workId, characters)
         : []);
-    const sources = [
-      ...chapters.map((chapter) => ({
+    const sources: RelationshipSourcePreview["sources"] = [
+      ...chapters.map((chapter): RelationshipSourcePreview["sources"][number] => ({
         sourceType: "chapter",
         sourceId: String(chapter.id),
         title: String(chapter.title),
@@ -9404,7 +9502,7 @@ export class AiManager {
         characterCount: String(chapter.content ?? "").length,
         matchType: sourceSelection?.matchKinds[this.relationshipIndexedSourceKey("chapter", String(chapter.id))] ?? "scope"
       })),
-      ...settings.map((setting) => ({
+      ...settings.map((setting): RelationshipSourcePreview["sources"][number] => ({
         sourceType: setting.sourceType,
         sourceId: setting.sourceId,
         title: setting.title,
@@ -9417,17 +9515,24 @@ export class AiManager {
       throw new AppError(409, "RELATIONSHIP_SOURCE_PREVIEW_TOO_LARGE", "预检来源超过 5000 条，请缩小分析范围");
     }
     return {
-      preFilterRelationshipSources,
-      chapterCount: chapters.length,
-      settingCount: settings.length,
-      sourceCount: sources.length,
-      totalCharacters: sources.reduce((total, source) => total + source.characterCount, 0),
-      estimatedBatchCount: this.buildChapterChunks(chapters, 12_000).length + this.buildSettingChunks(settings, 12_000).length,
-      sources,
-      indexGeneration: sourceSelection?.generation ?? null,
-      selectionSummary: sourceSelection?.summary ?? null,
-      verificationCallCount: sourceSelection?.verificationCallIds.length ?? 0
+      preview: {
+        preFilterRelationshipSources,
+        chapterCount: chapters.length,
+        settingCount: settings.length,
+        sourceCount: sources.length,
+        totalCharacters: sources.reduce((total, source) => total + source.characterCount, 0),
+        estimatedBatchCount: this.buildChapterChunks(chapters, 12_000).length + this.buildSettingChunks(settings, 12_000).length,
+        sources,
+        indexGeneration: sourceSelection?.generation ?? null,
+        selectionSummary: sourceSelection?.summary ?? null,
+        verificationCallCount: sourceSelection?.verificationCallIds.length ?? 0
+      },
+      sourceSelection
     };
+  }
+
+  async previewRelationshipSources(workId: string, scope: ContextScope, modelId?: string): Promise<RelationshipSourcePreview> {
+    return (await this.prepareRelationshipSourcePreview(workId, scope, modelId)).preview;
   }
 
   private async runRelationshipAnalysis(workId: string, scope: ContextScope, modelId?: string, taskId?: string): Promise<Record<string, unknown>> {
@@ -10124,50 +10229,8 @@ export class AiManager {
       if (taskId && includesSettings) this.store.refreshTaskSourceVersions(taskId);
     }
     if (sourceSelection) {
-      const acceptedVariants = sourceSelection.variantDecisions.filter((decision) => decision.verdict === "same" && decision.confidence >= 0.8);
-      const reviewIds = new Set<string>();
-      this.store.db.transaction(() => {
-        for (const decision of acceptedVariants) {
-          const observedIndex = decision.snippet.indexOf(decision.observed);
-          const quote = observedIndex < 0
-            ? decision.snippet.slice(0, 160)
-            : decision.snippet.slice(Math.max(0, observedIndex - 60), Math.min(decision.snippet.length, observedIndex + decision.observed.length + 60));
-          const dedupeKey = this.store.hashContent([
-            decision.targetCharacterId,
-            normalizeRelationshipSearchText(decision.observed),
-            decision.sourceType,
-            decision.sourceId,
-            decision.sourceVersion
-          ].join("|"));
-          const review = this.store.createReviewItem(workId, {
-            itemType: "character-name-variant",
-            dedupeKey,
-            severity: "medium",
-            title: `疑似人物名错字：${decision.observed} → ${decision.targetName}`,
-            description: `AI 判断来源“${decision.sourceTitle}”中的“${decision.observed}”可能指向人物“${decision.targetName}”。`,
-            entityRefs: [{
-              characterId: decision.targetCharacterId,
-              sourceType: decision.sourceType,
-              sourceId: decision.sourceId,
-              sourceVersion: decision.sourceVersion
-            }],
-            evidence: [{
-              sourceType: decision.sourceType,
-              sourceId: decision.sourceId,
-              sourceTitle: decision.sourceTitle,
-              sourceVersion: decision.sourceVersion,
-              observed: decision.observed,
-              quote,
-              confidence: decision.confidence,
-              reason: decision.reason
-            }],
-            suggestion: `请核对“${decision.observed}”是否为“${decision.targetName}”的错别字；确认后再修改原文或登记别名。`,
-            status: "pending"
-          });
-          reviewIds.add(String(review.id));
-        }
-      });
-      sourceSelection.summary.reviewIds = [...reviewIds];
+      sourceSelection.summary.reviewIds = this.store.db.transaction(() =>
+        this.createRelationshipVariantReviews(workId, sourceSelection));
     }
     if (previewRelationshipChanges && taskId && includesSettings) this.store.refreshTaskSourceVersions(taskId);
     const relationshipResults = [...relationshipOutcomes.values()].map(({ action, relationship }) =>
@@ -10238,7 +10301,11 @@ export class AiManager {
       replacedRelationshipCount,
       preFilterRelationshipSources,
       sourcePreviewApplied: Boolean(previewedSources),
-      ...(sourceSelection ? { sourceSelection: sourceSelection.summary } : {}),
+      ...(sourceSelection
+        ? { sourceSelection: sourceSelection.summary }
+        : scope.relationshipSourceSelectionSummary
+          ? { sourceSelection: scope.relationshipSourceSelectionSummary }
+          : {}),
       callIds
     };
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -2380,11 +2380,18 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       input.modelId
     ));
   });
-  app.post("/api/works/:workId/tasks", (request, response) => {
+  app.post("/api/works/:workId/tasks", async (request, response) => {
     const input = parse(analysisTaskSchema, request.body);
+    const permissions = requestPermissions(request, request.params.workId);
+    const deniedModules = analysisTaskReadModules(input.taskType, input.scope).filter((module) => permissions[module] === "none");
+    if (deniedModules.length > 0) {
+      throw new AppError(403, "WORK_MODULE_READ_DENIED", "你没有读取创建分析任务所需资料模块的权限", {
+        modules: deniedModules
+      });
+    }
     data(response, redactTaskCharacterNames(
-      ai.createTask(request.params.workId, input),
-      requestPermissions(request, request.params.workId)
+      await ai.createTask(request.params.workId, input),
+      permissions
     ), 201);
   });
   app.post("/api/works/:workId/tasks/auto-run", (request, response) => {
@@ -2446,7 +2453,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       requestPermissions(request)
     ));
   });
-  app.post("/api/tasks/:taskId/rerun", (request, response) => {
+  app.post("/api/tasks/:taskId/rerun", async (request, response) => {
     const input = parse(z.object({ modelId: identifier.optional() }).strict(), request.body ?? {});
     const task = store.getTask(request.params.taskId);
     const permissions = requestPermissions(request, String(task.workId));
@@ -2457,7 +2464,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       });
     }
     data(response, redactTaskCharacterNames(
-      ai.rerunTask(request.params.taskId, input.modelId),
+      await ai.rerunTask(request.params.taskId, input.modelId),
       requestPermissions(request)
     ), 201);
   });

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -108,6 +108,17 @@ export type ContextScope = {
   preFilterRelationshipSources?: boolean;
   previewRelationshipChanges?: boolean;
   relationshipSourceRefs?: Array<{ sourceType: string; sourceId: string; sourceVersion: string }>;
+  /** 服务端创建任务时固化的来源筛选摘要；创建 API 不接收该内部字段。 */
+  relationshipSourceSelectionSummary?: {
+    policyVersion: number;
+    indexGeneration: number;
+    exactSourceCount: number;
+    fuzzyCandidateCount: number;
+    confirmedSourceCount: number;
+    rejectedSourceCount: number;
+    uncertainSourceCount: number;
+    reviewIds: string[];
+  };
   replaceExistingRelationships?: boolean;
   excludeRelationshipConstraints?: boolean;
   suppressAutomaticContext?: boolean;

--- a/tests/integration/feature-suite-api.test.ts
+++ b/tests/integration/feature-suite-api.test.ts
@@ -1693,10 +1693,17 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     }).expect(200);
 
     const rerun = await request(runtime.app).post(`/api/tasks/${original.body.data.id}/rerun`).send({}).expect(201);
-    expect(rerun.body.data.scope).not.toHaveProperty("relationshipSourceRefs");
+    expect(rerun.body.data.scope.relationshipSourceRefs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sourceType: "chapter",
+        sourceId: chapters[0].id,
+        sourceVersion: "2"
+      })
+    ]));
     expect(rerun.body.data.sourceVersions[chapters[0].id]).toBe(2);
     const completed = await request(runtime.app).post(`/api/tasks/${rerun.body.data.id}/run`).send({}).expect(200);
     expect(completed.body.data.status).toBe("review");
+    expect(completed.body.data.result.sourcePreviewApplied).toBe(true);
     expect(userPrompts.join("\n")).toContain("林舟与沈星在北港重新订立盟约。");
   });
 
@@ -2124,13 +2131,13 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
         additionalPrompt: "重点检查失联前后的关系连续性。"
       }
     }).expect(201);
-    expect(task.body.data.scopeSummary).toBe("全书 + 设定集 · 定向 2 人：林舟、沈星");
+    expect(task.body.data.scopeSummary).toBe("全书 + 设定集 · 定向 2 人：林舟、沈星 · 已预检 5 条来源");
     expect(task.body.data.scope.targetCharacters).toEqual([{ id: linId, name: "林舟" }, { id: shenId, name: "沈星" }]);
+    const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
     await request(runtime.app).patch(`/api/characters/${linId}`).send({ name: "林舟（调查员）" }).expect(200);
     const taskPage = await request(runtime.app).get(`/api/works/${workId}/tasks?page=1&limit=30`).expect(200);
     expect(taskPage.body.data.items.find((item: { id: string }) => item.id === task.body.data.id)?.scopeSummary)
-      .toBe("全书 + 设定集 · 定向 2 人：林舟、沈星");
-    const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
+      .toBe("全书 + 设定集 · 定向 2 人：林舟、沈星 · 已预检 5 条来源");
     expect(result.body.data.result).toMatchObject({
       candidateCount: 1,
       targetedCharacterIds: [linId, shenId],
@@ -2143,7 +2150,8 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     expect(userPrompts.some((prompt) => prompt.includes("小说人物关系全局归纳器"))).toBe(true);
     expect(userPrompts.some((prompt) => prompt.includes("沈星直接说明两人一直是朋友"))).toBe(true);
     expect(userPrompts.every((prompt) => !prompt.includes("北港旧约只认可长期互信"))).toBe(true);
-    expect(userPrompts.every((prompt) => prompt.includes("林舟") && prompt.includes("调查员"))).toBe(true);
+    expect(userPrompts.every((prompt) => prompt.includes("林舟"))).toBe(true);
+    expect(userPrompts.some((prompt) => prompt.includes("调查员"))).toBe(true);
     expect(systemPrompts.every((prompt) => prompt.includes("重点检查失联前后的关系连续性"))).toBe(true);
     const relationships = await request(runtime.app).get(`/api/works/${workId}/relationships`).expect(200);
     expect(relationships.body.data.some((relationship: { id: string }) => relationship.id === unrelated.body.data.id)).toBe(true);
@@ -2440,7 +2448,7 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     expect(selection.exactKeys).toContain(`setting:${setting.body.data.id}`);
   });
 
-  it("来源候选超限时保存结构化诊断并可通过身份资料修复", async () => {
+  it("来源候选超限时在创建前拒绝并让历史任务彻底失败", async () => {
     fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
       choices: [{ message: { content: "[]" } }]
     }), { status: 200, headers: { "Content-Type": "application/json" } }));
@@ -2452,13 +2460,12 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     (runtime.ai as unknown as { relationshipFuzzyIndexMatches: () => Set<string> }).relationshipFuzzyIndexMatches = () =>
       new Set(Array.from({ length: 201 }, (_, index) => `setting:diagnostic_${index}`));
 
-    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
+    const rejected = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
       taskType: "relationship-analysis",
       scope: { type: "book", includeAllSettings: true, characterIds: [target.body.data.id] },
       modelId
-    }).expect(201);
-    const failed = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({}).expect(409);
-    expect(failed.body.error).toMatchObject({
+    }).expect(409);
+    expect(rejected.body.error).toMatchObject({
       code: "RELATIONSHIP_MATCH_CANDIDATES_EXCEEDED",
       details: {
         characterId: target.body.data.id,
@@ -2468,7 +2475,18 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
         identityAnchorCount: 0
       }
     });
-    const detail = await request(runtime.app).get(`/api/tasks/${task.body.data.id}/detail`).expect(200);
+    const tasks = await request(runtime.app).get(`/api/works/${workId}/tasks`).expect(200);
+    expect(tasks.body.data.items).toEqual([]);
+
+    const legacyTask = runtime.store.createTask(workId, {
+      taskType: "relationship-analysis",
+      scope: { type: "book", includeAllSettings: true, characterIds: [target.body.data.id] },
+      modelId
+    });
+    const failed = await request(runtime.app).post(`/api/tasks/${legacyTask.id}/run`).send({}).expect(409);
+    expect(failed.body.error.code).toBe("RELATIONSHIP_MATCH_CANDIDATES_EXCEEDED");
+    const detail = await request(runtime.app).get(`/api/tasks/${legacyTask.id}/detail`).expect(200);
+    expect(detail.body.data.status).toBe("failed");
     expect(detail.body.data.failures).toEqual([expect.objectContaining({
       code: "RELATIONSHIP_MATCH_CANDIDATES_EXCEEDED",
       message: "“魔斯拉”的拼音疑似来源仍然过多；请取消勾选“分析前按人物名称和拼音过滤来源”后重新预览",
@@ -2500,12 +2518,14 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
       scope: { type: "book", includeAllSettings: true, characterIds: [target.body.data.id] },
       modelId
     }).expect(201);
+    expect(retry.body.data.scope.relationshipSourceRefs).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sourceType: "character", sourceId: target.body.data.id })
+    ]));
     const completed = await request(runtime.app).post(`/api/tasks/${retry.body.data.id}/run`).send({}).expect(200);
     expect(completed.body.data.result).toMatchObject({
       preFilterRelationshipSources: true,
-      sourceSelection: expect.objectContaining({ exactSourceCount: expect.any(Number) })
+      sourcePreviewApplied: true
     });
-    expect(completed.body.data.result.sourceSelection.exactSourceCount).toBeGreaterThan(0);
   });
 
   it("通过拼音疑似写法确认来源并并发安全地去重审核项", async () => {
@@ -2565,7 +2585,8 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     const runTask = async () => {
       const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
         taskType: "relationship-analysis",
-        scope: { type: "book", characterIds: [target.body.data.id] }
+        scope: { type: "book", characterIds: [target.body.data.id] },
+        modelId
       }).expect(201);
       return request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
     };
@@ -2589,12 +2610,19 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     expect(userPrompts.every((prompt) => !prompt.includes("这段正文没有任何目标人物，不应作为全文发送。"))).toBe(true);
 
     const promptCount = userPrompts.length;
-    await runTask();
+    const repeatedTask = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
+      taskType: "relationship-analysis",
+      scope: { type: "book", characterIds: [target.body.data.id] },
+      modelId
+    }).expect(201);
+    const verificationCountBeforeRun = userPrompts.filter((prompt) => prompt.includes("人物名称变体确认器")).length;
+    await request(runtime.app).post(`/api/tasks/${repeatedTask.body.data.id}/run`).send({}).expect(200);
+    expect(userPrompts.filter((prompt) => prompt.includes("人物名称变体确认器"))).toHaveLength(verificationCountBeforeRun);
     const repeatedTaskPrompts = userPrompts.slice(promptCount);
     expect(repeatedTaskPrompts.every((prompt) => !prompt.includes("审核项：疑似人物名错字"))).toBe(true);
   });
 
-  it("疑似写法确认结果不完整时不写入关系和审核项", async () => {
+  it("疑似写法确认结果不完整时在创建前失败且不写入任务和审核项", async () => {
     fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
       choices: [{ message: { content: "[]" } }]
     }), { status: 200, headers: { "Content-Type": "application/json" } }));
@@ -2606,13 +2634,14 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     const target = await request(runtime.app).post(`/api/works/${workId}/characters`).send({ name: "魔斯拉" }).expect(201);
     await request(runtime.app).post(`/api/works/${workId}/characters`).send({ name: "拉顿" }).expect(201);
     const modelId = await configureAi(runtime, workId);
-    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
+    const failed = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
       taskType: "relationship-analysis",
-      scope: { type: "book", characterIds: [target.body.data.id] }
-    }).expect(201);
-
-    const failed = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(502);
+      scope: { type: "book", characterIds: [target.body.data.id] },
+      modelId
+    }).expect(502);
     expect(failed.body.error.code).toBe("RELATIONSHIP_VARIANT_VERIFICATION_FAILED");
+    const tasks = await request(runtime.app).get(`/api/works/${workId}/tasks`).expect(200);
+    expect(tasks.body.data.items.filter((item: { taskType: string }) => item.taskType === "relationship-analysis")).toEqual([]);
     const relationships = await request(runtime.app).get(`/api/works/${workId}/relationships`).expect(200);
     expect(relationships.body.data).toEqual([]);
     const reviews = await request(runtime.app).get(`/api/works/${workId}/reviews`).expect(200);
@@ -2652,7 +2681,8 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
     };
     const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
       taskType: "relationship-analysis",
-      scope: { type: "book", characterIds: [target.body.data.id] }
+      scope: { type: "book", characterIds: [target.body.data.id] },
+      modelId
     }).expect(201);
     const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
     expect(result.body.data.result).toMatchObject({ coveredChapterCount: 1 });
@@ -2845,7 +2875,7 @@ describe("续写守卫和全书关系 Map-Reduce", () => {
       scope: { type: "book", characterIds: [linId], replaceExistingRelationships: true }
     });
     const task = await createTask().expect(201);
-    expect(task.body.data.scopeSummary).toBe("全书 · 定向 1 人：林舟 · 覆盖已有关系");
+    expect(task.body.data.scopeSummary).toBe("全书 · 定向 1 人：林舟 · 已预检 2 条来源 · 覆盖已有关系");
     const result = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({ modelId }).expect(200);
     expect(result.body.data.result.replacedRelationshipCount).toBe(2);
     const replaced = await request(runtime.app).get(`/api/works/${workId}/relationships`).expect(200);

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -2142,6 +2142,10 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-CSRF-Token", owner.csrfToken)
       .send({ name: "TOP_SECRET_CHARACTER" })
       .expect(201);
+    await owner.agent.post(`/api/works/${workId}/characters`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ name: "TOP_SECRET_OTHER" })
+      .expect(201);
     const targetedTask = await owner.agent.post(`/api/works/${workId}/tasks`)
       .set("X-CSRF-Token", owner.csrfToken)
       .send({
@@ -2149,7 +2153,7 @@ describe("用户、作品权限与操作者追踪 API", () => {
         scope: { type: "book", characterIds: [secretCharacter.body.data.id] }
       })
       .expect(201);
-    expect(targetedTask.body.data.scopeSummary).toBe("全书 · 定向 1 人：TOP_SECRET_CHARACTER");
+    expect(targetedTask.body.data.scopeSummary).toBe("全书 · 定向 1 人：TOP_SECRET_CHARACTER · 已预检 0 条来源");
     const collaboratorTargetedTask = await analysisOnly.agent.post(`/api/works/${workId}/tasks`)
       .set("X-CSRF-Token", analysisOnly.csrfToken)
       .send({
@@ -2217,13 +2221,13 @@ describe("用户、作品权限与操作者追踪 API", () => {
     await analysisOnly.agent.get(`/api/works/${workId}/characters`).expect(403);
     const protectedTasks = await analysisOnly.agent.get(`/api/works/${workId}/tasks?page=1&limit=30`).expect(200);
     const protectedTaskSummary = protectedTasks.body.data.items.find((item: { id: string }) => item.id === targetedTask.body.data.id);
-    expect(protectedTaskSummary.scopeSummary).toBe("全书 · 定向 1 人");
+    expect(protectedTaskSummary.scopeSummary).toBe("全书 · 定向 1 人 · 已预检 0 条来源");
     expect(JSON.stringify(protectedTaskSummary)).not.toContain("TOP_SECRET_CHARACTER");
     const protectedSelectionSummary = protectedTasks.body.data.items.find((item: { id: string }) => item.id === secretSelectionTask.body.data.id);
     expect(protectedSelectionSummary.scopeSummary).toBe("选定内容（正文读取权限受限）");
     expect(JSON.stringify(protectedSelectionSummary)).not.toContain("TOP_SECRET_SELECTION_PROSE");
     const protectedTaskDetail = await analysisOnly.agent.get(`/api/tasks/${targetedTask.body.data.id}`).expect(200);
-    expect(protectedTaskDetail.body.data.scopeSummary).toBe("全书 · 定向 1 人");
+    expect(protectedTaskDetail.body.data.scopeSummary).toBe("全书 · 定向 1 人 · 已预检 0 条来源");
     expect(protectedTaskDetail.body.data.scope.targetCharacters).toBeUndefined();
     expect(protectedTaskDetail.body.data.result.relationshipResults[0].fromCharacterName).toBeUndefined();
     expect(protectedTaskDetail.body.data.result.relationshipResults[0].toCharacterName).toBeUndefined();
@@ -2287,7 +2291,7 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-CSRF-Token", analysisOnly.csrfToken)
       .send({})
       .expect(200);
-    expect(protectedTaskCancellation.body.data.scopeSummary).toBe("全书 · 定向 1 人");
+    expect(protectedTaskCancellation.body.data.scopeSummary).toBe("全书 · 定向 1 人 · 已预检 0 条来源");
     expect(protectedTaskCancellation.body.data.scope.targetCharacters).toBeUndefined();
     expect(JSON.stringify(protectedTaskCancellation.body.data)).not.toContain("TOP_SECRET_CHARACTER");
     const protectedTaskRerun = await analysisOnly.agent.post(`/api/tasks/${targetedTask.body.data.id}/rerun`)


### PR DESCRIPTION
## Summary

- preflight targeted relationship source filtering before persisting a task
- persist and reuse validated source/version snapshots for task runs and reruns
- classify legacy pinyin candidate-limit failures as failed instead of partial
- preserve source-selection summaries, variant reviews, and module permission checks

## Verification

- npm run typecheck
- npx vitest run tests/integration/feature-suite-api.test.ts --maxWorkers=1
- npx vitest run tests/integration/task-creation-api.test.ts tests/integration/analysis-task-model.test.ts tests/integration/user-auth-api.test.ts --maxWorkers=1
- npm test (197 files, 1007 tests)
- npm run build

Closes MUXUE-79