### PR TITLE
fix(ui): center and resize task progress ring

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2&feature=galaxy-motion-mode-v2&feature=chapter-search-replace-v3">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2&feature=galaxy-motion-mode-v2&feature=chapter-search-replace-v3&feature=task-auto-run-ring-center-v3">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1589,6 +1589,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .platform-image-tool-field select { width: 100%; height: 36px; min-height: 36px; padding: 8px 10px; font-size: 12px; }
 .platform-image-tool-panel .config-save-button { flex: 0 0 auto; min-height: 36px; padding: 8px 14px; }
 .task-auto-run-panel {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 268px;
   gap: 12px;
@@ -1635,14 +1636,14 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
 .task-auto-run-alert strong { color: var(--ink); }
 .task-auto-run-alert span, .task-auto-run-alert small { color: var(--muted); }
 .task-auto-run-progress {
+  position: absolute;
+  top: 50%;
+  right: 90px;
   display: grid;
-  grid-column: 2;
-  grid-row: 2 / 5;
-  align-self: center;
-  justify-self: start;
-  width: 192px;
+  width: 184px;
+  transform: translateY(-50%);
 }
-.task-auto-run-progress-ring { position: relative; display: grid; width: 192px; height: 192px; place-items: center; }
+.task-auto-run-progress-ring { position: relative; display: grid; width: 184px; height: 184px; place-items: center; }
 .task-auto-run-progress-ring svg { display: block; width: 100%; height: 100%; overflow: visible; transform: rotate(-90deg); }
 .task-auto-run-progress-ring-track, .task-auto-run-progress-ring-value { fill: none; stroke-width: 8; }
 .task-auto-run-progress-ring-track { stroke: color-mix(in srgb, var(--line) 72%, transparent); }
@@ -3558,7 +3559,7 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
   .task-auto-run-panel { grid-template-columns: minmax(0, 1fr); column-gap: 0; }
   .task-auto-run-header, .task-auto-run-controls, .task-auto-run-meta { grid-column: 1; }
   .task-auto-run-help, .task-auto-run-alert { grid-column: 1; }
-  .task-auto-run-progress { grid-column: 1; grid-row: auto; justify-self: stretch; width: 100%; }
+  .task-auto-run-progress { position: static; top: auto; right: auto; width: 100%; transform: none; }
   .task-auto-run-progress-ring { display: none; }
   .task-auto-run-progress-bar-layout { display: grid; gap: 6px; width: 100%; }
   .settings-hub-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -710,10 +710,10 @@ describe("作者完整创作流程", () => {
     expect(styles.text).toContain(".task-auto-run-panel");
     expect(styles.text).toContain("grid-template-columns: minmax(0, 1fr) 268px;");
     expect(styles.text).toContain(".task-auto-run-header { display: grid; grid-column: 1 / -1;");
-    expect(styles.text).toContain("grid-column: 2;\n  grid-row: 2 / 5;");
-    expect(styles.text).toContain("justify-self: start;");
-    expect(styles.text).toContain("width: 192px;");
-    expect(styles.text).toContain(".task-auto-run-progress-ring { position: relative; display: grid; width: 192px; height: 192px;");
+    expect(styles.text).toContain("position: absolute;\n  top: 50%;\n  right: 90px;");
+    expect(styles.text).toContain("transform: translateY(-50%);");
+    expect(styles.text).toContain("width: 184px;");
+    expect(styles.text).toContain(".task-auto-run-progress-ring { position: relative; display: grid; width: 184px; height: 184px;");
     expect(styles.text).toContain(".task-auto-run-actions { display: flex; align-items: start;");
     expect(styles.text).not.toContain(".task-auto-run-actions { display: flex; grid-column: 2;");
     expect(styles.text).toContain(".task-auto-run-progress-ring-value { stroke: var(--accent);");


### PR DESCRIPTION
## 变更内容

- 将自动执行任务圆环从任务卡片网格流中移出，改为相对卡片本身垂直居中。
- 将圆环尺寸从 192px 微调为 184px。
- 窄屏继续使用横向进度条，并清除桌面端绝对定位。
- 更新静态资源缓存版本和系统样式断言。

## 修复原因

原圆环只在控件、帮助文案和队列状态组成的网格区域内居中，视觉位置偏下。尝试跨网格行会撑开第一行并挤乱卡片内容，因此改为绝对定位到卡片垂直中心，避免参与网格轨道尺寸计算。

## 验证

- `npm run typecheck`
- `npm run test:system -- tests/system/author-journey.test.ts`
- 内置浏览器 1600×900：圆环与卡片中心偏差 0px。
- 内置浏览器 390×844：切换为进度条，无横向溢出。
- 浏览器控制台无新增错误。