### PR TITLE
chore(release): bump version to 0.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.8.1";
+export const APP_VERSION = "0.8.2";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 主要变化

- 将包版本、锁文件根版本和运行时 `APP_VERSION` 从 `0.8.1` 同步更新到 `0.8.2`。

## 验证

- `tests/unit/version.test.ts`
- `npm run check`
- 隔离开发服务健康检查
- SQLite `integrity_check` 与 `foreign_key_check`