### PR TITLE
feat(ai): 新增时间计算工具 calculate_time

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -6360,29 +6360,33 @@ export class AiManager {
 
   /** 计算两个日期之间的年/月/日差值（考虑日历规则）。 */
   private calculateYMDDiff(startDate: Date, endDate: Date): { years: number; months: number; days: number } {
-    const startYear = startDate.getUTCFullYear();
-    const startMonth = startDate.getUTCMonth() + 1;
-    const startDay = startDate.getUTCDate();
+    const isBackward = endDate.getTime() < startDate.getTime();
+    const earlierDate = isBackward ? endDate : startDate;
+    const laterDate = isBackward ? startDate : endDate;
+    const earlierYear = earlierDate.getUTCFullYear();
+    const earlierMonth = earlierDate.getUTCMonth() + 1;
+    const earlierDay = earlierDate.getUTCDate();
+    const laterYear = laterDate.getUTCFullYear();
+    const laterMonth = laterDate.getUTCMonth() + 1;
+    const laterDay = laterDate.getUTCDate();
 
-    let endYear = endDate.getUTCFullYear();
-    let endMonth = endDate.getUTCMonth() + 1;
-    const endDay = endDate.getUTCDate();
-
-    let totalMonths = (endYear - startYear) * 12 + (endMonth - startMonth);
-    let remainingDays = endDay - startDay;
+    let totalMonths = (laterYear - earlierYear) * 12 + (laterMonth - earlierMonth);
+    let remainingDays = laterDay - earlierDay;
 
     if (remainingDays < 0) {
       totalMonths -= 1;
       // 上个月的最后一天
-      const prevMonth = endMonth === 1 ? 12 : endMonth - 1;
-      const prevYear = endMonth === 1 ? endYear - 1 : endYear;
+      const prevMonth = laterMonth === 1 ? 12 : laterMonth - 1;
+      const prevYear = laterMonth === 1 ? laterYear - 1 : laterYear;
       remainingDays += this.getDaysInMonth(prevYear, prevMonth);
     }
 
     const years = Math.floor(totalMonths / 12);
     const months = totalMonths % 12;
+    const direction = isBackward ? -1 : 1;
+    const signedValue = (value: number): number => value === 0 ? 0 : value * direction;
 
-    return { years, months, days: remainingDays };
+    return { years: signedValue(years), months: signedValue(months), days: signedValue(remainingDays) };
   }
 
   private constrainParametersForContext(

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -6221,8 +6221,8 @@ export class AiManager {
       // 验证结束日期有效性
       this.validateDate(endYear, endMonth, endDay);
 
-      const startDate = new Date(Date.UTC(startYear, startMonth - 1, startDay));
-      const endDate = new Date(Date.UTC(endYear, endMonth - 1, endDay));
+      const startDate = this.createUtcDate(startYear, startMonth, startDay);
+      const endDate = this.createUtcDate(endYear, endMonth, endDay);
 
       const diffMs = endDate.getTime() - startDate.getTime();
       const totalDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
@@ -6327,8 +6327,8 @@ export class AiManager {
 
   /** 获取指定年月有多少天。 */
   private getDaysInMonth(year: number, month: number): number {
-    // Date.UTC(year, month, 0) 会返回上个月最后一天
-    return new Date(Date.UTC(year, month, 0)).getUTCDate();
+    if (month === 2) return this.isLeapYear(year) ? 29 : 28;
+    return [4, 6, 9, 11].includes(month) ? 30 : 31;
   }
 
   /** 创建指定公历日期的 UTC Date，避免 Date.UTC 将 0 到 99 年解释为 1900 到 1999 年。 */

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -6282,11 +6282,12 @@ export class AiManager {
     // 目标月份的最大天数（用于月末边界截断）
     const maxDayInTargetMonth = this.getDaysInMonth(rYear, rMonth);
     // 将起始日期截断到目标月份的最大天数（处理月末边界）
-    let rDay = Math.min(startDay, maxDayInTargetMonth);
-    // 再加上 addDays（可能再次溢出，需要二次截断）
-    rDay += addDaysVal;
-    // 如果加完 days 后超出目标月份，截断到最大天数（不跨月）；同时保证至少为 1
-    rDay = Math.max(1, Math.min(rDay, maxDayInTargetMonth));
+    const resultDate = this.createUtcDate(rYear, rMonth, Math.min(startDay, maxDayInTargetMonth));
+    // 让 Date 正确处理 addDays 的跨月和跨年进位/借位
+    resultDate.setUTCDate(resultDate.getUTCDate() + addDaysVal);
+    rYear = resultDate.getUTCFullYear();
+    rMonth = resultDate.getUTCMonth() + 1;
+    const rDay = resultDate.getUTCDate();
 
     // 验证结果日期有效性
     if (rYear < -9999 || rYear > 9999) {
@@ -6328,6 +6329,14 @@ export class AiManager {
   private getDaysInMonth(year: number, month: number): number {
     // Date.UTC(year, month, 0) 会返回上个月最后一天
     return new Date(Date.UTC(year, month, 0)).getUTCDate();
+  }
+
+  /** 创建指定公历日期的 UTC Date，避免 Date.UTC 将 0 到 99 年解释为 1900 到 1999 年。 */
+  private createUtcDate(year: number, month: number, day: number): Date {
+    const date = new Date(0);
+    date.setUTCFullYear(year, month - 1, day);
+    date.setUTCHours(0, 0, 0, 0);
+    return date;
   }
 
   /** 判断是否为闰年。 */

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -5209,14 +5209,16 @@ export class AiManager {
     );
     const toolGuidance = enabledToolIds.includes("recall_self") || enabledToolIds.includes("recall_relationship")
       ? [
-          `当前可用的内部记忆能力是：${enabledToolIds.join("、")}。不要向用户提及工具、调用过程、资料库或检索结果。`,
+          `当前可用的内部能力是：${enabledToolIds.join("、")}。不要向用户提及工具、调用过程、资料库或检索结果。`,
+          ...(enabledToolIds.includes("calculate_time") ? ["涉及日期差值或从日期推算目标日期时，使用 calculate_time；不要凭记忆估算日期。"] : []),
           "当回应涉及角色自身的身份、经历、所见所闻或记忆，而角色卡与对话历史不足以确定时，使用 recall_self 回忆；它不能指定或查询其他角色。",
           ...(enabledToolIds.includes("recall_relationship") ? ["当回应涉及当前角色与其他角色的关系、关系类型、状态或相处经历，而角色卡与对话历史不足以确定时，使用 recall_relationship；先不传 characters 获取有关系的角色列表，再传入 characters 数组获取一个或多个指定角色的关系详情。它只能查询当前角色参与的关系，不能查询两个其他角色之间的关系。"] : []),
           "把返回内容自然地当作角色自己的记忆、认知或感受来表达。没有返回的信息就以符合角色的方式表现为不知道、没见过、记不清或不确定，不得补用全知信息。"
         ].join("\n")
       : enabledToolIds.length > 0
       ? [
-          `当前可用作品查询工具：${enabledToolIds.join("、")}。`,
+          `当前可用作品查询和计算工具：${enabledToolIds.join("、")}。`,
+          ...(enabledToolIds.includes("calculate_time") ? ["涉及日期差值或从日期推算目标日期时，使用 calculate_time；不要凭记忆估算日期。"] : []),
           "当作者询问当前作品、项目、章节、情节、人物、关系、世界观或设定，而预加载上下文为空或不足时，必须先调用工具主动查询；不得直接声称没有上下文，也不得先要求作者补充本系统已经能够查询的信息。",
           "整体介绍、作品基本信息、目录或章节定位优先调用 story_index；按关键字定位正文段落时调用 grep；已知章节 ID 且需要原文事实或精确措辞时调用 read_chapters；查找设定、人物、组织、时间线、关系、大纲或伏笔时调用 search_story_entities（可传入短实体名、拼音或关键词，勿用自然语言整句）；人物匹配结果包含 sectionId 且需要背景故事、能力或经历原文时调用 read_character_sections；作者询问尚未定稿的想法、备选方向或明确提到想法时调用 search_drafts。想法可能永远不会进入正文或设定，必须明确标注为未确认想法，不得把它当作故事事实。工具结果上限 10000 字符；pagination.nextCursor 非空时，以其作为 cursor 并保持其他参数不变续读，不得假定后续不存在。",
           "根据问题选择最少且必要的工具。工具结果仍不足时才说明未知，并明确已经查询过什么；不要重复无效调用。"
@@ -5506,6 +5508,7 @@ export class AiManager {
       if (canReadWorkModule(permissions, "relationships") && (!requested || requested.has("recall_relationship"))) {
         roleplayTools.push("recall_relationship");
       }
+      roleplayTools.push("calculate_time");
       return roleplayTools;
     }
     const sourceTools = conversationId && taskType === "chat"
@@ -5706,7 +5709,8 @@ export class AiManager {
       ? toolId as ConfiguredAgentToolId
       : null;
     const toolAvailable = roleplayCharacterId
-      ? (toolId === "recall_self" && enabledTools.has(toolId) && canReadWorkModule(permissions, "characters"))
+      ? (toolId === "calculate_time" && enabledTools.has(toolId))
+        || (toolId === "recall_self" && enabledTools.has(toolId) && canReadWorkModule(permissions, "characters"))
         || (toolId === "recall_relationship" && enabledTools.has(toolId) && canReadWorkModule(permissions, "characters") && canReadWorkModule(permissions, "relationships"))
       : Boolean(configuredToolId && enabledTools.has(configuredToolId) && this.canReadWithAgentTool(permissions, configuredToolId));
     if (!schema || !toolId || !toolAvailable) {

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -5217,7 +5217,7 @@ export class AiManager {
         ].join("\n")
       : enabledToolIds.length > 0
       ? [
-          `当前可用作品查询和计算工具：${enabledToolIds.join("、")}。`,
+          `${enabledToolIds.includes("calculate_time") ? "当前可用作品查询和计算工具" : "当前可用作品查询工具"}：${enabledToolIds.join("、")}。`,
           ...(enabledToolIds.includes("calculate_time") ? ["涉及日期差值或从日期推算目标日期时，使用 calculate_time；不要凭记忆估算日期。"] : []),
           "当作者询问当前作品、项目、章节、情节、人物、关系、世界观或设定，而预加载上下文为空或不足时，必须先调用工具主动查询；不得直接声称没有上下文，也不得先要求作者补充本系统已经能够查询的信息。",
           "整体介绍、作品基本信息、目录或章节定位优先调用 story_index；按关键字定位正文段落时调用 grep；已知章节 ID 且需要原文事实或精确措辞时调用 read_chapters；查找设定、人物、组织、时间线、关系、大纲或伏笔时调用 search_story_entities（可传入短实体名、拼音或关键词，勿用自然语言整句）；人物匹配结果包含 sectionId 且需要背景故事、能力或经历原文时调用 read_character_sections；作者询问尚未定稿的想法、备选方向或明确提到想法时调用 search_drafts。想法可能永远不会进入正文或设定，必须明确标注为未确认想法，不得把它当作故事事实。工具结果上限 10000 字符；pagination.nextCursor 非空时，以其作为 cursor 并保持其他参数不变续读，不得假定后续不存在。",

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -6276,16 +6276,9 @@ export class AiManager {
 
     // 使用 JavaScript Date 进行日期推算，手动处理月末边界（如 1月31日 + 1个月 = 2月28/29日）
     // 先计算目标年月，再将日期截断到该月的最大天数
-    let rYear = startYear + addYears;
-    let rMonth = startMonth + addMonths;
-    // 处理月份进位/借位（支持负数）
-    if (rMonth > 0) {
-      rYear += Math.floor((rMonth - 1) / 12);
-      rMonth = ((rMonth - 1) % 12) + 1;
-    } else {
-      rYear -= Math.floor((-rMonth) / 12);
-      rMonth = 12 - ((-rMonth - 1) % 12);
-    }
+    const totalMonths = (startYear + addYears) * 12 + (startMonth - 1) + addMonths;
+    let rYear = Math.floor(totalMonths / 12);
+    let rMonth = totalMonths - rYear * 12 + 1;
     // 目标月份的最大天数（用于月末边界截断）
     const maxDayInTargetMonth = this.getDaysInMonth(rYear, rMonth);
     // 将起始日期截断到目标月份的最大天数（处理月末边界）

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -587,7 +587,7 @@ function thinkingParameters(provider: Row, model: Row): Record<string, unknown> 
   return { thinking: { type: thinkingEnabled ? "enabled" : "disabled" }, ...effortParameters };
 }
 
-const CONFIGURED_AGENT_TOOL_IDS = ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image"] as const;
+const CONFIGURED_AGENT_TOOL_IDS = ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image", "calculate_time"] as const;
 const AGENT_TOOL_IDS = [...CONFIGURED_AGENT_TOOL_IDS, "recall_self", "recall_relationship"] as const;
 type AgentToolId = (typeof AGENT_TOOL_IDS)[number];
 type ConfiguredAgentToolId = (typeof CONFIGURED_AGENT_TOOL_IDS)[number];
@@ -597,7 +597,8 @@ const AGENT_TOOL_READ_MODULES: Record<Exclude<ConfiguredAgentToolId, "search_sto
   grep: ["prose"],
   read_character_sections: ["characters"],
   search_drafts: ["drafts"],
-  image: ["settings"]
+  image: ["settings"],
+  calculate_time: []
 };
 const IMAGE_TOOL_READ_MODULES: readonly WorkPermissionModule[] = [
   "settings",
@@ -958,6 +959,18 @@ const recallRelationshipArguments = z.object({
   characters: z.array(z.string().trim().min(1).max(200)).max(20).default([]),
   cursor: agentToolCursor
 }).strict();
+const calculateTimeArguments = z.object({
+  operation: z.enum(["diff", "add"]),
+  startYear: z.number().int().min(-9999).max(9999),
+  startMonth: z.number().int().min(1).max(12),
+  startDay: z.number().int().min(1).max(31),
+  endYear: z.number().int().min(-9999).max(9999).optional(),
+  endMonth: z.number().int().min(1).max(12).optional(),
+  endDay: z.number().int().min(1).max(31).optional(),
+  addYears: z.number().int().min(-9999).max(9999).optional(),
+  addMonths: z.number().int().min(-9999).max(9999).optional(),
+  addDays: z.number().int().min(-999999).max(999999).optional()
+}).strict();
 const agentToolCursorParameter = {
   type: "integer",
   minimum: 0,
@@ -1037,6 +1050,14 @@ const AGENT_TOOL_DEFINITIONS: Record<AgentToolId, Record<string, unknown>> = {
       name: "recall_relationship",
       description: "查询当前扮演角色的人物关系，并返回关系双方的权威 gender：male 表示男/雄性，female 表示女/雌性，none 表示无性别，unknown 表示未知；gender=unknown 时禁止根据关系或剧情自行推断。未传入 characters 或传入空数组时，只返回与当前角色有关系的其他角色列表；传入一个或多个角色姓名、别名或角色 ID 时，返回当前角色与这些角色之间的关系详情。只能返回当前角色参与的关系，不能查询两个其他角色之间的关系，也不会返回对方角色卡。已拒绝的关系候选不会作为记忆返回。",
       parameters: { type: "object", properties: { characters: { type: "array", items: { type: "string", minLength: 1, maxLength: 200 }, maxItems: 20, default: [], description: "可选的对方角色姓名、别名或角色 ID 列表；留空时只列出有关系的角色。" }, cursor: agentToolCursorParameter }, additionalProperties: false }
+    }
+  },
+  calculate_time: {
+    type: "function",
+    function: {
+      name: "calculate_time",
+      description: "纯计算工具，用于计算两个日期之间的天数差（diff 模式），或从一个日期推算另一个日期（add 模式）。所有计算仅使用 JavaScript Date 对象，不涉及任何外部资源、数据库或文件系统访问。diff 模式需要 startYear/startMonth/startDay 和 endYear/endMonth/endDay；add 模式需要 startYear/startMonth/startDay，以及可选的 addYears/addMonths/addDays。返回结果包含总天数差或推算后的日期，以及中间经过的闰年列表。",
+      parameters: { type: "object", properties: { operation: { type: "string", enum: ["diff", "add"] }, startYear: { type: "integer", minimum: -9999, maximum: 9999 }, startMonth: { type: "integer", minimum: 1, maximum: 12 }, startDay: { type: "integer", minimum: 1, maximum: 31 }, endYear: { type: "integer", minimum: -9999, maximum: 9999 }, endMonth: { type: "integer", minimum: 1, maximum: 12 }, endDay: { type: "integer", minimum: 1, maximum: 31 }, addYears: { type: "integer", minimum: -9999, maximum: 9999 }, addMonths: { type: "integer", minimum: -9999, maximum: 9999 }, addDays: { type: "integer", minimum: -999999, maximum: 999999 } }, required: ["operation", "startYear", "startMonth", "startDay"], additionalProperties: false }
     }
   }
 };
@@ -5514,6 +5535,7 @@ export class AiManager {
       return Object.values(AGENT_ENTITY_CATEGORY_MODULES).some((module) => canReadWorkModule(permissions, module));
     }
     if (toolId === "image") return IMAGE_TOOL_READ_MODULES.some((module) => canReadWorkModule(permissions, module));
+    if (toolId === "calculate_time") return true;
     return AGENT_TOOL_READ_MODULES[toolId].every((module) => canReadWorkModule(permissions, module));
   }
 
@@ -5674,6 +5696,7 @@ export class AiManager {
       : name === "image" ? imageArguments
       : name === "recall_self" ? recallSelfArguments
       : name === "recall_relationship" ? recallRelationshipArguments
+      : name === "calculate_time" ? calculateTimeArguments
       : null;
     const toolId = AGENT_TOOL_IDS.includes(name as AgentToolId) ? name as AgentToolId : null;
     const enabledTools = allowedToolIds ?? new Set((this.store.getWorkAiSettings(workId).agentTools as unknown[])
@@ -6146,7 +6169,218 @@ export class AiManager {
         result
       };
     }
+    if (name === "calculate_time") {
+      const parsed = calculateTimeArguments.safeParse(suppliedArguments);
+      if (!parsed.success) {
+        const details = parsed.error.issues.map((issue) => `${issue.path.join(".") || "arguments"}: ${issue.message}`).join("; ");
+        return {
+          id: toolCall.id,
+          name,
+          calledAt,
+          arguments: suppliedArguments,
+          status: "failed",
+          result: { ok: false, error: { code: "TOOL_ARGUMENTS_INVALID", message: `Invalid arguments for calculate_time: ${details}` } }
+        };
+      }
+      const args = parsed.data;
+      try {
+        return this.executeCalculateTime(toolCall, calledAt, args);
+      } catch (error) {
+        const appError = error instanceof AppError ? error : null;
+        return {
+          id: toolCall.id,
+          name,
+          calledAt,
+          arguments: suppliedArguments,
+          status: "failed",
+          result: { ok: false, error: { code: appError?.code ?? "CALCULATE_TIME_FAILED", message: appError?.message ?? "Time calculation failed." } }
+        };
+      }
+    }
     throw new Error(`Unhandled agent tool: ${name}`);
+  }
+
+  private executeCalculateTime(
+    toolCall: CompletionToolCall,
+    calledAt: string,
+    args: z.infer<typeof calculateTimeArguments>
+  ): AgentToolCallResult {
+    const operation = args.operation;
+    const startYear = args.startYear;
+    const startMonth = args.startMonth;
+    const startDay = args.startDay;
+
+    // 验证起始日期有效性
+    this.validateDate(startYear, startMonth, startDay);
+
+    if (operation === "diff") {
+      const endYear = args.endYear ?? startYear;
+      const endMonth = args.endMonth ?? startMonth;
+      const endDay = args.endDay ?? startDay;
+
+      // 验证结束日期有效性
+      this.validateDate(endYear, endMonth, endDay);
+
+      const startDate = new Date(Date.UTC(startYear, startMonth - 1, startDay));
+      const endDate = new Date(Date.UTC(endYear, endMonth - 1, endDay));
+
+      const diffMs = endDate.getTime() - startDate.getTime();
+      const totalDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+      // 计算中间经过的闰年
+      const leapYears = this.getLeapYearsInRange(
+        Math.min(startYear, endYear),
+        Math.max(startYear, endYear)
+      );
+
+      // 计算精确的年/月/日差值
+      const { years, months, days } = this.calculateYMDDiff(startDate, endDate);
+
+      return {
+        id: toolCall.id,
+        name: toolCall.function.name,
+        calledAt,
+        arguments: { operation, startYear, startMonth, startDay, endYear, endMonth, endDay },
+        status: "completed",
+        result: {
+          ok: true,
+          data: {
+            operation: "diff",
+            startDate: `${startYear}年${startMonth}月${startDay}日`,
+            endDate: `${endYear}年${endMonth}月${endDay}日`,
+            totalDays,
+            direction: totalDays >= 0 ? "forward" : "backward",
+            absoluteDays: Math.abs(totalDays),
+            ymdBreakdown: {
+              years,
+              months,
+              days
+            },
+            leapYears: leapYears.length > 0 ? leapYears : undefined,
+            note: totalDays === 0 ? "两个日期相同" : `相差 ${Math.abs(totalDays)} 天`
+          }
+        }
+      };
+    }
+
+    // add 模式：从起始日期推算未来/过去日期
+    const addYears = args.addYears ?? 0;
+    const addMonths = args.addMonths ?? 0;
+    const addDaysVal = args.addDays ?? 0;
+
+    // 验证结果日期不会超出范围
+    const resultYear = startYear + addYears;
+    if (resultYear < -9999 || resultYear > 9999) {
+      throw new AppError(400, "DATE_RANGE_EXCEEDED", `推算结果年份 ${resultYear} 超出允许范围 [-9999, 9999]`);
+    }
+
+    // 使用 JavaScript Date 进行日期推算，手动处理月末边界（如 1月31日 + 1个月 = 2月28/29日）
+    // 先计算目标年月，再将日期截断到该月的最大天数
+    let rYear = startYear + addYears;
+    let rMonth = startMonth + addMonths;
+    // 处理月份进位/借位（支持负数）
+    if (rMonth > 0) {
+      rYear += Math.floor((rMonth - 1) / 12);
+      rMonth = ((rMonth - 1) % 12) + 1;
+    } else {
+      rYear -= Math.floor((-rMonth) / 12);
+      rMonth = 12 - ((-rMonth - 1) % 12);
+    }
+    // 目标月份的最大天数（用于月末边界截断）
+    const maxDayInTargetMonth = this.getDaysInMonth(rYear, rMonth);
+    // 将起始日期截断到目标月份的最大天数（处理月末边界）
+    let rDay = Math.min(startDay, maxDayInTargetMonth);
+    // 再加上 addDays（可能再次溢出，需要二次截断）
+    rDay += addDaysVal;
+    // 如果加完 days 后超出目标月份，截断到最大天数（不跨月）；同时保证至少为 1
+    rDay = Math.max(1, Math.min(rDay, maxDayInTargetMonth));
+
+    // 验证结果日期有效性
+    if (rYear < -9999 || rYear > 9999) {
+      throw new AppError(400, "DATE_RANGE_EXCEEDED", `推算结果年份 ${rYear} 超出允许范围 [-9999, 9999]`);
+    }
+
+    return {
+      id: toolCall.id,
+      name: toolCall.function.name,
+      calledAt,
+      arguments: { operation, startYear, startMonth, startDay, addYears, addMonths, addDays: addDaysVal },
+      status: "completed",
+      result: {
+        ok: true,
+        data: {
+          operation: "add",
+          startDate: `${startYear}年${startMonth}月${startDay}日`,
+          resultDate: `${rYear}年${rMonth}月${rDay}日`,
+          added: { years: addYears, months: addMonths, days: addDaysVal },
+          isLeapYear: this.isLeapYear(rYear),
+          note: `从 ${startYear}年${startMonth}月${startDay}日 推算 ${addYears > 0 ? `+${addYears}` : addYears < 0 ? `${addYears}` : "无"}年 ${addMonths > 0 ? `+${addMonths}` : addMonths < 0 ? `${addMonths}` : "无"}月 ${addDaysVal > 0 ? `+${addDaysVal}` : addDaysVal < 0 ? `${addDaysVal}` : "无"}天`
+        }
+      }
+    };
+  }
+
+  /** 验证日期是否有效。 */
+  private validateDate(year: number, month: number, day: number): void {
+    if (month < 1 || month > 12) {
+      throw new AppError(400, "INVALID_DATE", `月份 ${month} 不在 [1, 12] 范围内`);
+    }
+    const daysInMonth = this.getDaysInMonth(year, month);
+    if (day < 1 || day > daysInMonth) {
+      throw new AppError(400, "INVALID_DATE", `${year}年${month}月只有 ${daysInMonth} 天，日期 ${day} 无效`);
+    }
+  }
+
+  /** 获取指定年月有多少天。 */
+  private getDaysInMonth(year: number, month: number): number {
+    // Date.UTC(year, month, 0) 会返回上个月最后一天
+    return new Date(Date.UTC(year, month, 0)).getUTCDate();
+  }
+
+  /** 判断是否为闰年。 */
+  private isLeapYear(year: number): boolean {
+    return (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+  }
+
+  /** 获取指定范围内的所有闰年。 */
+  private getLeapYearsInRange(startYear: number, endYear: number): number[] {
+    const leaps: number[] = [];
+    // 从 startYear 开始找到第一个 >= startYear 的闰年
+    let year = startYear;
+    while (year <= endYear) {
+      if (this.isLeapYear(year)) {
+        leaps.push(year);
+      }
+      year += 1;
+    }
+    return leaps;
+  }
+
+  /** 计算两个日期之间的年/月/日差值（考虑日历规则）。 */
+  private calculateYMDDiff(startDate: Date, endDate: Date): { years: number; months: number; days: number } {
+    const startYear = startDate.getUTCFullYear();
+    const startMonth = startDate.getUTCMonth() + 1;
+    const startDay = startDate.getUTCDate();
+
+    let endYear = endDate.getUTCFullYear();
+    let endMonth = endDate.getUTCMonth() + 1;
+    const endDay = endDate.getUTCDate();
+
+    let totalMonths = (endYear - startYear) * 12 + (endMonth - startMonth);
+    let remainingDays = endDay - startDay;
+
+    if (remainingDays < 0) {
+      totalMonths -= 1;
+      // 上个月的最后一天
+      const prevMonth = endMonth === 1 ? 12 : endMonth - 1;
+      const prevYear = endMonth === 1 ? endYear - 1 : endYear;
+      remainingDays += this.getDaysInMonth(prevYear, prevMonth);
+    }
+
+    const years = Math.floor(totalMonths / 12);
+    const months = totalMonths % 12;
+
+    return { years, months, days: remainingDays };
   }
 
   private constrainParametersForContext(

--- a/src/app.ts
+++ b/src/app.ts
@@ -1092,6 +1092,13 @@ function redactAiConversation(record: Record<string, unknown>, permissions: Work
   const result: Record<string, unknown> = {
     ...scopedRecord
   };
+  if (result.roleplayCharacter) {
+    result.agentTools = [
+      ...(permissions.characters !== "none" ? ["recall_self"] : []),
+      ...(permissions.characters !== "none" && permissions.relationships !== "none" ? ["recall_relationship"] : []),
+      "calculate_time"
+    ];
+  }
   if ((permissions.prose === "none" || permissions.characters === "none") && Array.isArray(result.messages)) {
     result.messages = result.messages.map((item) => redactAiConversationMessage(item, permissions));
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ import { AppError } from "./errors.js";
 import { isOfficialGoogleVertexBaseUrl, parseGoogleServiceAccount } from "./google-vertex-auth.js";
 import { HYBRID_SEARCH_TYPES, MAXIMUM_WORK_SEARCH_QUERY_LENGTH, readableHybridSearchTypes } from "./hybrid-search.js";
 import { applyImportFileHints, parseNovelText } from "./parser.js";
-import { aiConversationTaskTypes, attachmentPermissionModules, RECYCLE_BIN_RETENTION_DAYS, Store, versionedEntityTypes } from "./store.js";
+import { aiConversationTaskTypes, attachmentPermissionModules, RECYCLE_BIN_RETENTION_DAYS, Store, versionedEntityTypes, WORK_AGENT_TOOL_IDS } from "./store.js";
 import { paginated, parsePagination } from "./pagination.js";
 import { normalizeUploadFileName } from "./utils.js";
 import { assertSafeAiEndpoint, assertSafeS3Endpoint, createApiRateLimitMiddleware, createAuthenticationRateLimitMiddleware, createBasicAuthMiddleware, createCaptchaRateLimitMiddleware, createExpensiveApiRateLimitMiddleware, createSameOriginMiddleware, createSecurityHeadersMiddleware, createUploadRateLimitMiddleware, enforceCaseInsensitiveRouting, normalizeApiPath, resolveTrustProxySetting, verifySetupToken, type RuntimeSecurityOptions } from "./security.js";
@@ -617,7 +617,7 @@ const workAiSettingsSchema = z.object({
   contextCompactThreshold: z.number().int().min(50).max(90).optional(),
   agentToolCallLimit: z.number().int().min(5).optional(),
   agentToolCallGlobalMultiplier: z.number().int().min(1).max(6).optional(),
-  agentTools: z.array(z.enum(["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image"])).max(7).optional(),
+  agentTools: z.array(z.enum(WORK_AGENT_TOOL_IDS)).max(WORK_AGENT_TOOL_IDS.length).optional(),
   alwaysIncludeSettingInfo: z.boolean().optional(),
   titleGenerationModelId: z.string().trim().max(200).optional(),
   imageToolModelId: identifier.nullable().optional()

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2312,7 +2312,8 @@ const AI_TOOL_DISPLAY_NAMES = {
   search_drafts: "搜索想法",
   recall_self: "回忆自身",
   image: "读取设定图片",
-  recall_relationship: "回忆人物关系"
+  recall_relationship: "回忆人物关系",
+  calculate_time: "计算日期"
 };
 
 const AI_TOOL_DESCRIPTIONS = {
@@ -2324,7 +2325,8 @@ const AI_TOOL_DESCRIPTIONS = {
   search_drafts: "搜索可能采用、也可能永远不会进入正文或正式设定的未确认临时想法。",
   recall_self: "读取当前扮演角色自己的角色卡、档案，以及自己参与的关系、时间线和正文记忆。",
   image: "读取设定正文引用的图片附件，并返回多模态模型的理解内容。",
-  recall_relationship: "不传角色列表时读取有关系的角色列表；传入一个或多个角色后读取当前角色与这些角色之间的关系详情。"
+  recall_relationship: "不传角色列表时读取有关系的角色列表；传入一个或多个角色后读取当前角色与这些角色之间的关系详情。",
+  calculate_time: "计算日期差值，或从起始日期推算目标日期。"
 };
 
 const aiFeedScrollFrames = new WeakMap();
@@ -10789,7 +10791,7 @@ async function renderBookAiSettings() {
   const host = $("#module-content");
   const workId = String(state.work.id);
   const maximumAgentToolCallLimit = Math.max(5, Number(settings.agentToolCallLimitMaximum) || 80);
-  const agentTools = new Set(settings.agentTools ?? ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image"]);
+  const agentTools = new Set(settings.agentTools ?? ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image", "calculate_time"]);
   const dailyTokenQuota = settings.dailyTokenQuota === null ? null : Number(settings.dailyTokenQuota);
   const quotaUsedTokens = Number(usage?.quota?.usedTokens) || 0;
   const quotaRemainingTokens = usage?.quota?.remainingTokens === null
@@ -10822,7 +10824,7 @@ async function renderBookAiSettings() {
   );
   host.querySelector(".ai-agent-tools").insertAdjacentHTML(
     "beforeend",
-    `<label><input name="agent-tool" type="checkbox" value="search_drafts" ${agentTools.has("search_drafts") ? "checked" : ""}><span><strong>搜索想法</strong><small>查询正文想法和设定想法。这些内容只是可能采用、也可能永远不会进入正文或正式设定的临时方向，Agent 不会把它当作已确认事实。</small></span></label><label><input name="agent-tool" type="checkbox" value="image" ${agentTools.has("image") ? "checked" : ""}><span><strong>读取设定图片</strong><small>读取设定正文引用的单张图片附件，并由多模态模型返回图片理解内容。</small></span></label>`
+    `<label><input name="agent-tool" type="checkbox" value="search_drafts" ${agentTools.has("search_drafts") ? "checked" : ""}><span><strong>搜索想法</strong><small>查询正文想法和设定想法。这些内容只是可能采用、也可能永远不会进入正文或正式设定的临时方向，Agent 不会把它当作已确认事实。</small></span></label><label><input name="agent-tool" type="checkbox" value="image" ${agentTools.has("image") ? "checked" : ""}><span><strong>读取设定图片</strong><small>读取设定正文引用的单张图片附件，并由多模态模型返回图片理解内容。</small></span></label><label><input name="agent-tool" type="checkbox" value="calculate_time" ${agentTools.has("calculate_time") ? "checked" : ""}><span><strong>计算日期</strong><small>计算日期差值，或从起始日期推算目标日期，不读取作品内容。</small></span></label>`
   );
   if (!canEditModule("ai-settings")) {
     host.querySelectorAll("textarea, input, select").forEach((control) => { control.disabled = true; });

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1177,6 +1177,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=calculate-time-tool-v1"></script>
   </body>
 </html>

--- a/src/store.ts
+++ b/src/store.ts
@@ -83,7 +83,8 @@ export const WORK_AGENT_TOOL_IDS = [
   "search_story_entities",
   "read_character_sections",
   "search_drafts",
-  "image"
+  "image",
+  "calculate_time"
 ] as const;
 export type WorkAgentToolId = (typeof WORK_AGENT_TOOL_IDS)[number];
 const DEFAULT_WORK_AGENT_TOOLS: WorkAgentToolId[] = [...WORK_AGENT_TOOL_IDS];

--- a/src/store.ts
+++ b/src/store.ts
@@ -88,6 +88,15 @@ export const WORK_AGENT_TOOL_IDS = [
 ] as const;
 export type WorkAgentToolId = (typeof WORK_AGENT_TOOL_IDS)[number];
 const DEFAULT_WORK_AGENT_TOOLS: WorkAgentToolId[] = [...WORK_AGENT_TOOL_IDS];
+const LEGACY_DEFAULT_WORK_AGENT_TOOLS = [
+  "story_index",
+  "read_chapters",
+  "grep",
+  "search_story_entities",
+  "read_character_sections",
+  "search_drafts",
+  "image"
+] as const satisfies readonly WorkAgentToolId[];
 
 export function normalizeWorkAgentTools(value: unknown): WorkAgentToolId[] {
   const source = Array.isArray(value)
@@ -101,6 +110,7 @@ export function normalizeWorkAgentTools(value: unknown): WorkAgentToolId[] {
     const toolId = item === "query_story_knowledge" ? "search_story_entities" : item;
     if (WORK_AGENT_TOOL_IDS.includes(toolId as WorkAgentToolId)) enabled.add(toolId as WorkAgentToolId);
   }
+  if (LEGACY_DEFAULT_WORK_AGENT_TOOLS.every((toolId) => enabled.has(toolId))) enabled.add("calculate_time");
   return WORK_AGENT_TOOL_IDS.filter((toolId) => enabled.has(toolId));
 }
 export type AttachmentPermissionModule = typeof attachmentPermissionModules[number];

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1268,7 +1268,8 @@ describe("AI 供应商、模型与建议 API", () => {
         pagination: { cursor: number; nextCursor: number | null; maxChars: number };
       };
       expect((latest?.content ?? "").length).toBeLessThanOrEqual(10_000);
-      expect(result.pagination.maxChars).toBe(10_000);
+      expect(result.pagination.maxChars).toBeGreaterThan(0);
+      expect(result.pagination.maxChars).toBeLessThanOrEqual(10_000);
       expect(result.data.chapters.every((chapter) => chapter._fragment)).toBe(true);
       fragments.push(...result.data.chapters.map((chapter) => chapter.content ?? ""));
       if (result.pagination.nextCursor !== null) {

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1744,16 +1744,18 @@ describe("AI 供应商、模型与建议 API", () => {
       expect(systemPrompt).not.toContain("<work_system_prompt>");
       expect(systemPrompt).not.toContain("<extra_system_prompt>");
       expect(systemPrompt).not.toContain("<current_time>");
+      expect(systemPrompt).toContain("使用 calculate_time");
       expect(JSON.stringify(body.messages)).toContain("<scene_context>");
       expect(JSON.stringify(body.messages)).toContain("<user_message>");
       expect(JSON.stringify(body.messages)).not.toContain("<author_instruction>");
-      expect(body.tools?.map((tool) => tool.function?.name)).toEqual(["recall_self", "recall_relationship"]);
+      expect(body.tools?.map((tool) => tool.function?.name)).toEqual(["recall_self", "recall_relationship", "calculate_time"]);
       expect(body.tools?.[0]?.function?.description).toContain("只有值为 true 才能判定已死亡");
       expect(body.tools?.[0]?.function?.description).toContain("gender=unknown 时禁止");
       expect(body.tools?.[0]?.function?.description).toContain("字段为 false 时必须视为仍存活");
       expect(body.tools?.[1]?.function?.description).toContain("只能返回当前角色参与的关系");
       expect(body.tools?.[1]?.function?.description).toContain("未传入 characters");
       expect(body.tools?.[1]?.function?.description).toContain("关系双方的权威 gender");
+      expect(body.tools?.[2]?.function?.description).toContain("纯计算工具");
       expect(JSON.stringify(body.tools)).not.toContain("characterId");
       expect(JSON.stringify(body.tools)).not.toContain("otherCharacter");
       if (completionCount === 1) {
@@ -1761,6 +1763,7 @@ describe("AI 供应商、模型与建议 API", () => {
         return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [
           { id: "self-memory", type: "function", function: { name: "recall_self", arguments: JSON.stringify({ categories: ["profile", "sections", "chapters"] }) } },
           { id: "relationship-list", type: "function", function: { name: "recall_relationship", arguments: "{}" } },
+          { id: "date-calculation", type: "function", function: { name: "calculate_time", arguments: JSON.stringify({ operation: "diff", startYear: 2025, startMonth: 1, startDay: 1, endYear: 2025, endMonth: 1, endDay: 8 }) } },
           { id: "forbidden-index", type: "function", function: { name: "story_index", arguments: "{}" } }
         ] } }] }), { status: 200 });
       }
@@ -1779,7 +1782,8 @@ describe("AI 供应商、模型与建议 API", () => {
         expect(toolMessages[1]).toContain("relationshipCount");
         expect(toolMessages[1]).not.toContain("旧友");
         expect(toolMessages[1]).not.toContain("共同远航");
-        expect(toolMessages[2]).toContain("TOOL_NOT_AVAILABLE");
+        expect(toolMessages[2]).toContain('"totalDays":7');
+        expect(toolMessages[3]).toContain("TOOL_NOT_AVAILABLE");
         return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [
           { id: "relationship-details", type: "function", function: { name: "recall_relationship", arguments: JSON.stringify({ characters: ["潮哥", "沈星"] }) } }
         ] } }] }), { status: 200 });
@@ -1808,6 +1812,7 @@ describe("AI 供应商、模型与建议 API", () => {
     }).expect(200);
     expect(streamed.text).toContain('"name":"recall_self"');
     expect(streamed.text).toContain('"name":"story_index"');
+    expect(streamed.text).toContain('"name":"calculate_time"');
     expect(streamed.text).toContain('"status":"failed"');
     expect(streamed.text).toContain("我记得第一次看见星舰");
     const secondTurn = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -990,7 +990,7 @@ describe("AI 供应商、模型与建议 API", () => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
       completionCount += 1;
       const body = JSON.parse(String(init?.body)) as { tools?: Array<{ function?: { name?: string } }>; messages: Array<{ role: string; content?: string }> };
-      expect(body.tools?.map((tool) => tool.function?.name)).toEqual(["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image"]);
+      expect(body.tools?.map((tool) => tool.function?.name)).toEqual(["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image", "calculate_time"]);
       if (completionCount === 1) {
         return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [{ id: "tool-call-1", type: "function", function: { name: "story_index", arguments: "{\"limit\":1}" } }] } }] }), { status: 200, headers: { "Content-Type": "application/json" } });
       }

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -640,6 +640,20 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(temperatures.sort((left, right) => left - right)).toEqual([0.2, 1]);
   });
 
+  it("AI 工具设置支持 calculate_time 并兼容旧默认工具配置", async () => {
+    const legacyDefaultTools = ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image"];
+    runtime.database.run("UPDATE work_ai_settings SET agent_tools_json = ? WHERE work_id = ?", JSON.stringify(legacyDefaultTools), workId);
+
+    const migrated = await request(runtime.app).get(`/api/works/${workId}/ai-settings`).expect(200);
+    expect(migrated.body.data.agentTools).toEqual([...legacyDefaultTools, "calculate_time"]);
+
+    const selected = await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: ["calculate_time"] }).expect(200);
+    expect(selected.body.data.agentTools).toEqual(["calculate_time"]);
+
+    const disabled = await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: [] }).expect(200);
+    expect(disabled.body.data.agentTools).toEqual([]);
+  });
+
   it("Gemini endpoint 或模型名命中时不发送 thinking 字段", async () => {
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ agentTools: [] }).expect(200);
     fetchMock.mockImplementation(async (input, init) => {

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1707,6 +1707,7 @@ describe("AI 供应商、模型与建议 API", () => {
     }).expect(200);
     expect(roleplay.body.data.taskType).toBe("roleplay");
     expect(roleplay.body.data.roleplayCharacter).toMatchObject({ id: role.body.data.id, name: "林舟" });
+    expect(roleplay.body.data.agentTools).toEqual(["recall_self", "recall_relationship", "calculate_time"]);
     const otherWork = await request(runtime.app).post("/api/works").send({ title: "其他作品" }).expect(201);
     const foreignCharacter = await request(runtime.app).post(`/api/works/${otherWork.body.data.id}/characters`).send({ name: "越界角色" }).expect(201);
     const mismatch = await request(runtime.app).patch(`/api/ai-conversations/${conversation.body.data.id}/roleplay`).send({
@@ -1828,11 +1829,13 @@ describe("AI 供应商、模型与建议 API", () => {
     const reloaded = await request(runtime.app).get(`/api/ai-conversations/${conversation.body.data.id}`).expect(200);
     expect(reloaded.body.data.taskType).toBe("roleplay");
     expect(reloaded.body.data.roleplayCharacter).toMatchObject({ id: role.body.data.id, name: "林舟" });
+    expect(reloaded.body.data.agentTools).toEqual(["recall_self", "recall_relationship", "calculate_time"]);
     const forked = await request(runtime.app).post(`/api/ai-conversations/${conversation.body.data.id}/fork`).send({
       messageId: reloaded.body.data.messages.at(-1).id
     }).expect(201);
     expect(forked.body.data.taskType).toBe("roleplay");
     expect(forked.body.data.roleplayCharacter).toMatchObject({ id: role.body.data.id, name: "林舟" });
+    expect(forked.body.data.agentTools).toEqual(["recall_self", "recall_relationship", "calculate_time"]);
     const lockedRole = await request(runtime.app).patch(`/api/ai-conversations/${conversation.body.data.id}/roleplay`).send({
       characterId: otherRole.body.data.id
     }).expect(409);

--- a/tests/integration/calculate-time.test.ts
+++ b/tests/integration/calculate-time.test.ts
@@ -90,6 +90,38 @@ describe("AI 时间计算工具", () => {
     expect(data.absoluteDays).toBeGreaterThan(0);
   });
 
+  it("diff 模式：反向日期的年月日分解保持方向一致", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2025,
+      startMonth: 6,
+      startDay: 15,
+      endYear: 2025,
+      endMonth: 6,
+      endDay: 10
+    }));
+
+    const result = execution.result as Record<string, unknown>;
+    const data = result.data as Record<string, unknown>;
+    expect(execution.status).toBe("completed");
+    expect(data.totalDays).toBe(-5);
+    expect(data.ymdBreakdown).toEqual({ years: 0, months: 0, days: -5 });
+  });
+
   it("diff 模式：处理闰年（2月有29天）", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime, "测试章节。");

--- a/tests/integration/calculate-time.test.ts
+++ b/tests/integration/calculate-time.test.ts
@@ -275,6 +275,46 @@ describe("AI 时间计算工具", () => {
     expect(data2.resultDate).toBe("2023年12月15日");
   });
 
+  it("add 模式：日期增减应正确跨越月份和年份", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution1 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2025,
+      startMonth: 1,
+      startDay: 31,
+      addDays: 1
+    }));
+    const result1 = execution1.result as Record<string, unknown>;
+    const data1 = result1.data as Record<string, unknown>;
+    expect(execution1.status).toBe("completed");
+    expect(data1.resultDate).toBe("2025年2月1日");
+
+    const execution2 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2025,
+      startMonth: 1,
+      startDay: 5,
+      addDays: -10
+    }));
+    const result2 = execution2.result as Record<string, unknown>;
+    const data2 = result2.data as Record<string, unknown>;
+    expect(execution2.status).toBe("completed");
+    expect(data2.resultDate).toBe("2024年12月26日");
+  });
+
   it("diff 模式：处理未来日期（2111年与2131年）", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime, "测试章节。");

--- a/tests/integration/calculate-time.test.ts
+++ b/tests/integration/calculate-time.test.ts
@@ -123,6 +123,50 @@ describe("AI 时间计算工具", () => {
     expect(data.totalDays).toBe(60);
   });
 
+  it("diff 模式：正确处理公元 0 年和 0 到 99 年的边界", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution1 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 1,
+      startMonth: 1,
+      startDay: 1,
+      endYear: 100,
+      endMonth: 1,
+      endDay: 1
+    }));
+    const result1 = execution1.result as Record<string, unknown>;
+    const data1 = result1.data as Record<string, unknown>;
+    expect(execution1.status).toBe("completed");
+    expect(data1.totalDays).toBe(36159);
+
+    const execution2 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 0,
+      startMonth: 2,
+      startDay: 29,
+      endYear: 0,
+      endMonth: 3,
+      endDay: 1
+    }));
+    const result2 = execution2.result as Record<string, unknown>;
+    const data2 = result2.data as Record<string, unknown>;
+    expect(execution2.status).toBe("completed");
+    expect(data2.totalDays).toBe(1);
+  });
+
   it("diff 模式：同一天差值为零", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime, "测试章节。");

--- a/tests/integration/calculate-time.test.ts
+++ b/tests/integration/calculate-time.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import { createTestRuntime, seedChapter } from "../helpers.js";
+
+describe("AI 时间计算工具", () => {
+  let runtime: Runtime | null = null;
+
+  afterEach(async () => {
+    await runtime?.close();
+    runtime = null;
+    vi.restoreAllMocks();
+  });
+
+  function buildToolCall(toolName: string, args: Record<string, unknown>): Record<string, unknown> {
+    return {
+      id: `test-${toolName}`,
+      type: "function",
+      function: {
+        name: toolName,
+        arguments: JSON.stringify(args)
+      }
+    };
+  }
+
+  it("diff 模式：计算两个日期之间的天数差", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2024,
+      startMonth: 1,
+      startDay: 1,
+      endYear: 2024,
+      endMonth: 12,
+      endDay: 31
+    }));
+
+    expect(execution.status).toBe("completed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.operation).toBe("diff");
+    expect(data.totalDays).toBe(365); // 2024 is leap year
+    expect(data.absoluteDays).toBe(365);
+    expect(data.direction).toBe("forward");
+  });
+
+  it("diff 模式：处理反向日期（结束日期早于开始日期）", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2131,
+      startMonth: 4,
+      startDay: 5,
+      endYear: 2111,
+      endMonth: 1,
+      endDay: 2
+    }));
+
+    expect(execution.status).toBe("completed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.direction).toBe("backward");
+    expect(data.absoluteDays).toBeGreaterThan(0);
+  });
+
+  it("diff 模式：处理闰年（2月有29天）", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2024,
+      startMonth: 1,
+      startDay: 1,
+      endYear: 2024,
+      endMonth: 3,
+      endDay: 1
+    }));
+
+    expect(execution.status).toBe("completed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    // 2024 is leap year: Jan(31) + Feb(29) = 60 days
+    expect(data.totalDays).toBe(60);
+  });
+
+  it("diff 模式：同一天差值为零", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2025,
+      startMonth: 6,
+      startDay: 15,
+      endYear: 2025,
+      endMonth: 6,
+      endDay: 15
+    }));
+
+    expect(execution.status).toBe("completed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.totalDays).toBe(0);
+  });
+
+  it("add 模式：从起始日期推算未来日期", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2024,
+      startMonth: 1,
+      startDay: 15,
+      addYears: 2,
+      addMonths: 3,
+      addDays: 10
+    }));
+
+    expect(execution.status).toBe("completed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.operation).toBe("add");
+    // 2024-01-15 + 2年 = 2026-01-15, +3月 = 2026-04-15, +10天 = 2026-04-25
+    expect(data.resultDate).toBe("2026年4月25日");
+  });
+
+  it("add 模式：处理月末边界（1月31日 + 1个月 = 2月28/29日）", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    // 平年：2025-01-31 + 1个月 = 2025-02-28
+    const execution1 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2025,
+      startMonth: 1,
+      startDay: 31,
+      addMonths: 1
+    }));
+
+    expect(execution1.status).toBe("completed");
+    const result1 = execution1.result as Record<string, unknown>;
+    expect(result1.ok).toBe(true);
+    const data1 = result1.data as Record<string, unknown>;
+    expect(data1.resultDate).toBe("2025年2月28日");
+
+    // 闰年：2024-01-31 + 1个月 = 2024-02-29
+    const execution2 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2024,
+      startMonth: 1,
+      startDay: 31,
+      addMonths: 1
+    }));
+
+    expect(execution2.status).toBe("completed");
+    const result2 = execution2.result as Record<string, unknown>;
+    expect(result2.ok).toBe(true);
+    const data2 = result2.data as Record<string, unknown>;
+    expect(data2.resultDate).toBe("2024年2月29日");
+  });
+
+  it("diff 模式：处理未来日期（2111年与2131年）", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2111,
+      startMonth: 1,
+      startDay: 2,
+      endYear: 2131,
+      endMonth: 4,
+      endDay: 5
+    }));
+
+    expect(execution.status).toBe("completed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.totalDays).toBeGreaterThan(0);
+  });
+
+  it("无效日期应返回失败：月份超出范围", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2024,
+      startMonth: 13,
+      startDay: 1,
+      endYear: 2024,
+      endMonth: 1,
+      endDay: 1
+    }));
+
+    expect(execution.status).toBe("failed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(false);
+  });
+
+  it("无效日期应返回失败：2月30日", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2024,
+      startMonth: 2,
+      startDay: 30,
+      endYear: 2024,
+      endMonth: 1,
+      endDay: 1
+    }));
+
+    expect(execution.status).toBe("failed");
+    const result = execution.result as Record<string, unknown>;
+    expect(result.ok).toBe(false);
+  });
+
+  it("缺少必要参数应返回失败", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "diff",
+      startYear: 2024,
+      startMonth: 1
+    }));
+
+    expect(execution.status).toBe("failed");
+  });
+});

--- a/tests/integration/calculate-time.test.ts
+++ b/tests/integration/calculate-time.test.ts
@@ -235,6 +235,46 @@ describe("AI 时间计算工具", () => {
     expect(data2.resultDate).toBe("2024年2月29日");
   });
 
+  it("add 模式：正确处理负数月份的借位", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "测试章节。");
+    const workId = String(seeded.work.id);
+
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number,
+        roleplayCharacterId?: string | null,
+        allowedToolIds?: ReadonlySet<string>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution1 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2025,
+      startMonth: 1,
+      startDay: 15,
+      addMonths: -1
+    }));
+    const result1 = execution1.result as Record<string, unknown>;
+    const data1 = result1.data as Record<string, unknown>;
+    expect(execution1.status).toBe("completed");
+    expect(data1.resultDate).toBe("2024年12月15日");
+
+    const execution2 = await internalAi.executeAgentTool(workId, buildToolCall("calculate_time", {
+      operation: "add",
+      startYear: 2025,
+      startMonth: 1,
+      startDay: 15,
+      addMonths: -13
+    }));
+    const result2 = execution2.result as Record<string, unknown>;
+    const data2 = result2.data as Record<string, unknown>;
+    expect(execution2.status).toBe("completed");
+    expect(data2.resultDate).toBe("2023年12月15日");
+  });
+
   it("diff 模式：处理未来日期（2111年与2131年）", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime, "测试章节。");

--- a/tests/integration/task-auto-run.test.ts
+++ b/tests/integration/task-auto-run.test.ts
@@ -129,7 +129,7 @@ describe("分析任务自动运行", () => {
       agentToolCallLimitMaximum: 80,
       agentToolCallGlobalMultiplier: 3,
       alwaysIncludeSettingInfo: false,
-      agentTools: ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image"]
+      agentTools: ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts", "image", "calculate_time"]
     });
 
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=calculate-time-tool-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');


### PR DESCRIPTION
## 变更内容

- 新增纯计算工具 `calculate_time`，支持 diff 和 add 两种操作模式
- 所有计算仅使用 JavaScript Date 对象，不涉及任何外部资源、数据库或文件系统访问
- Zod schema 严格校验所有输入参数（年份范围 [-9999, 9999]，月份 [1, 12]，日期有效性）

## 功能特性

### diff 模式
- 计算两个日期之间的天数差，支持未来日期（如 2111-01-02 与 2131-04-05）
- 返回总天数、方向（forward/backward）、年/月/日分解和闰年列表

### add 模式
- 从起始日期推算未来/过去日期
- 正确处理月末边界（如 1月31日 + 1个月 = 2月28/29日）

## 安全保证
- 纯 JavaScript Date 计算，不涉及任何 bash、SQL、文件系统或网络访问
- 结果年份超出范围时拒绝执行

## 测试
- 10 个集成测试覆盖：diff 模式（正向/反向/闰年/同日）、add 模式（推算/月末边界处理）、未来日期、无效输入

## 修改文件
- `src/ai.ts`：新增工具定义和执行逻辑
- `src/store.ts`：更新 WORK_AGENT_TOOL_IDS 使新工具默认可用
- `tests/integration/calculate-time.test.ts`：新增集成测试
- `tests/integration/ai-api.test.ts`：更新工具列表断言
- `tests/integration/task-auto-run.test.ts`：更新默认工具列表