### PR TITLE
feat(characters): filter by gender and death state

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -76,7 +76,7 @@ import { WORK_PERMISSION_MODULES, canReadPermissionModule, canReadUiModule, canW
 import { MODULE_LAYOUT_STORAGE_KEY, LEGACY_SETTINGS_LAYOUT_STORAGE_KEY, normalizeModuleLayout } from "/module-layout.js?v=20260723-module-layout-toggle";
 import { isGlobalSearchShortcut } from "/keyboard-shortcuts.js?v=20260723-global-search";
 import { prioritizeGlobalSearchResults, resolveGlobalSearchTarget, splitGlobalSearchHighlight } from "/global-search.js?v=20260804-agent-history-score-sort-v1";
-import { filterCharacters, paginateCharacters } from "/character-filters.js?v=20260725-character-filters";
+import { filterCharacters, paginateCharacters } from "/character-filters.js?v=20260817-character-filter-state-v1";
 import { filterRelationships } from "/relationship-filters.js?v=20260726-relationship-filters";
 import { filterSettings } from "/setting-filters.js?v=20260810-setting-inline-filters-v1";
 import {
@@ -1275,8 +1275,9 @@ const moduleListPages = {
   comments: 1,
   reviews: 1
 };
-const characterFilters = { raceIds: [], organizationIds: [] };
+const characterFilters = { raceIds: [], organizationIds: [], genderValues: [], deathState: "all" };
 const CHARACTER_GENDER_OPTIONS = [["unknown", "未知"], ["male", "男 / 雄"], ["female", "女 / 雌"], ["none", "无性别"]];
+const CHARACTER_DEATH_STATE_OPTIONS = [["all", "全部状态"], ["alive", "未死亡"], ["dead", "已死亡"]];
 let characterFiltersPanelOpen = false;
 const settingFilters = { keyword: "", category: "", lockState: "all" };
 let settingFiltersPanelOpen = false;
@@ -8304,7 +8305,10 @@ async function renderSettings(page = moduleListPages.settings) {
 }
 
 async function renderCharacters(page = characterListPage) {
-  const hasCharacterFilters = characterFilters.raceIds.length > 0 || characterFilters.organizationIds.length > 0;
+  const hasCharacterFilters = characterFilters.raceIds.length > 0
+    || characterFilters.organizationIds.length > 0
+    || characterFilters.genderValues.length > 0
+    || characterFilters.deathState !== "all";
   const pageSize = pageSizeFor("characters");
   const [characterSource, races, organizations] = await Promise.all([
     hasCharacterFilters
@@ -8368,16 +8372,25 @@ async function renderCharacters(page = characterListPage) {
     : "";
   const selectedRaceIds = new Set(characterFilters.raceIds);
   const selectedOrganizationIds = new Set(characterFilters.organizationIds);
+  const selectedGenderValues = new Set(characterFilters.genderValues);
   const selectedRaceNames = races.filter((race) => selectedRaceIds.has(String(race.id))).map((race) => racePathLabel(race) || race.name);
   const selectedOrganizationNames = organizations.filter((organization) => selectedOrganizationIds.has(String(organization.id))).map((organization) => organization.name);
+  const selectedGenderNames = CHARACTER_GENDER_OPTIONS
+    .filter(([value]) => selectedGenderValues.has(value))
+    .map(([, label]) => label);
+  const selectedDeathStateLabel = CHARACTER_DEATH_STATE_OPTIONS.find(([value]) => value === characterFilters.deathState)?.[1] ?? "全部状态";
   const filterOptionList = (items, selectedIds, valueKey = "id") => items.map((item) => {
     const value = String(item[valueKey]);
     const label = valueKey === "id" ? (racePathLabel(item) || item.name) : item.name;
     return `<label class="character-filter-option"><input type="checkbox" value="${esc(value)}" ${selectedIds.has(value) ? "checked" : ""}><span>${esc(label)}</span></label>`;
   }).join("");
-  const filterToolbar = `<section id="character-filter-panel" class="character-filter-toolbar${characterFiltersPanelOpen ? "" : " hidden"}" aria-label="角色筛选">
+  const genderFilterOptions = CHARACTER_GENDER_OPTIONS.map(([value, label]) => `<label class="character-filter-option"><input type="checkbox" value="${esc(value)}" ${selectedGenderValues.has(value) ? "checked" : ""}><span>${esc(label)}</span></label>`).join("");
+  const deathStateFilterOptions = CHARACTER_DEATH_STATE_OPTIONS.map(([value, label]) => `<label class="character-filter-option"><input type="radio" name="character-death-state" value="${esc(value)}" ${characterFilters.deathState === value ? "checked" : ""}><span>${esc(label)}</span></label>`).join("");
+  const filterToolbar = `<section id="character-filter-panel" class="character-filter-toolbar character-filter-toolbar-with-extra-filters${characterFiltersPanelOpen ? "" : " hidden"}" aria-label="角色筛选">
     <details class="character-filter-dropdown"><summary><span>按种族筛选</span><strong>${selectedRaceNames.length ? `已选 ${selectedRaceNames.length} 项` : "全部种族"}</strong></summary><div id="character-race-filter" class="character-filter-options">${filterOptionList(orderRaceFilterOptions(races), selectedRaceIds)}</div></details>
     <details class="character-filter-dropdown"><summary><span>按组织筛选</span><strong>${selectedOrganizationNames.length ? `已选 ${selectedOrganizationNames.length} 项` : "全部组织"}</strong></summary><div id="character-organization-filter" class="character-filter-options">${filterOptionList(organizations, selectedOrganizationIds, "id")}</div></details>
+    <details class="character-filter-dropdown"><summary><span>按性别筛选</span><strong>${selectedGenderNames.length ? `已选 ${selectedGenderNames.length} 项` : "全部性别"}</strong></summary><div id="character-gender-filter" class="character-filter-options">${genderFilterOptions}</div></details>
+    <details class="character-filter-dropdown"><summary><span>按死亡状态筛选</span><strong>${esc(selectedDeathStateLabel)}</strong></summary><div id="character-death-filter" class="character-filter-options">${deathStateFilterOptions}</div></details>
     <div class="character-filter-toolbar-actions">${hasCharacterFilters ? `<span class="character-filter-result-count" aria-live="polite">筛选后剩余 ${characterPage.total} 个角色</span>` : ""}<button id="clear-character-filters" class="ghost-button" type="button" ${hasCharacterFilters ? "" : "disabled"}>重置筛选</button></div>
   </section>`;
   mountCharacterFilterToggle();
@@ -8399,10 +8412,24 @@ async function renderCharacters(page = characterListPage) {
     characterListPage = 1;
     await renderCharacters(1);
   });
+  $("#character-gender-filter").addEventListener("change", async () => {
+    characterFiltersPanelOpen = true;
+    characterFilters.genderValues = readSelectedValues("#character-gender-filter");
+    characterListPage = 1;
+    await renderCharacters(1);
+  });
+  $("#character-death-filter").addEventListener("change", async (event) => {
+    characterFiltersPanelOpen = true;
+    characterFilters.deathState = CHARACTER_DEATH_STATE_OPTIONS.some(([value]) => value === event.target.value) ? event.target.value : "all";
+    characterListPage = 1;
+    await renderCharacters(1);
+  });
   $("#clear-character-filters")?.addEventListener("click", async () => {
     characterFiltersPanelOpen = true;
     characterFilters.raceIds = [];
     characterFilters.organizationIds = [];
+    characterFilters.genderValues = [];
+    characterFilters.deathState = "all";
     characterListPage = 1;
     await renderCharacters(1);
   });

--- a/src/public/character-filters.d.ts
+++ b/src/public/character-filters.d.ts
@@ -3,11 +3,13 @@ type CharacterFilterItem = {
   race?: { id?: string | null } | null;
   raceId?: string | null;
   organizations?: Array<{ id?: string | null }> | null;
+  gender?: string | null;
+  isDead?: boolean | null;
 };
 
 export declare function filterCharacters<T extends CharacterFilterItem>(
   characters: T[],
-  filters?: { raceIds?: string[]; organizationIds?: string[] }
+  filters?: { raceIds?: string[]; organizationIds?: string[]; genderValues?: string[]; deathState?: "all" | "alive" | "dead" }
 ): T[];
 
 export declare function paginateCharacters<T>(

--- a/src/public/character-filters.js
+++ b/src/public/character-filters.js
@@ -8,14 +8,29 @@ function characterOrganizationIds(character) {
     .filter(Boolean);
 }
 
-export function filterCharacters(characters, { raceIds = [], organizationIds = [] } = {}) {
+function characterGender(character) {
+  const gender = String(character?.gender ?? "unknown");
+  return ["male", "female", "none", "unknown"].includes(gender) ? gender : "unknown";
+}
+
+/**
+ * @param {unknown[]} characters
+ * @param {{ raceIds?: string[]; organizationIds?: string[]; genderValues?: string[]; deathState?: string }} [options]
+ */
+export function filterCharacters(characters, options = {}) {
+  const { raceIds = [], organizationIds = [], genderValues = [], deathState = "all" } = options;
   const selectedRaceIds = new Set(raceIds.map(String).filter(Boolean));
   const selectedOrganizationIds = new Set(organizationIds.map(String).filter(Boolean));
+  const selectedGenderValues = new Set(genderValues.map(String).filter(Boolean));
+  const selectedDeathState = deathState === "alive" || deathState === "dead" ? deathState : "all";
   return characters.filter((character) => {
     const matchesRace = selectedRaceIds.size === 0 || selectedRaceIds.has(characterRaceId(character));
     const matchesOrganization = selectedOrganizationIds.size === 0
       || characterOrganizationIds(character).some((organizationId) => selectedOrganizationIds.has(organizationId));
-    return matchesRace && matchesOrganization;
+    const matchesGender = selectedGenderValues.size === 0 || selectedGenderValues.has(characterGender(character));
+    const matchesDeathState = selectedDeathState === "all"
+      || (selectedDeathState === "dead" ? Boolean(character?.isDead) : !Boolean(character?.isDead));
+    return matchesRace && matchesOrganization && matchesGender && matchesDeathState;
   });
 }
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
@@ -1177,6 +1177,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>
   </body>
 </html>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1465,6 +1465,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .entity-lifecycle-badge { display: inline-flex; align-items: center; min-height: 20px; margin-left: 7px; padding: 2px 7px; border: 1px solid color-mix(in srgb, var(--accent) 58%, var(--line)); border-radius: 10px; background: color-mix(in srgb, var(--accent) 13%, var(--surface)); color: var(--accent-dark); font-size: 9px; font-weight: 650; line-height: 1; vertical-align: middle; white-space: nowrap; }
 .character-lock-badge svg { width: 11px; height: 11px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
 .character-filter-toolbar { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)) auto; gap: 12px; align-items: start; width: 100%; min-width: 0; box-sizing: border-box; margin-bottom: 18px; padding: 12px 14px; border: 1px solid var(--line); background: var(--surface-soft); }
+.character-filter-toolbar-with-extra-filters { grid-template-columns: repeat(4, minmax(0, 1fr)) auto; }
 .character-filter-dropdown { position: relative; min-width: 0; }
 .character-filter-dropdown summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: 38px; padding: 0 11px; border: 1px solid var(--line); border-radius: 4px; background: var(--surface); color: var(--ink); cursor: pointer; list-style: none; }
 .character-filter-dropdown summary::-webkit-details-marker { display: none; }
@@ -3197,6 +3198,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
   .import-mode-options { grid-template-columns: 1fr; }
   .import-mode-dialog .dialog-actions { flex-wrap: wrap; }
   .character-filter-toolbar { grid-template-columns: minmax(0, 1fr); }
+  .character-filter-toolbar-with-extra-filters { grid-template-columns: minmax(0, 1fr); }
   .character-filter-toolbar-actions { justify-content: flex-start; }
   .draft-filter-toolbar { grid-template-columns: minmax(0, 1fr); }
   .setting-filter-toolbar { grid-template-columns: minmax(0, 1fr); }

--- a/tests/system/character-gender-ui.test.ts
+++ b/tests/system/character-gender-ui.test.ts
@@ -30,4 +30,22 @@ describe("角色性别界面", () => {
     expect(styles.text).toContain(".character-species, .character-gender {");
     expect(page.text).toContain("feature=character-gender-v1");
   });
+
+  it("在角色筛选器中支持性别多选和死亡状态筛选", async () => {
+    const [application, styles, page] = await Promise.all([
+      request(runtime.app).get("/app.js").expect(200),
+      request(runtime.app).get("/styles.css").expect(200),
+      request(runtime.app).get("/").expect(200)
+    ]);
+
+    expect(application.text).toContain('/character-filters.js?v=20260817-character-filter-state-v1');
+    expect(application.text).toContain('const characterFilters = { raceIds: [], organizationIds: [], genderValues: [], deathState: "all" };');
+    expect(application.text).toContain('id="character-gender-filter"');
+    expect(application.text).toContain('按性别筛选');
+    expect(application.text).toContain('id="character-death-filter"');
+    expect(application.text).toContain('name="character-death-state"');
+    expect(application.text).toContain('characterFilters.deathState = CHARACTER_DEATH_STATE_OPTIONS.some');
+    expect(styles.text).toContain('.character-filter-toolbar-with-extra-filters { grid-template-columns: repeat(4, minmax(0, 1fr)) auto; }');
+    expect(page.text).toContain("feature=character-filter-state-v1");
+  });
 });

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');
@@ -102,7 +102,7 @@ expect(application.text).toContain('/display-labels.js?v=20260816-character-gend
     expect(application.text).toContain("characterPage.hasMore");
     expect(application.text).toContain("pageCharacters.length && (characterPage.page > 1 || characterPage.hasMore)");
     expect(application.text).toContain("if (!characterPage.items.length && page > 1) return renderCharacters(page - 1)");
-    expect(application.text).toContain('const hasCharacterFilters = characterFilters.raceIds.length > 0 || characterFilters.organizationIds.length > 0;');
+    expect(application.text).toContain('const hasCharacterFilters = characterFilters.raceIds.length > 0\n    || characterFilters.organizationIds.length > 0\n    || characterFilters.genderValues.length > 0\n    || characterFilters.deathState !== "all";');
     expect(application.text).toContain('moduleApiAllPages("characters", `/api/works/${state.work.id}/characters`)');
     expect(application.text).toContain('filterOptionList(orderRaceFilterOptions(races), selectedRaceIds)');
     expect(application.text).toContain('filterOptionList(organizations, selectedOrganizationIds, "id")');

--- a/tests/unit/character-filters.test.ts
+++ b/tests/unit/character-filters.test.ts
@@ -3,16 +3,23 @@ import { filterCharacters, paginateCharacters } from "../../src/public/character
 
 describe("character filters", () => {
   const characters = [
-    { id: "a", race: { id: "r1" }, organizations: [{ organizationId: "o1" }] },
-    { id: "b", race: { id: "r2" }, organizations: [{ organizationId: "o1" }, { id: "o2" }] },
-    { id: "c", race: { id: "r1" }, organizations: [] },
-    { id: "d", race: null, organizations: [{ id: "o2" }] }
+    { id: "a", race: { id: "r1" }, organizations: [{ organizationId: "o1" }], gender: "male", isDead: false },
+    { id: "b", race: { id: "r2" }, organizations: [{ organizationId: "o1" }, { id: "o2" }], gender: "female", isDead: true },
+    { id: "c", race: { id: "r1" }, organizations: [], gender: "none", isDead: false },
+    { id: "d", race: null, organizations: [{ id: "o2" }], gender: "unknown", isDead: true }
   ];
 
   it("matches any selected value within a filter and all active filter groups", () => {
     expect(filterCharacters(characters, { raceIds: ["r1", "r2"] }).map((item) => item.id)).toEqual(["a", "b", "c"]);
     expect(filterCharacters(characters, { organizationIds: ["o2"] }).map((item) => item.id)).toEqual(["b", "d"]);
     expect(filterCharacters(characters, { raceIds: ["r1"], organizationIds: ["o1"] }).map((item) => item.id)).toEqual(["a"]);
+  });
+
+  it("按性别多选和死亡状态组合筛选", () => {
+    expect(filterCharacters(characters, { genderValues: ["female", "unknown"] }).map((item) => item.id)).toEqual(["b", "d"]);
+    expect(filterCharacters(characters, { genderValues: ["male", "none"], deathState: "alive" }).map((item) => item.id)).toEqual(["a", "c"]);
+    expect(filterCharacters(characters, { deathState: "dead" }).map((item) => item.id)).toEqual(["b", "d"]);
+    expect(filterCharacters(characters, { deathState: "alive" }).map((item) => item.id)).toEqual(["a", "c"]);
   });
 
   it("returns all characters when no filter is selected", () => {


### PR DESCRIPTION
## 变更内容

- 角色筛选支持性别多选。
- 角色筛选支持全部、未死亡、已死亡三态筛选。
- 保持与种族、组织筛选的组合逻辑，并同步分页数量与重置状态。

## 验证

- `npm run typecheck`
- `npm test`：200 个测试文件、1031 项通过。
- `npm run build`
- SQLite `PRAGMA integrity_check` 与 `PRAGMA foreign_key_check` 通过。
- 内置浏览器验证 1600×900 与 390×844 视口、筛选结果、重置行为和控制台无错误。