### PR TITLE
feat(ui): show chapter save toast status

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -4902,7 +4902,6 @@ async function persistChapter({ automatic = false } = {}) {
     const currentDraft = chapterDraftSnapshot();
     if (sameChapterSnapshot(currentDraft, draft)) {
       setSaveState(automatic ? "已自动保存" : collaborationAutoSaveDisabled ? "已保存 · 自动保存已关闭" : "已保存");
-      if (!automatic) toast(`正文已保存为 v${state.chapter.versionNo}`);
     } else {
       scheduleChapterAutoSave(250);
     }
@@ -7664,7 +7663,14 @@ function handleReadingWheel(event) {
 }
 
 async function saveChapter() {
-  return persistChapter({ automatic: false });
+  const dismissSavingToast = persistentToast("正在保存中");
+  try {
+    const saved = await persistChapter({ automatic: false });
+    if (saved) toast(`保存成功（正文 v${saved.versionNo}）`);
+    return saved;
+  } finally {
+    dismissSavingToast();
+  }
 }
 
 function tidyChapterBlankLines() {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1198,6 +1198,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=global-replace-volume-v1&feature=chapter-search-replace-v1"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=chapter-save-toast-v1"></script>
   </body>
 </html>

--- a/tests/system/editor-toolbar-layout.test.ts
+++ b/tests/system/editor-toolbar-layout.test.ts
@@ -52,6 +52,8 @@ describe("编辑器工具栏布局", () => {
     expect(styles.text).toContain(".editor-view.is-read-only #save-button");
     expect(application.text).toContain("function applyChapterEditorMode()");
     expect(application.text).toContain("function enterChapterEditMode()");
+    expect(application.text).toContain('persistentToast("正在保存中")');
+    expect(application.text).toContain('toast(`保存成功（正文 v${saved.versionNo}）`)');
     expect(application.text).toContain('$("#chapter-delete-button").classList.toggle("hidden", permissionBlocked || chapterEditorReadOnly || !state.chapter);');
     expect(application.text).toContain('$("#chapter-edit-button").addEventListener("click", enterChapterEditMode)');
     expect(styles.text).toContain('#chapter-path { grid-area: path;');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=global-replace-volume-v1&feature=chapter-search-replace-v1"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=chapter-save-toast-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');


### PR DESCRIPTION
## 变更内容

- 手动点击“保存正文”时显示“正在保存中”。
- 保存完成后显示“保存成功（正文 vN）”。
- 自动保存不额外显示手动保存提示。
- 更新前端资源缓存版本并补充界面回归断言。

## 验证

- `npm test`：201 个测试文件、1035 个测试通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。
- 内置浏览器完成桌面与窄屏正文保存提示验证。