### PR TITLE
fix(ai): throttle expired task notifications

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -90,7 +90,7 @@ import {
   outlineBoardRequestPath,
   outlineBoardUnresolvedCount
 } from "/outline-board.js?v=20260813-outline-board-page-v1";
-import { backgroundTaskActivityCount, backgroundTaskPollDelay, collectBackgroundTaskTransitions } from "/background-task-center.js?v=20260810-analysis-task-failed-v1";
+import { backgroundTaskActivityCount, backgroundTaskPollDelay, collectBackgroundTaskTransitions, filterBackgroundTaskTransitionsForAnnouncement } from "/background-task-center.js?v=20260817-analysis-task-expired-toast-v1";
 import { createModuleRequestCache } from "/module-request-cache.js?v=20260730-module-request-cache-v1";
 import { systemStatusPresentation } from "/system-status.js?v=20260801-system-health-v1";
 import { collectS3BackupRunTransitions, s3BackupEncryptionKeyFile, s3BackupEncryptionPresentation, s3BackupFailureToast, s3BackupRootPrefix, s3BackupStatusLabel } from "/s3-backup-ui.js?v=20260810-backup-encryption-v1";
@@ -243,6 +243,7 @@ let backgroundTaskCenterRequest = 0;
 let backgroundTaskCenterWorkId = null;
 let backgroundTaskCenterTasksInitialized = false;
 let backgroundTaskCenterTaskSnapshots = new Map();
+let backgroundTaskCenterExpiredNoticeTimes = new Map();
 let backgroundTaskCenterSnapshot = { taskPage: null, relationshipIndex: null, errors: {} };
 let s3BackupTargets = [];
 let s3BackupRuns = [];
@@ -10548,7 +10549,12 @@ async function refreshBackgroundTaskCenter({ announce = true } = {}) {
     backgroundTaskCenterTaskSnapshots = transitionResult.snapshots;
     backgroundTaskCenterSnapshot.taskPage = taskResult.value;
     if (backgroundTaskCenterTasksInitialized && announce && state.module !== "tasks") {
-      for (const transition of transitionResult.transitions) {
+      const announcementResult = filterBackgroundTaskTransitionsForAnnouncement(
+        transitionResult.transitions,
+        backgroundTaskCenterExpiredNoticeTimes
+      );
+      backgroundTaskCenterExpiredNoticeTimes = announcementResult.noticeTimes;
+      for (const transition of announcementResult.transitions) {
         const notification = backgroundTaskTransitionMessage(transition);
         toast(notification.message, notification.type);
       }
@@ -10576,6 +10582,7 @@ function stopBackgroundTaskCenter() {
   backgroundTaskCenterWorkId = null;
   backgroundTaskCenterTasksInitialized = false;
   backgroundTaskCenterTaskSnapshots = new Map();
+  backgroundTaskCenterExpiredNoticeTimes = new Map();
   backgroundTaskCenterSnapshot = { taskPage: null, relationshipIndex: null, errors: {} };
   const dialog = $("#background-task-dialog");
   if (dialog?.open) dialog.close();

--- a/src/public/background-task-center.d.ts
+++ b/src/public/background-task-center.d.ts
@@ -25,4 +25,13 @@ export function collectBackgroundTaskTransitions(
   transitions: BackgroundTaskTransition[];
 };
 
+export function filterBackgroundTaskTransitionsForAnnouncement(
+  transitions: BackgroundTaskTransition[] | null | undefined,
+  previousExpiredNoticeTimes: Map<string, number>,
+  now?: number
+): {
+  noticeTimes: Map<string, number>;
+  transitions: BackgroundTaskTransition[];
+};
+
 export function backgroundTaskPollDelay(activityCount: unknown, dialogOpen?: boolean): number;

--- a/src/public/background-task-center.js
+++ b/src/public/background-task-center.js
@@ -1,5 +1,6 @@
 const activeTaskStatuses = new Set(["pending", "running"]);
 const terminalTaskStatuses = new Set(["review", "completed", "partial", "failed", "expired", "cancelled"]);
+const expiredTransitionNoticeCooldown = 60_000;
 
 export function backgroundTaskActivityCount(taskPage, relationshipIndex) {
   const pendingCount = Number(taskPage?.stats?.pendingCount ?? 0);
@@ -23,6 +24,23 @@ export function collectBackgroundTaskTransitions(previousSnapshots, tasks, initi
     snapshots.set(taskId, status);
   }
   return { snapshots, transitions };
+}
+
+export function filterBackgroundTaskTransitionsForAnnouncement(transitions, previousExpiredNoticeTimes, now = Date.now()) {
+  const noticeTimes = new Map(previousExpiredNoticeTimes instanceof Map ? previousExpiredNoticeTimes : []);
+  const selected = [];
+  for (const transition of Array.isArray(transitions) ? transitions : []) {
+    if (transition?.status !== "expired") {
+      selected.push(transition);
+      continue;
+    }
+    const taskType = String(transition.task?.taskType ?? "");
+    const lastNoticeAt = noticeTimes.get(taskType);
+    if (Number.isFinite(lastNoticeAt) && now - lastNoticeAt < expiredTransitionNoticeCooldown) continue;
+    noticeTimes.set(taskType, now);
+    selected.push(transition);
+  }
+  return { noticeTimes, transitions: selected };
 }
 
 export function backgroundTaskPollDelay(activityCount, dialogOpen = false) {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1177,6 +1177,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=analysis-task-expired-toast-v1"></script>
   </body>
 </html>

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -462,7 +462,7 @@ describe("作者完整创作流程", () => {
     expect(page.text).toContain('id="setting-editor-confirm"');
     expect(application.text).toContain('review: "已完成"');
     expect(application.text).toContain('failed: "失败"');
-    expect(application.text).toContain('/background-task-center.js?v=20260810-analysis-task-failed-v1');
+    expect(application.text).toContain('/background-task-center.js?v=20260817-analysis-task-expired-toast-v1');
     expect(application.text).toContain('if (transition.status === "failed") return { message: `${label}失败，请打开任务详情查看`, type: "error" };');
     expect(application.text).not.toContain('review: "待审核"');
     expect(application.text).toContain('"分析已完成"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=analysis-task-expired-toast-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');

--- a/tests/unit/background-task-center.test.ts
+++ b/tests/unit/background-task-center.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   backgroundTaskActivityCount,
   backgroundTaskPollDelay,
-  collectBackgroundTaskTransitions
+  collectBackgroundTaskTransitions,
+  filterBackgroundTaskTransitionsForAnnouncement
 } from "../../src/public/background-task-center.js";
 
 describe("全局后台任务中心", () => {
@@ -45,6 +46,28 @@ describe("全局后台任务中心", () => {
     expect(initial.transitions).toEqual([
       expect.objectContaining({ previousStatus: "running", status: "failed" })
     ]);
+  });
+
+  it("按分析类型降低连续过期提醒频率，但不影响其他终态提醒", () => {
+    const transitions = [
+      { task: { id: "chapter-1", taskType: "chapter-analysis" }, previousStatus: "running", status: "expired" },
+      { task: { id: "chapter-2", taskType: "chapter-analysis" }, previousStatus: "running", status: "expired" },
+      { task: { id: "book-1", taskType: "book-analysis" }, previousStatus: "running", status: "expired" },
+      { task: { id: "failed-1", taskType: "chapter-analysis" }, previousStatus: "running", status: "failed" }
+    ];
+    const first = filterBackgroundTaskTransitionsForAnnouncement(transitions, new Map(), 1_000);
+    expect(first.transitions).toHaveLength(3);
+    expect(first.transitions.map((transition) => transition.task.id)).toEqual(["chapter-1", "book-1", "failed-1"]);
+
+    const second = filterBackgroundTaskTransitionsForAnnouncement([
+      { task: { id: "chapter-3", taskType: "chapter-analysis" }, previousStatus: "running", status: "expired" }
+    ], first.noticeTimes, 30_000);
+    expect(second.transitions).toEqual([]);
+
+    const afterCooldown = filterBackgroundTaskTransitionsForAnnouncement([
+      { task: { id: "chapter-4", taskType: "chapter-analysis" }, previousStatus: "running", status: "expired" }
+    ], second.noticeTimes, 61_000);
+    expect(afterCooldown.transitions).toHaveLength(1);
   });
 
   it("活动任务或打开弹窗时采用更短轮询间隔", () => {


### PR DESCRIPTION
## 变更

- 对同一作品内同一种分析任务的 `expired` 状态提醒增加 60 秒节流。
- 冷却窗口内只保留一次提醒，其他失败、部分失败、取消和完成提示保持原行为。
- 更新静态资源缓存版本，并补充节流回归测试。

## 根因

后台任务中心会按轮询结果逐个提醒连续过期的章节理解任务；原有任务状态快照只能避免同一个任务重复提醒，无法降低同一类型任务的连续弹窗频率。

## 验证

- `npm run typecheck`
- `npm test`：200 个测试文件、1030 个测试通过
- `npm run build`
- 内置浏览器验证 1600×900 和 390×844，窄屏无横向溢出，控制台无错误或警告
- 隔离服务健康检查和 SQLite `integrity_check`、`foreign_key_check` 通过