### PR TITLE
fix(ai): delay chapter analysis task creation

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2160,6 +2160,12 @@ export class AiManager {
   private readonly taskControllers = new Map<string, AbortController>();
   private readonly autoRunStarting = new Map<string, Set<string>>();
   private readonly autoRunTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly chapterAnalysisTimers = new Map<string, {
+    timer: ReturnType<typeof setTimeout>;
+    workId: string;
+    chapterId: string;
+    versionNo: number;
+  }>();
   private autoRunStartupTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly relationshipIndexBuilds = new Map<string, Promise<number>>();
   private readonly relationshipSelectionCache = new Map<string, RelationshipLocalSourceSelection>();
@@ -2203,6 +2209,9 @@ export class AiManager {
     this.retrySleep = options.retrySleep ?? waitForAiRetry;
     this.contextBuilder = new ContextBuilder(store);
     this.store.setAnalysisTaskQueuedHandler((workId) => this.scheduleAutoRun(workId));
+    this.store.setChapterAnalysisInvalidatedHandler((workId, chapterId, versionNo) => {
+      this.scheduleChapterAnalysisTask(workId, chapterId, versionNo);
+    });
     this.autoRunStartupTimer = setTimeout(() => {
       this.autoRunStartupTimer = null;
       for (const workId of this.store.listAutoRunWorkIds()) this.scheduleAutoRun(workId);
@@ -2778,6 +2787,11 @@ export class AiManager {
     if (autoRunTimer) clearTimeout(autoRunTimer);
     this.autoRunTimers.delete(workId);
     this.autoRunStarting.delete(workId);
+    for (const entry of [...this.chapterAnalysisTimers.values()]) {
+      if (entry.workId !== workId) continue;
+      clearTimeout(entry.timer);
+      this.chapterAnalysisTimers.delete(this.chapterAnalysisTimerKey(entry.workId, entry.chapterId));
+    }
     const relationshipIndexTimer = this.relationshipIndexSyncTimers.get(workId);
     if (relationshipIndexTimer) clearTimeout(relationshipIndexTimer);
     this.relationshipIndexSyncTimers.delete(workId);
@@ -2795,12 +2809,15 @@ export class AiManager {
     for (const timer of this.autoRunTimers.values()) clearTimeout(timer);
     this.autoRunTimers.clear();
     this.autoRunStarting.clear();
+    for (const entry of this.chapterAnalysisTimers.values()) clearTimeout(entry.timer);
+    this.chapterAnalysisTimers.clear();
     this.relationshipIndexDisposed = true;
     for (const timer of this.relationshipIndexSyncTimers.values()) clearTimeout(timer);
     this.relationshipIndexSyncTimers.clear();
     if (this.relationshipIndexTimer) clearTimeout(this.relationshipIndexTimer);
     this.relationshipIndexTimer = null;
     this.store.setAnalysisTaskQueuedHandler(null);
+    this.store.setChapterAnalysisInvalidatedHandler(null);
     this.store.setRelationshipIndexQueuedHandler(null);
     logger.info("ai.manager.disposed");
   }
@@ -2811,6 +2828,49 @@ export class AiManager {
     const created = new Set<string>();
     this.autoRunStarting.set(workId, created);
     return created;
+  }
+
+  private chapterAnalysisTimerKey(workId: string, chapterId: string): string {
+    return `${workId}\u0000${chapterId}`;
+  }
+
+  private scheduleChapterAnalysisTask(workId: string, chapterId: string, versionNo: number): void {
+    const key = this.chapterAnalysisTimerKey(workId, chapterId);
+    const existing = this.chapterAnalysisTimers.get(key);
+    if (existing) clearTimeout(existing.timer);
+    let delayMinutes = 2;
+    try {
+      const settings = this.store.getWorkAiSettings(workId);
+      delayMinutes = Math.min(120, Math.max(1, Number(settings.autoRunStabilityDelayMinutes ?? 2) || 2));
+    } catch {
+      return;
+    }
+    const delayMs = delayMinutes * 60_000;
+    const timer = setTimeout(() => {
+      this.chapterAnalysisTimers.delete(key);
+      try {
+        const chapter = this.store.getChapter(chapterId);
+        if (String(chapter.workId) !== workId || Number(chapter.versionNo) !== versionNo || chapter.deletedAt) return;
+        this.store.createTask(workId, {
+          taskType: "chapter-analysis",
+          scope: { type: "chapter", chapterId }
+        });
+        logger.info("ai.chapter_analysis_task.created_after_stability", { workId, chapterId, versionNo, delayMs });
+      } catch (error) {
+        logger.warn("ai.chapter_analysis_task.create_after_stability_failed", { workId, chapterId, versionNo, delayMs, error: aiErrorForLog(error) });
+      }
+    }, delayMs);
+    this.chapterAnalysisTimers.set(key, { timer, workId, chapterId, versionNo });
+    logger.debug("ai.chapter_analysis_task.scheduled_after_stability", { workId, chapterId, versionNo, delayMs });
+  }
+
+  rescheduleChapterAnalysisTasks(workId: string): void {
+    for (const entry of [...this.chapterAnalysisTimers.values()]) {
+      if (entry.workId !== workId) continue;
+      clearTimeout(entry.timer);
+      this.chapterAnalysisTimers.delete(this.chapterAnalysisTimerKey(entry.workId, entry.chapterId));
+      this.scheduleChapterAnalysisTask(entry.workId, entry.chapterId, entry.versionNo);
+    }
   }
 
   private async drainAutoRun(workId: string): Promise<void> {

--- a/src/app.ts
+++ b/src/app.ts
@@ -613,6 +613,7 @@ const workAiSettingsSchema = z.object({
   autoRunBatchLimit: z.number().int().min(1).max(200).optional(),
   autoRunDailyTaskLimit: z.number().int().min(0).max(10_000).optional(),
   autoRunFailureThreshold: z.number().int().min(1).max(10).optional(),
+  autoRunStabilityDelayMinutes: z.number().int().min(1).max(120).optional(),
   bookSummaryContextPercent: z.number().int().min(1).max(90).optional(),
   contextCompactThreshold: z.number().int().min(50).max(90).optional(),
   agentToolCallLimit: z.number().int().min(5).optional(),
@@ -2598,6 +2599,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       if (input.autoRunEnabled === true && !before.autoRunEnabled) updated = ai.resumeAutoRun(workId);
       else ai.scheduleAutoRun(workId);
     }
+    if (input.autoRunStabilityDelayMinutes !== undefined) ai.rescheduleChapterAnalysisTasks(workId);
     data(response, updated);
   });
   app.get("/api/works/:workId/ai-conversations", (request, response) => {

--- a/src/database.ts
+++ b/src/database.ts
@@ -7,9 +7,9 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询；版本 94 增加模型思考强度；版本 95 增加供应商最大输出参数选择；版本 96 扩展模型思考强度档位；版本 97 增加人物性别字段。
+// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询；版本 94 增加模型思考强度；版本 95 增加供应商最大输出参数选择；版本 96 扩展模型思考强度档位；版本 97 增加人物性别字段；版本 98 增加正文稳定等待配置。
 export const ENTITY_VERSION_BASELINE_MIGRATION_VERSION = 82;
-export const DATABASE_SCHEMA_VERSION = 97;
+export const DATABASE_SCHEMA_VERSION = 98;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -3695,6 +3695,22 @@ export class Database {
           this.run("ALTER TABLE characters ADD COLUMN gender TEXT NOT NULL DEFAULT 'unknown' CHECK(gender IN ('male', 'female', 'none', 'unknown'))");
         }
         this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (97, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    if (!applied.has(98)) {
+      this.transaction(() => {
+        const columns = new Set(this.all("PRAGMA table_info(work_ai_settings)").map((row) => String(row.name)));
+        if (!columns.has("auto_run_stability_delay_minutes")) {
+          this.run(`ALTER TABLE work_ai_settings ADD COLUMN auto_run_stability_delay_minutes INTEGER NOT NULL DEFAULT 2
+            CHECK(auto_run_stability_delay_minutes BETWEEN 1 AND 120)`);
+        }
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (98, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -9184,7 +9184,7 @@ async function renderTasks(page = taskListPage, { refresh = false } = {}) {
     moduleApiPage("tasks", `/api/works/${state.work.id}/tasks`, page, pageSize, { refresh }),
     canReadModule("ai-settings")
       ? moduleApi("tasks", `/api/works/${state.work.id}/ai-settings`, { refresh })
-      : Promise.resolve({ autoRunEnabled: false, autoRunConcurrency: 2, autoRunDailyTaskLimit: 0, autoRunFailureThreshold: 3, autoRunPaused: false })
+      : Promise.resolve({ autoRunEnabled: false, autoRunConcurrency: 2, autoRunDailyTaskLimit: 0, autoRunFailureThreshold: 3, autoRunStabilityDelayMinutes: 2, autoRunPaused: false })
   ]);
   if (!taskPage.items.length && page > 1) return renderTasks(page - 1, { refresh });
   taskListPage = taskPage.page;
@@ -9221,6 +9221,7 @@ async function renderTasks(page = taskListPage, { refresh = false } = {}) {
         <div class="task-auto-run-copy">
           <strong id="task-auto-run-title">自动执行待分析任务</strong>
           <small>只执行已经进入“待执行”队列的任务，不会自动创建人物关系、世界观或其他分析。</small>
+          <small>正文停止编辑后，等待稳定窗口结束才会创建章节理解任务。</small>
           <small>开启后会持续执行直到队列清空；临时错误自动退避重试，连续失败达到阈值后暂停。</small>
         </div>
         <div class="task-auto-run-actions">
@@ -9232,11 +9233,13 @@ async function renderTasks(page = taskListPage, { refresh = false } = {}) {
         <label>同时运行上限<input id="task-auto-run-concurrency" type="number" min="1" max="8" value="${esc(String(settings.autoRunConcurrency ?? 2))}" ${autoRunEditing ? "" : "disabled"} aria-readonly="${String(!autoRunEditing)}"></label>
         <label>每日任务上限<input id="task-auto-run-daily-limit" type="number" min="0" max="10000" value="${esc(String(settings.autoRunDailyTaskLimit ?? 0))}" ${autoRunEditing ? "" : "disabled"} aria-readonly="${String(!autoRunEditing)}" aria-describedby="task-auto-run-daily-help"></label>
         <label>连续失败暂停阈值<input id="task-auto-run-failure-threshold" type="number" min="1" max="10" value="${esc(String(settings.autoRunFailureThreshold ?? 3))}" ${autoRunEditing ? "" : "disabled"} aria-readonly="${String(!autoRunEditing)}"></label>
+        <label>停止编辑后创建任务<input id="task-auto-run-stability-delay" type="number" min="1" max="120" value="${esc(String(settings.autoRunStabilityDelayMinutes ?? 2))}" ${autoRunEditing ? "" : "disabled"} aria-readonly="${String(!autoRunEditing)}" aria-describedby="task-auto-run-stability-help"></label>
         ${autoRunEditing
           ? `<button id="task-auto-run-save" class="primary-button" type="button">保存并生效</button><button id="task-auto-run-pause" class="ghost-button" type="button">${autoRunPauseLabel}</button>`
           : ""}
       </div>
       <p id="task-auto-run-daily-help" class="task-auto-run-help">每日任务上限填 0 表示不限制；达到上限后会在下一个 UTC 自然日自动恢复。</p>
+      <p id="task-auto-run-stability-help" class="task-auto-run-help">正文连续 ${esc(String(settings.autoRunStabilityDelayMinutes ?? 2))} 分钟没有编辑，才会创建章节理解任务；最低 1 分钟。</p>
       <p class="task-auto-run-meta">待执行队列 ${pendingCount} 个 · 正在运行 ${runningCount} 个 · ${autoRunPaused ? "已暂停" : autoRunActive ? "持续执行中" : "未开启"}</p>
       ${autoRunPaused ? `<p class="task-auto-run-alert" role="status"><strong>自动执行已暂停</strong><span>${esc(settings.autoRunPauseReason || "需要人工确认后恢复")}</span>${settings.autoRunResumeAt ? `<small>预计 ${esc(formatDateTime(settings.autoRunResumeAt))} 自动恢复</small>` : ""}</p>` : ""}
       <div class="task-auto-run-progress ${activeTaskCount ? "" : "hidden"}" aria-live="polite">
@@ -9290,7 +9293,8 @@ async function renderTasks(page = taskListPage, { refresh = false } = {}) {
           autoRunEnabled: $("#task-auto-run-enabled").checked,
           autoRunConcurrency: Number($("#task-auto-run-concurrency").value),
           autoRunDailyTaskLimit: Number($("#task-auto-run-daily-limit").value),
-          autoRunFailureThreshold: Number($("#task-auto-run-failure-threshold").value)
+          autoRunFailureThreshold: Number($("#task-auto-run-failure-threshold").value),
+          autoRunStabilityDelayMinutes: Number($("#task-auto-run-stability-delay").value)
         }
       });
       toast(updated.autoRunEnabled

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1177,6 +1177,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=analysis-task-expired-toast-v1"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=analysis-task-expired-toast-v1&feature=analysis-task-stability-delay-v1"></script>
   </body>
 </html>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1464,10 +1464,15 @@ export class Store {
   }
 
   private analysisTaskQueuedHandler: ((workId: string) => void) | null = null;
+  private chapterAnalysisInvalidatedHandler: ((workId: string, chapterId: string, versionNo: number) => void) | null = null;
   private relationshipIndexQueuedHandler: ((workId: string) => void) | null = null;
 
   setAnalysisTaskQueuedHandler(handler: ((workId: string) => void) | null): void {
     this.analysisTaskQueuedHandler = handler;
+  }
+
+  setChapterAnalysisInvalidatedHandler(handler: ((workId: string, chapterId: string, versionNo: number) => void) | null): void {
+    this.chapterAnalysisInvalidatedHandler = handler;
   }
 
   setRelationshipIndexQueuedHandler(handler: ((workId: string) => void) | null): void {
@@ -1479,6 +1484,14 @@ export class Store {
       this.analysisTaskQueuedHandler?.(workId);
     } catch {
       // 自动运行调度失败不影响主写入路径
+    }
+  }
+
+  private notifyChapterAnalysisInvalidated(workId: string, chapterId: string, versionNo: number): void {
+    try {
+      this.chapterAnalysisInvalidatedHandler?.(workId, chapterId, versionNo);
+    } catch {
+      // 稳定等待调度失败不影响主写入路径
     }
   }
 
@@ -1497,6 +1510,7 @@ export class Store {
       autoRunBatchLimit: Math.min(200, Math.max(1, Number(row?.auto_run_batch_limit ?? 20) || 20)),
       autoRunDailyTaskLimit: Math.min(10_000, Math.max(0, Number(row?.auto_run_daily_task_limit ?? 0) || 0)),
       autoRunFailureThreshold: Math.min(10, Math.max(1, Number(row?.auto_run_failure_threshold ?? 3) || 3)),
+      autoRunStabilityDelayMinutes: Math.min(120, Math.max(1, Number(row?.auto_run_stability_delay_minutes ?? 2) || 2)),
       autoRunPaused: Number(row?.auto_run_paused ?? 0) === 1,
       autoRunPauseReason: String(row?.auto_run_pause_reason ?? ""),
       autoRunResumeAt: row?.auto_run_resume_at === null || row?.auto_run_resume_at === undefined ? null : String(row.auto_run_resume_at),
@@ -1526,6 +1540,7 @@ export class Store {
     autoRunBatchLimit?: number;
     autoRunDailyTaskLimit?: number;
     autoRunFailureThreshold?: number;
+    autoRunStabilityDelayMinutes?: number;
     bookSummaryContextPercent?: number;
     contextCompactThreshold?: number;
     agentToolCallLimit?: number;
@@ -1548,6 +1563,7 @@ export class Store {
     const nextBatchLimit = input.autoRunBatchLimit ?? Number(current.autoRunBatchLimit);
     const nextDailyTaskLimit = input.autoRunDailyTaskLimit ?? Number(current.autoRunDailyTaskLimit);
     const nextFailureThreshold = input.autoRunFailureThreshold ?? Number(current.autoRunFailureThreshold);
+    const nextStabilityDelayMinutes = input.autoRunStabilityDelayMinutes ?? Number(current.autoRunStabilityDelayMinutes);
     const nextBookSummaryContextPercent = input.bookSummaryContextPercent ?? Number(current.bookSummaryContextPercent);
     const nextContextCompactThreshold = input.contextCompactThreshold ?? Number(current.contextCompactThreshold);
     const nextAgentToolCallLimit = input.agentToolCallLimit ?? Number(current.agentToolCallLimit);
@@ -1563,11 +1579,11 @@ export class Store {
     this.db.run(
       `INSERT INTO work_ai_settings (
          work_id, system_prompt, daily_token_quota, auto_run_enabled, auto_run_concurrency, auto_run_batch_limit,
-         auto_run_daily_task_limit, auto_run_failure_threshold, auto_run_paused, auto_run_pause_reason,
+         auto_run_daily_task_limit, auto_run_failure_threshold, auto_run_stability_delay_minutes, auto_run_paused, auto_run_pause_reason,
          auto_run_resume_at, auto_run_consecutive_failures, book_summary_context_percent,
          context_compact_threshold, agent_tool_call_limit, agent_tool_call_global_multiplier,
          agent_tools_json, title_generation_model_id, image_tool_model_id, always_include_setting_info, updated_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(work_id) DO UPDATE SET
          system_prompt = excluded.system_prompt,
          daily_token_quota = excluded.daily_token_quota,
@@ -1576,6 +1592,7 @@ export class Store {
          auto_run_batch_limit = excluded.auto_run_batch_limit,
          auto_run_daily_task_limit = excluded.auto_run_daily_task_limit,
          auto_run_failure_threshold = excluded.auto_run_failure_threshold,
+         auto_run_stability_delay_minutes = excluded.auto_run_stability_delay_minutes,
          auto_run_paused = excluded.auto_run_paused,
          auto_run_pause_reason = excluded.auto_run_pause_reason,
          auto_run_resume_at = excluded.auto_run_resume_at,
@@ -1597,6 +1614,7 @@ export class Store {
       Math.min(200, Math.max(1, nextBatchLimit)),
       Math.min(10_000, Math.max(0, nextDailyTaskLimit)),
       Math.min(10, Math.max(1, nextFailureThreshold)),
+      Math.min(120, Math.max(1, nextStabilityDelayMinutes)),
       current.autoRunPaused ? 1 : 0,
       String(current.autoRunPauseReason ?? ""),
       current.autoRunResumeAt === null ? null : String(current.autoRunResumeAt),
@@ -1619,6 +1637,7 @@ export class Store {
       autoRunBatchLimit: Math.min(200, Math.max(1, nextBatchLimit)),
       autoRunDailyTaskLimit: Math.min(10_000, Math.max(0, nextDailyTaskLimit)),
       autoRunFailureThreshold: Math.min(10, Math.max(1, nextFailureThreshold)),
+      autoRunStabilityDelayMinutes: Math.min(120, Math.max(1, nextStabilityDelayMinutes)),
       bookSummaryContextPercent: Math.min(90, Math.max(1, nextBookSummaryContextPercent)),
       contextCompactThreshold: Math.min(90, Math.max(50, nextContextCompactThreshold)),
       agentToolCallLimit: Math.min(maximumAgentToolCallLimit, Math.max(5, nextAgentToolCallLimit)),
@@ -3593,8 +3612,6 @@ export class Store {
     this.db.run(
       `UPDATE analysis_tasks SET status = 'expired', updated_at = ?
        WHERE work_id = ? AND status IN ('pending', 'running', 'completed', 'partial', 'review')
-       AND NOT (status = 'pending' AND task_type = 'chapter-analysis'
-         AND json_extract(scope_json, '$.chapterId') = ?)
        AND (json_extract(scope_json, '$.chapterId') = ?
          OR EXISTS (SELECT 1 FROM json_each(scope_json, '$.chapterIds') WHERE json_each.value = ?)
          OR json_extract(scope_json, '$.type') = 'book'
@@ -3609,37 +3626,9 @@ export class Store {
       chapterId,
       chapterId,
       chapterId,
-      chapterId,
       chapterId
     );
-    const existing = this.db.get(
-      `SELECT id FROM analysis_tasks WHERE work_id = ? AND task_type = 'chapter-analysis' AND status = 'pending'
-       AND json_extract(scope_json, '$.chapterId') = ?`,
-      workId,
-      chapterId
-    );
-    if (!existing) {
-      const timestamp = now();
-      this.db.run(
-        `INSERT INTO analysis_tasks (id, work_id, task_type, scope_json, status, source_versions_json, created_at, updated_at, created_by_user_id)
-         VALUES (?, ?, 'chapter-analysis', ?, 'pending', ?, ?, ?, ?)`,
-        id("task"),
-        workId,
-        JSON.stringify({ type: "chapter", chapterId }),
-        JSON.stringify({ [chapterId]: versionNo }),
-        timestamp,
-        timestamp,
-        currentRequestActor()?.userId ?? null
-      );
-    } else {
-      this.db.run(
-        "UPDATE analysis_tasks SET source_versions_json = ?, updated_at = ? WHERE id = ?",
-        JSON.stringify({ [chapterId]: versionNo }),
-        now(),
-        requiredString(existing, "id")
-      );
-    }
-    this.notifyAnalysisTaskQueued(workId);
+    this.notifyChapterAnalysisInvalidated(workId, chapterId, versionNo);
   }
 
   private mapWorks(rows: Row[]): Record<string, unknown>[] {

--- a/tests/integration/task-auto-run.test.ts
+++ b/tests/integration/task-auto-run.test.ts
@@ -119,6 +119,7 @@ describe("分析任务自动运行", () => {
       autoRunBatchLimit: 20,
       autoRunDailyTaskLimit: 0,
       autoRunFailureThreshold: 3,
+      autoRunStabilityDelayMinutes: 2,
       autoRunPaused: false,
       autoRunPauseReason: "",
       autoRunResumeAt: null,
@@ -146,6 +147,12 @@ describe("分析任务自动运行", () => {
     }).expect(400);
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
       autoRunFailureThreshold: 0
+    }).expect(400);
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
+      autoRunStabilityDelayMinutes: 0
+    }).expect(400);
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
+      autoRunStabilityDelayMinutes: 121
     }).expect(400);
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
       bookSummaryContextPercent: 91
@@ -177,6 +184,7 @@ describe("分析任务自动运行", () => {
     }).expect(400);
     const updated = await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
       dailyTokenQuota: 10_000,
+      autoRunStabilityDelayMinutes: 1,
       bookSummaryContextPercent: 35,
       contextCompactThreshold: 90,
       agentToolCallLimit: 80,
@@ -184,6 +192,7 @@ describe("分析任务自动运行", () => {
       alwaysIncludeSettingInfo: true
     }).expect(200);
     expect(updated.body.data.dailyTokenQuota).toBe(10_000);
+    expect(updated.body.data.autoRunStabilityDelayMinutes).toBe(1);
     expect(updated.body.data.bookSummaryContextPercent).toBe(35);
     expect(updated.body.data.contextCompactThreshold).toBe(90);
     expect(updated.body.data.agentToolCallLimit).toBe(80);
@@ -277,6 +286,43 @@ describe("分析任务自动运行", () => {
     const secondPage = await request(runtime.app).get(`/api/works/${workId}/tasks?page=2`).expect(200);
     expect(secondPage.body.data).toMatchObject({ page: 2, limit: 30, total: 55, hasMore: false, nextPage: null });
     expect(secondPage.body.data.items).toHaveLength(25);
+  });
+
+  it("正文持续编辑时重置稳定等待，并在停止编辑后才创建章节理解任务", async () => {
+    const runtime = createTestRuntime();
+    runtimes.push(runtime);
+    const work = runtime.store.createWork({ title: "章节分析稳定等待测试" });
+    const volume = runtime.store.createVolume(String(work.id), { title: "第一卷" });
+    const chapter = runtime.store.createChapter(String(work.id), {
+      volumeId: String(volume.id),
+      title: "第一章",
+      content: "初始正文"
+    });
+    const workId = String(work.id);
+    const chapterId = String(chapter.id);
+
+    vi.useFakeTimers();
+    try {
+      runtime.store.saveChapter(chapterId, { content: "第一次编辑" });
+      expect(runtime.store.countPendingTasks(workId)).toBe(0);
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(runtime.store.countPendingTasks(workId)).toBe(0);
+
+      runtime.store.saveChapter(chapterId, { content: "第二次编辑" });
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(runtime.store.countPendingTasks(workId)).toBe(0);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(runtime.store.countPendingTasks(workId)).toBe(1);
+      const taskId = String(runtime.store.listTaskSummariesPage(workId, { page: 1, limit: 10, offset: 0 }).items[0]?.id);
+      expect(runtime.store.getTask(taskId)).toMatchObject({
+        taskType: "chapter-analysis",
+        status: "pending",
+        sourceVersions: { [chapterId]: 3 }
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each(["structure", "report-update", "future-analysis"])("不支持的任务类型 %s 明确失败且自动运行不重试", async (taskType) => {

--- a/tests/integration/work-chapter-api.test.ts
+++ b/tests/integration/work-chapter-api.test.ts
@@ -25,27 +25,35 @@ describe("作品、导入和章节版本 API", () => {
     expect(chapter).not.toHaveProperty("content");
     expect(JSON.stringify(imported.body)).not.toContain("林舟收到信号。");
 
-    const saved = await request(runtime.app)
-      .patch(`/api/chapters/${chapter.id}`)
-      .send({ content: "林舟收到来自深空的信号。" })
-      .expect(200);
-    expect(saved.body.data).toMatchObject({ versionNo: 2, analysisStatus: "expired" });
+    vi.useFakeTimers();
+    try {
+      const saved = await request(runtime.app)
+        .patch(`/api/chapters/${chapter.id}`)
+        .send({ content: "林舟收到来自深空的信号。" })
+        .expect(200);
+      expect(saved.body.data).toMatchObject({ versionNo: 2, analysisStatus: "expired" });
 
-    await request(runtime.app)
-      .patch(`/api/chapters/${chapter.id}`)
-      .send({ content: "林舟收到来自深空的求救信号。", source: "auto" })
-      .expect(200);
+      await request(runtime.app)
+        .patch(`/api/chapters/${chapter.id}`)
+        .send({ content: "林舟收到来自深空的求救信号。", source: "auto" })
+        .expect(200);
 
-    const versions = await request(runtime.app).get(`/api/chapters/${chapter.id}/versions`).expect(200);
-    expect(versions.body.data.map((item: { versionNo: number }) => item.versionNo)).toEqual([3, 2, 1]);
-    expect(versions.body.data[0].source).toBe("auto");
+      const versions = await request(runtime.app).get(`/api/chapters/${chapter.id}/versions`).expect(200);
+      expect(versions.body.data.map((item: { versionNo: number }) => item.versionNo)).toEqual([3, 2, 1]);
+      expect(versions.body.data[0].source).toBe("auto");
 
-    const tasks = await request(runtime.app).get(`/api/works/${workId}/tasks`).expect(200);
-    expect(tasks.body.data.items).toHaveLength(1);
-    expect(tasks.body.data.items[0]).toMatchObject({ status: "pending" });
-    expect(tasks.body.data.items[0]).not.toHaveProperty("sourceVersions");
-    const task = await request(runtime.app).get(`/api/tasks/${tasks.body.data.items[0].id}`).expect(200);
-    expect(task.body.data).toMatchObject({ status: "pending", sourceVersions: { [chapter.id]: 3 } });
+      expect((await request(runtime.app).get(`/api/works/${workId}/tasks`).expect(200)).body.data.items).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      const tasks = await request(runtime.app).get(`/api/works/${workId}/tasks`).expect(200);
+      expect(tasks.body.data.items).toHaveLength(1);
+      expect(tasks.body.data.items[0]).toMatchObject({ status: "pending" });
+      expect(tasks.body.data.items[0]).not.toHaveProperty("sourceVersions");
+      const task = await request(runtime.app).get(`/api/tasks/${tasks.body.data.items[0].id}`).expect(200);
+      expect(task.body.data).toMatchObject({ status: "pending", sourceVersions: { [chapter.id]: 3 } });
+    } finally {
+      vi.useRealTimers();
+    }
 
     const restored = await request(runtime.app).post(`/api/chapters/${chapter.id}/restore`).send({ versionNo: 1 }).expect(200);
     expect(restored.body.data).toMatchObject({ content: "林舟收到信号。", versionNo: 4 });

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -693,6 +693,9 @@ describe("作者完整创作流程", () => {
     expect(application.text).toContain("同时运行上限");
     expect(application.text).toContain("每日任务上限");
     expect(application.text).toContain("连续失败暂停阈值");
+    expect(application.text).toContain('id="task-auto-run-stability-delay"');
+    expect(application.text).toContain("停止编辑后创建任务");
+    expect(application.text).toContain("稳定窗口");
     expect(application.text).toContain("恢复自动执行");
     expect(application.text).not.toContain("每轮任务上限");
     expect(application.text).not.toContain("开始下一轮");

--- a/tests/system/module-layout-toggle.test.ts
+++ b/tests/system/module-layout-toggle.test.ts
@@ -25,7 +25,7 @@ describe("知识模块布局切换", () => {
 
     expect(page.text).toContain('/styles.css?v=20260816-task-scope-volume-collapse-v2');
     expect(page.text).toContain('/app.js?v=20260816-extended-thinking-effort-v1');
-    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=analysis-task-expired-toast-v1"></script>')
+    expect(page.text).toContain('<script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=analysis-task-expired-toast-v1&feature=analysis-task-stability-delay-v1"></script>')
     expect(page.text).toContain('id="setting-editor-readonly-badge"');
     expect(page.text).toContain('id="character-editor-readonly-badge"');
     expect(page.text).toContain('id="knowledge-editor-readonly-badge"');

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -282,6 +282,7 @@ describe("数据库版本化迁移", () => {
         "auto_run_batch_limit",
         "auto_run_daily_task_limit",
         "auto_run_failure_threshold",
+        "auto_run_stability_delay_minutes",
         "auto_run_paused",
         "auto_run_pause_reason",
         "auto_run_resume_at",


### PR DESCRIPTION
## 变更

- 章节正文保存后不再立即创建章节理解任务，停止编辑并连续稳定等待后才创建。
- 默认稳定等待为 2 分钟，连续编辑会重置等待计时器。
- 在本书 AI 设置中增加等待时长配置，支持 1 至 120 分钟，最低 1 分钟。
- 章节新版本会使旧的待执行任务失效，避免持续编辑期间重复堆积任务。
- 增加数据库迁移、API、调度、界面和稳定等待回归测试。

## 验证

- `npm run typecheck`
- `npm test`：200 个测试文件、1031 个测试通过
- `npm run build`
- 内置浏览器验证桌面 1600×900 和窄屏 390×844，窄屏无横向溢出，控制台无错误或警告
- 隔离服务健康检查和 SQLite `integrity_check`、`foreign_key_check` 通过