### PR TITLE
chore(release): bump version to 0.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.8.4";
+export const APP_VERSION = "0.8.5";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更
- 将 `package.json`、`package-lock.json` 根包元数据和 `src/version.ts` 的应用版本统一更新为 `0.8.5`。

## 发布审计
- `develop` 相对 `main` 的改动未新增或修改 CLI 用户操作、API 契约、认证权限范围或导入导出格式，因此无需 CLI 同步变更。

## 验证
- `tests/unit/version.test.ts` 通过。
- 功能 PR #527 已先合入 `develop`。
- 工作区原有的 `package-lock.json` 非版本差异未包含在本 PR。