### PR TITLE
fix(characters): group relationship panel entries by character

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -78,7 +78,7 @@ import { MODULE_LAYOUT_STORAGE_KEY, LEGACY_SETTINGS_LAYOUT_STORAGE_KEY, normaliz
 import { isGlobalSearchShortcut } from "/keyboard-shortcuts.js?v=20260723-global-search";
 import { prioritizeGlobalSearchResults, resolveGlobalSearchTarget, splitGlobalSearchHighlight } from "/global-search.js?v=20260804-agent-history-score-sort-v1";
 import { filterCharacters, paginateCharacters } from "/character-filters.js?v=20260817-character-filter-state-v1";
-import { filterRelationships } from "/relationship-filters.js?v=20260726-relationship-filters";
+import { filterRelationships, sortCharacterRelationships } from "/relationship-filters.js?v=20260818-character-relationship-group-v1";
 import { filterSettings } from "/setting-filters.js?v=20260810-setting-inline-filters-v1";
 import {
   prepareTimelineEvents,
@@ -12367,7 +12367,7 @@ async function loadCharacterEditorRelationships(characterId, { refresh = false }
     ]);
     if (state.work?.id !== workId || characterEditorItem?.id !== characterId) return;
     state.characters = characters;
-    characterEditorRelationships = relationships.filter((relationship) => relationship.fromCharacterId === characterId || relationship.toCharacterId === characterId);
+    characterEditorRelationships = sortCharacterRelationships(relationships.filter((relationship) => relationship.fromCharacterId === characterId || relationship.toCharacterId === characterId), characterId);
     characterEditorRelationshipsLoaded = true;
     loaded = true;
   } catch (error) {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -12328,8 +12328,11 @@ function renderCharacterEditorRelationships() {
     const category = relationshipCategoryLabel(relationship.category);
     const relationLabel = [category, relationship.subtype].filter(Boolean).join(" · ") || "未细分";
     const keywords = Array.isArray(relationship.keywords) ? relationship.keywords : [];
+    const actions = !entityEditorReadOnly && canEditModule("relationships")
+      ? `<div class="character-relationship-actions"><button type="button" data-character-relationship-edit="${esc(relationship.id)}">编辑关系</button><button class="danger-button" type="button" data-character-relationship-delete="${esc(relationship.id)}">删除关系</button></div>`
+      : "";
     return `<article class="character-relationship-row">
-      <div class="character-relationship-heading"><div><strong>${esc(nameOf(otherCharacterId))}</strong><span>${direction} ${esc(relationLabel)}</span></div>${!entityEditorReadOnly && canEditModule("relationships") ? `<button type="button" data-character-relationship-edit="${esc(relationship.id)}">编辑关系</button>` : ""}</div>
+      <div class="character-relationship-heading"><div><strong>${esc(nameOf(otherCharacterId))}</strong><span>${direction} ${esc(relationLabel)}</span></div>${actions}</div>
       <div class="character-relationship-keywords"><small>关系关键词</small><div>${keywords.map((keyword) => `<span class="pill relationship-keyword">${esc(keyword)}</span>`).join("") || '<span class="character-relationship-empty-keywords">未填写关键词</span>'}</div></div>
     </article>`;
   }).join("");
@@ -12337,6 +12340,14 @@ function renderCharacterEditorRelationships() {
   host.querySelectorAll("[data-character-relationship-edit]").forEach((button) => button.addEventListener("click", () => {
     const relationship = characterEditorRelationships.find((item) => item.id === button.dataset.characterRelationshipEdit);
     if (relationship) void openRelationshipDialog(relationship, { characterId });
+  }));
+  host.querySelectorAll("[data-character-relationship-delete]").forEach((button) => button.addEventListener("click", () => {
+    const relationship = characterEditorRelationships.find((item) => item.id === button.dataset.characterRelationshipDelete);
+    if (!relationship) return;
+    button.disabled = true;
+    void deleteRelationshipRecord(relationship, characterId).finally(() => {
+      if (button.isConnected) button.disabled = false;
+    });
   }));
   host.querySelector("[data-character-relationship-create]")?.addEventListener("click", () => void openRelationshipDialog(null, { characterId }));
 }
@@ -12378,6 +12389,21 @@ async function refreshRelationshipSurfaces(characterId = null) {
     tasks.push(loadCharacterEditorRelationships(characterId, { refresh: true }));
   }
   await Promise.all(tasks);
+}
+
+async function deleteRelationshipRecord(item, characterId = null) {
+  const relationshipName = `${state.characters.find((character) => character.id === item.fromCharacterId)?.name ?? "未知角色"} / ${state.characters.find((character) => character.id === item.toCharacterId)?.name ?? "未知角色"}`;
+  if (!await confirmToast(`确认删除人物关系“${relationshipName}”吗？`, { title: "删除人物关系", confirmLabel: "继续删除" })) return false;
+  if (!await confirmToast(`删除人物关系“${relationshipName}”后无法恢复。`, { title: "删除操作需要再次确认", confirmLabel: "确认删除" })) return false;
+  try {
+    await api(`/api/relationships/${item.id}`, { method: "DELETE", body: { expectedVersionNo: item.versionNo } });
+    await Promise.all([refreshRelationshipSurfaces(characterId), loadAiReferences()]);
+    deleteToast(`已删除人物关系“${relationshipName}”`);
+    return true;
+  } catch (error) {
+    toast(error.message, "error");
+    return false;
+  }
 }
 
 const characterSectionTypeLabels = {
@@ -13773,7 +13799,6 @@ async function openRelationshipDialog(item, options = {}) {
   const characterOptions = state.characters.map((item) => [item.id, item.name]);
   const defaultFrom = options.characterId && state.characters.some((character) => character.id === options.characterId) ? options.characterId : characterOptions[0][0];
   const defaultTo = characterOptions.find(([id]) => id !== defaultFrom)?.[0] ?? characterOptions[1][0];
-  const relationshipName = item ? `${state.characters.find((character) => character.id === item.fromCharacterId)?.name ?? "未知角色"} / ${state.characters.find((character) => character.id === item.toCharacterId)?.name ?? "未知角色"}` : "";
   const management = item && canEditModule("relationships") ? `<section class="entity-dialog-management" aria-label="人物关系操作">
     <div><strong>关系操作</strong><small>删除操作会记录到版本历史和审计日志。</small></div>
     <div class="entity-dialog-management-actions"><button class="danger-button" type="button" data-dialog-relationship-delete>删除关系</button></div>
@@ -13791,16 +13816,7 @@ async function openRelationshipDialog(item, options = {}) {
       dialog.showModal();
     };
     dialog.close();
-    if (!await confirmToast(`确认删除人物关系“${relationshipName}”吗？`, { title: "删除人物关系", confirmLabel: "继续删除" })) return reopenDialog();
-    if (!await confirmToast(`删除人物关系“${relationshipName}”后无法恢复。`, { title: "删除操作需要再次确认", confirmLabel: "确认删除" })) return reopenDialog();
-    try {
-      await api(`/api/relationships/${item.id}`, { method: "DELETE", body: { expectedVersionNo: item.versionNo } });
-      await Promise.all([refreshRelationshipSurfaces(options.characterId ?? null), loadAiReferences()]);
-      deleteToast(`已删除人物关系“${relationshipName}”`);
-    } catch (error) {
-      reopenDialog();
-      toast(error.message, "error");
-    }
+    if (!await deleteRelationshipRecord(item, options.characterId ?? null)) return reopenDialog();
   });
 }
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1198,6 +1198,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=character-relationship-delete-v1"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=character-relationship-delete-v1&feature=character-relationship-group-v1"></script>
   </body>
 </html>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2&feature=galaxy-motion-mode-v2&feature=chapter-search-replace-v3">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2&feature=galaxy-motion-mode-v2&feature=chapter-search-replace-v3&feature=character-relationship-delete-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
@@ -1198,6 +1198,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=character-relationship-delete-v1"></script>
   </body>
 </html>

--- a/src/public/relationship-filters.d.ts
+++ b/src/public/relationship-filters.d.ts
@@ -8,3 +8,8 @@ export declare function filterRelationships<T extends RelationshipFilterItem>(
   relationships: T[],
   filters?: { fromCharacterIds?: string[]; toCharacterIds?: string[] }
 ): T[];
+
+export declare function sortCharacterRelationships<T extends RelationshipFilterItem & { confidence?: number | string | null; createdAt?: string | null }>(
+  relationships: T[],
+  characterId: string | null | undefined
+): T[];

--- a/src/public/relationship-filters.js
+++ b/src/public/relationship-filters.js
@@ -9,3 +9,34 @@ export function filterRelationships(relationships, { fromCharacterIds = [], toCh
     return matchesFromCharacter && matchesToCharacter;
   });
 }
+
+function compareRelationshipText(left, right) {
+  const leftText = String(left ?? "");
+  const rightText = String(right ?? "");
+  if (leftText < rightText) return -1;
+  if (leftText > rightText) return 1;
+  return 0;
+}
+
+function compareRelationshipDetails(left, right) {
+  const confidenceDifference = Number(right?.confidence ?? 0) - Number(left?.confidence ?? 0);
+  if (confidenceDifference !== 0) return confidenceDifference;
+  return compareRelationshipText(left?.createdAt, right?.createdAt)
+    || compareRelationshipText(left?.id, right?.id);
+}
+
+export function sortCharacterRelationships(relationships, characterId) {
+  const currentCharacterId = String(characterId ?? "");
+  return [...relationships].sort((left, right) => {
+    const leftFromCharacterId = String(left?.fromCharacterId ?? "");
+    const rightFromCharacterId = String(right?.fromCharacterId ?? "");
+    const leftOtherCharacterId = leftFromCharacterId === currentCharacterId
+      ? String(left?.toCharacterId ?? "")
+      : leftFromCharacterId;
+    const rightOtherCharacterId = rightFromCharacterId === currentCharacterId
+      ? String(right?.toCharacterId ?? "")
+      : rightFromCharacterId;
+    return compareRelationshipText(leftOtherCharacterId, rightOtherCharacterId)
+      || compareRelationshipDetails(left, right);
+  });
+}

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -3374,6 +3374,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .character-relationship-row { display: grid; gap: 10px; padding: 12px; border: 1px solid var(--line); border-radius: 5px; background: var(--surface-soft); }
 .character-relationship-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .character-relationship-heading > div { display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px; min-width: 0; }
+.character-relationship-actions { display: flex; flex: 0 0 auto; flex-wrap: wrap; gap: 6px; }
 .character-relationship-heading strong { font-size: 14px; }
 .character-relationship-heading span { color: var(--muted); font-size: 10px; }
 .character-relationship-heading button { flex: 0 0 auto; padding: 6px 9px; border: 1px solid var(--line); border-radius: 4px; background: transparent; color: var(--muted); font-size: 10px; }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -241,6 +241,7 @@ describe("作者完整创作流程", () => {
     expect(application.text).toContain("refreshRelationshipSurfaces");
     expect(application.text).toContain("data-character-relationship-edit");
     expect(application.text).toContain("data-character-relationship-delete");
+    expect(application.text).toContain("sortCharacterRelationships");
     expect(application.text).toContain("async function deleteRelationshipRecord(item, characterId = null)");
     expect(application.text).toContain('const canEditRelationships = canEditModule("relationships");');
     expect(application.text).toContain('canEditRelationships ? `<button data-edit-relationship=');

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -240,6 +240,8 @@ describe("作者完整创作流程", () => {
     expect(application.text).toContain('class="character-species"');
     expect(application.text).toContain("refreshRelationshipSurfaces");
     expect(application.text).toContain("data-character-relationship-edit");
+    expect(application.text).toContain("data-character-relationship-delete");
+    expect(application.text).toContain("async function deleteRelationshipRecord(item, characterId = null)");
     expect(application.text).toContain('const canEditRelationships = canEditModule("relationships");');
     expect(application.text).toContain('canEditRelationships ? `<button data-edit-relationship=');
     expect(application.text).toContain("data-dialog-relationship-delete");

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=character-relationship-delete-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=character-relationship-delete-v1"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=character-relationship-delete-v1&feature=character-relationship-group-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');
@@ -106,7 +106,7 @@ expect(application.text).toContain('/display-labels.js?v=20260816-character-gend
     expect(application.text).toContain('moduleApiAllPages("characters", `/api/works/${state.work.id}/characters`)');
     expect(application.text).toContain('filterOptionList(orderRaceFilterOptions(races), selectedRaceIds)');
     expect(application.text).toContain('filterOptionList(organizations, selectedOrganizationIds, "id")');
-    expect(application.text).toContain('/relationship-filters.js?v=20260726-relationship-filters');
+    expect(application.text).toContain('/relationship-filters.js?v=20260818-character-relationship-group-v1');
     expect(application.text).toContain('aria-controls="relationship-filter-panel"');
     expect(application.text).toContain('id="relationship-from-character-filter"');
     expect(application.text).toContain('id="relationship-to-character-filter"');

--- a/tests/unit/relationship-filters.test.ts
+++ b/tests/unit/relationship-filters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { filterRelationships } from "../../src/public/relationship-filters.js";
+import { filterRelationships, sortCharacterRelationships } from "../../src/public/relationship-filters.js";
 
 describe("relationship filters", () => {
   const relationships = [
@@ -17,5 +17,17 @@ describe("relationship filters", () => {
 
   it("returns all relationships when no filter is selected", () => {
     expect(filterRelationships(relationships)).toEqual(relationships);
+  });
+
+  it("groups the same other character before applying the stable detail order", () => {
+    const characterRelationships = [
+      { id: "r1", fromCharacterId: "self", toCharacterId: "b", confidence: 1, createdAt: "2026-01-01T00:00:00Z" },
+      { id: "r2", fromCharacterId: "self", toCharacterId: "a", confidence: 0.1, createdAt: "2026-01-03T00:00:00Z" },
+      { id: "r3", fromCharacterId: "c", toCharacterId: "self", confidence: 0.9, createdAt: "2026-01-02T00:00:00Z" },
+      { id: "r4", fromCharacterId: "self", toCharacterId: "b", confidence: 0.9, createdAt: "2026-01-02T00:00:00Z" }
+    ];
+
+    expect(sortCharacterRelationships(characterRelationships, "self").map((item) => item.id)).toEqual(["r2", "r1", "r4", "r3"]);
+    expect(characterRelationships.map((item) => item.id)).toEqual(["r1", "r2", "r3", "r4"]);
   });
 });


### PR DESCRIPTION
## Summary

- 在单个角色自己的“人物关系”面板中，按另一端角色 ID 对关系进行分组。
- 同一角色组内按置信度、创建时间和关系 ID 稳定排序。
- 保留角色关系面板中的新建、编辑和删除能力；不修改全局“关系”tab 的展示排序。

## Validation

- `npm run typecheck`
- `npm test`：202 个测试文件、1052 个测试通过
- `npm run build`
- SQLite `PRAGMA integrity_check` 和 `PRAGMA foreign_key_check` 通过
- 内置浏览器验证 1600×900 与 390×844，重复角色连续显示、无横向溢出、控制台无错误