### PR TITLE
fix(ai): defer chat title generation

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -4411,17 +4411,21 @@ export class AiManager {
     const conversationBefore: AiConversationTitleContext | null = input.conversationId
       ? this.store.getAiConversationTitleContext(input.conversationId, input.workId)
       : null;
-    const firstUserMessage = conversationBefore?.messages.length === 1 && conversationBefore.messages[0]?.role === "user"
-      ? conversationBefore.messages[0]
-      : null;
+    const userMessages = conversationBefore?.messages.filter((message) => message.role === "user") ?? [];
+    const assistantMessages = conversationBefore?.messages.filter((message) => message.role === "assistant") ?? [];
+    const firstUserMessage = userMessages[0] ?? null;
     const firstUserContent = firstUserMessage?.content ?? "";
     const titleSettings = this.store.getWorkAiSettings(input.workId);
     const titleModelId = typeof titleSettings.titleGenerationModelId === "string" ? titleSettings.titleGenerationModelId : "";
     const defaultTitle = firstUserContent ? defaultAiConversationTitle(firstUserContent) : "";
+    const isCompletingSecondAssistantTurn = conversationBefore?.messages.at(-1)?.role === "user"
+      && userMessages.length === 2
+      && assistantMessages.length === 1;
     const shouldGenerateTitle = Boolean(
       input.conversationId
       && firstUserContent
       && titleModelId
+      && isCompletingSecondAssistantTurn
       && (conversationBefore?.title === "新对话" || conversationBefore?.title === defaultTitle)
     );
     const processStartedAt = process.hrtime.bigint();
@@ -4495,8 +4499,10 @@ export class AiManager {
         input.workId,
         input.conversationId,
         titleModelId,
-        firstUserContent,
-        generated.content,
+        [
+          ...(conversationBefore?.messages ?? []),
+          { role: "assistant" as const, content: generated.content }
+        ],
         defaultTitle
       ).catch((error) => {
         logger.warn("ai.conversation_title.failed", { workId: input.workId, conversationId: input.conversationId, error: aiErrorForLog(error) });
@@ -4518,20 +4524,22 @@ export class AiManager {
     workId: string,
     conversationId: string,
     modelId: string,
-    prompt: string,
-    response: string,
+    messages: AiConversationTitleContext["messages"],
     fallbackTitle: string
   ): Promise<string | null> {
     try {
+      const conversation = messages.map((message) => {
+        const speaker = message.role === "user" ? "用户" : "助手";
+        return `<${speaker}>\n${Array.from(message.content).slice(0, 3_000).join("")}\n</${speaker}>`;
+      }).join("\n\n");
       const generated = await this.generate({
         workId,
         taskType: "chat",
         instruction: [
-          "请根据下面这次对话的第一轮用户提问和助手回答，生成一个简洁、准确的会话标题。",
+          "请根据下面前两轮用户与助手的对话，生成一个简洁、准确的会话标题。",
           "标题应概括用户真正想解决的主题，不要复述完整句子。",
           "只输出标题本身，不要引号、编号、Markdown、解释或句末标点；标题不超过 15 个汉字或 30 个字符。",
-          `<用户提问>\n${Array.from(prompt).slice(0, 6_000).join("")}\n</用户提问>`,
-          `<助手回答>\n${Array.from(response).slice(0, 6_000).join("")}\n</助手回答>`
+          `<对话记录>\n${conversation}\n</对话记录>`
         ].join("\n\n"),
         scope: { type: "none" },
         modelId,

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -2301,22 +2301,15 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(generated.content).toBe("首个增量");
   });
 
-  it("首轮对话默认使用提示词前十五字并可由独立模型生成标题", async () => {
+  it("第二轮助手回复后保留首个提示词截断标题，并由独立模型生成标题", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
     const settingsBefore = await request(runtime.app).get(`/api/works/${workId}/ai-settings`).expect(200);
     expect(settingsBefore.body.data.titleGenerationModelId).toBeNull();
 
-    const defaultConversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
-    await request(runtime.app).post(`/api/ai-conversations/${defaultConversation.body.data.id}/messages`).send({
-      role: "user",
-      content: "一二三四五六七八九十一二三四五六七八九十"
-    }).expect(201);
-    const defaultReloaded = await request(runtime.app).get(`/api/ai-conversations/${defaultConversation.body.data.id}`).expect(200);
-    expect(defaultReloaded.body.data.title).toBe("一二三四五六七八九十一二三四五");
-
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ titleGenerationModelId: modelId, agentTools: [] }).expect(200);
     const completionBodies: Array<{ stream?: boolean; tools?: unknown; messages?: Array<{ content?: string }> }> = [];
+    let chatRequestCount = 0;
     let titleRequestStarted = false;
     let releaseTitleRequest: (() => void) | null = null;
     fetchMock.mockImplementation(async (input, init) => {
@@ -2324,24 +2317,42 @@ describe("AI 供应商、模型与建议 API", () => {
       const body = JSON.parse(String(init?.body)) as { stream?: boolean; tools?: unknown; messages?: Array<{ content?: string }> };
       completionBodies.push(body);
       if (body.stream) {
-        return new Response("data: {\"choices\":[{\"delta\":{\"content\":\"助手回答\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n", {
+        chatRequestCount += 1;
+        const content = chatRequestCount === 1 ? "首轮助手回答" : "第二轮助手回答";
+        return new Response(`data: {"choices":[{"delta":{"content":"${content}"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n`, {
           status: 200,
           headers: { "Content-Type": "text/event-stream" }
         });
       }
       expect(body.tools).toBeUndefined();
+      expect(body.messages?.some((message) => message.content?.includes("你好"))).toBe(true);
       expect(body.messages?.some((message) => message.content?.includes("请规划北港跃迁路线"))).toBe(true);
-      expect(body.messages?.some((message) => message.content?.includes("助手回答"))).toBe(true);
+      expect(body.messages?.some((message) => message.content?.includes("第二轮助手回答"))).toBe(true);
       titleRequestStarted = true;
       return new Promise<Response>((resolve) => {
         releaseTitleRequest = () => resolve(new Response(JSON.stringify({ choices: [{ message: { content: "标题：北港跃迁路线" } }] }), { status: 200 }));
       });
     });
 
+    const firstStream = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+      instruction: "你好",
+      scope: { type: "chapter", chapterId },
+      modelId
+    }).expect(200).expect("Content-Type", /text\/event-stream/u);
+    const firstComplete = JSON.parse(firstStream.text.match(/event: complete\ndata: ([^\n]+)/u)?.[1] ?? "{}") as { conversationId?: string };
+    const conversationId = String(firstComplete.conversationId ?? "");
+    expect(conversationId).not.toBe("");
+    expect(titleRequestStarted).toBe(false);
+    expect(completionBodies).toHaveLength(1);
+    let reloaded = await request(runtime.app).get(`/api/ai-conversations/${conversationId}`).expect(200);
+    expect(reloaded.body.data.title).toBe("你好");
+    expect(reloaded.body.data.messages.map((message: { role: string }) => message.role)).toEqual(["user", "assistant"]);
+
     const streamPromise = request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
       instruction: "请规划北港跃迁路线",
       scope: { type: "chapter", chapterId },
-      modelId
+      modelId,
+      conversationId
     }).expect(200).expect("Content-Type", /text\/event-stream/u).then((response) => response);
     for (let index = 0; index < 50 && !titleRequestStarted; index += 1) await new Promise((resolve) => setTimeout(resolve, 2));
     expect(titleRequestStarted).toBe(true);
@@ -2353,15 +2364,14 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text).toContain("event: context");
     expect(streamed.text).toContain("event: user_message");
     expect(streamed.text).not.toContain('"conversationTitle":"北港跃迁路线"');
-    expect(completionBodies).toHaveLength(2);
-    const completePayload = JSON.parse(streamed.text.match(/event: complete\ndata: ([^\n]+)/u)?.[1] ?? "{}") as { conversationId?: string };
-    let reloaded = await request(runtime.app).get(`/api/ai-conversations/${completePayload.conversationId}`).expect(200);
+    expect(completionBodies).toHaveLength(3);
+    reloaded = await request(runtime.app).get(`/api/ai-conversations/${conversationId}`).expect(200);
     for (let index = 0; index < 50 && reloaded.body.data.title !== "北港跃迁路线"; index += 1) {
       await new Promise((resolve) => setTimeout(resolve, 2));
-      reloaded = await request(runtime.app).get(`/api/ai-conversations/${completePayload.conversationId}`).expect(200);
+      reloaded = await request(runtime.app).get(`/api/ai-conversations/${conversationId}`).expect(200);
     }
     expect(reloaded.body.data.title).toBe("北港跃迁路线");
-    expect(reloaded.body.data.messages.map((message: { role: string }) => message.role)).toEqual(["user", "assistant"]);
+    expect(reloaded.body.data.messages.map((message: { role: string }) => message.role)).toEqual(["user", "assistant", "user", "assistant"]);
     const settingsAfter = await request(runtime.app).get(`/api/works/${workId}/ai-settings`).expect(200);
     expect(settingsAfter.body.data.titleGenerationModelId).toBe(modelId);
   });
@@ -2551,7 +2561,7 @@ describe("AI 供应商、模型与建议 API", () => {
     });
   });
 
-  it("首轮标题生成失败时不影响主回答", async () => {
+  it("第二轮助手回复后的标题生成失败时不影响主回答", async () => {
     const { providerId, modelId } = await configureAi();
     await request(runtime.app).post(`/api/providers/${providerId}/test`).send({}).expect(200);
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({ titleGenerationModelId: modelId, agentTools: [] }).expect(200);
@@ -2569,10 +2579,21 @@ describe("AI 供应商、模型与建议 API", () => {
       return new Response(JSON.stringify({ error: { message: "标题模型不可用" } }), { status: 400 });
     });
 
-    const streamed = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+    const firstStream = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
       instruction: "标题生成失败时仍保留默认",
       scope: { type: "none" },
       modelId
+    }).expect(200).expect("Content-Type", /text\/event-stream/u);
+    const firstComplete = JSON.parse(firstStream.text.match(/event: complete\ndata: ([^\n]+)/u)?.[1] ?? "{}") as { conversationId?: string };
+    const conversationId = String(firstComplete.conversationId ?? "");
+    expect(conversationId).not.toBe("");
+    expect(titleRequestCount).toBe(0);
+
+    const streamed = await request(runtime.app).post(`/api/works/${workId}/chat/stream`).send({
+      instruction: "请继续说明",
+      scope: { type: "none" },
+      modelId,
+      conversationId
     }).expect(200).expect("Content-Type", /text\/event-stream/u);
 
     for (let index = 0; index < 50 && titleRequestCount < 1; index += 1) await new Promise((resolve) => setTimeout(resolve, 2));
@@ -2580,6 +2601,8 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text).toContain("event: complete");
     expect(streamed.text).not.toContain("event: error");
     expect(titleRequestCount).toBe(4);
+    const reloaded = await request(runtime.app).get(`/api/ai-conversations/${conversationId}`).expect(200);
+    expect(reloaded.body.data.title).toBe("标题生成失败时仍保留默认");
   });
 
   it("侧栏问答失败时通过 SSE 返回受控错误信息", async () => {

--- a/tests/system/ai-title-generation-ui.test.ts
+++ b/tests/system/ai-title-generation-ui.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("AI 对话标题生成设置", () => {
-  it("展示创作助手对话标题生成模型并接收首轮标题结果", async () => {
+  it("展示创作助手对话标题生成模型并接收延后标题结果", async () => {
     const publicPath = join(process.cwd(), "src", "public");
     const [application, page] = await Promise.all([
       readFile(join(publicPath, "app.js"), "utf8"),


### PR DESCRIPTION
## 修改内容

- 将 AI 对话标题模型的触发时机延后到第二轮助手回复完成并持久化后。
- 第一轮完整对话仍保留首个提示词的截断标题。
- 标题模型改为参考前两轮完整对话，避免“你好”等开场语被用作标题。

## 原因

首轮用户消息常为简短问候，首轮即重命名会产生无意义标题。

## 验证

- `npm run typecheck`
- `npm test`（204 个测试文件、1061 项测试通过）
- `npm run build`