### PR TITLE
MUXUE-86: isolate chat histories by user

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -2304,7 +2304,12 @@ export class AiManager {
   async searchWork(
     workId: string,
     query: string,
-    options: { type?: HybridSearchType; limit?: number; allowedTypes?: readonly HybridSearchType[] } = {}
+    options: {
+      type?: HybridSearchType;
+      limit?: number;
+      allowedTypes?: readonly HybridSearchType[];
+      conversationOwnerUserId?: string;
+    } = {}
   ): Promise<Record<string, unknown>[]> {
     this.store.getWork(workId);
     const normalizedQuery = normalizeWorkSearchQuery(query);
@@ -2349,7 +2354,9 @@ export class AiManager {
         ? this.hybridChapterMatches(workId, normalizedQuery, "exact", channelLimit, chapterLineRangeFallbackState)
         : []),
       ...(hasIndexedSourceTypes ? this.hybridIndexedSourceMatches(workId, normalizedQuery, "exact", requestedTypes, channelLimit) : []),
-      ...(requestedTypes.has("agent-history") ? this.hybridAgentHistoryMatches(workId, normalizedQuery, channelLimit) : [])
+      ...(requestedTypes.has("agent-history")
+        ? this.hybridAgentHistoryMatches(workId, normalizedQuery, channelLimit, options.conversationOwnerUserId)
+        : [])
     ];
     const phoneticCandidates = [
       ...(requestedTypes.has("chapter")
@@ -2368,7 +2375,12 @@ export class AiManager {
     }));
   }
 
-  private hybridAgentHistoryMatches(workId: string, query: string, limit: number): HybridSearchCandidate[] {
+  private hybridAgentHistoryMatches(
+    workId: string,
+    query: string,
+    limit: number,
+    conversationOwnerUserId?: string
+  ): HybridSearchCandidate[] {
     const columns = `SELECT history.source_type, history.source_id, history.conversation_id, history.message_id,
                             history.role, history.content, conversation.title AS conversation_title
                      FROM ai_history_search history
@@ -2378,20 +2390,26 @@ export class AiManager {
         `${columns}
          JOIN ai_history_search_short_terms term ON term.search_id = history.id
          WHERE history.work_id = ? AND term.term = ?
+           AND (? IS NULL OR conversation.created_by_user_id = ?)
          ORDER BY history.created_at DESC, history.id DESC
          LIMIT ?`,
         workId,
         query,
+        conversationOwnerUserId ?? null,
+        conversationOwnerUserId ?? null,
         limit
       )
       : this.store.db.all(
         `${columns}
          JOIN ai_history_search_fts fts ON fts.rowid = history.id
          WHERE history.work_id = ? AND ai_history_search_fts MATCH ?
+           AND (? IS NULL OR conversation.created_by_user_id = ?)
          ORDER BY bm25(ai_history_search_fts), history.created_at DESC, history.id DESC
          LIMIT ?`,
         workId,
         `"${query.replaceAll('"', '""')}"`,
+        conversationOwnerUserId ?? null,
+        conversationOwnerUserId ?? null,
         limit
       );
     return rows.map((row): HybridSearchCandidate => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -495,6 +495,14 @@ const aiUsageQuerySchema = z.object({
   timezoneOffset: z.coerce.number().int().min(-840).max(840).default(0)
 }).strict();
 
+const adminAiConversationQuerySchema = z.object({
+  page: z.string().optional(),
+  limit: z.string().optional(),
+  q: z.string().trim().max(200).optional(),
+  workId: identifier.optional(),
+  userId: identifier.optional()
+}).strict();
+
 const platformPageSizesSchema = z.object({
   drafts: z.number().int().min(10).max(100).optional(),
   settings: z.number().int().min(10).max(100).optional(),
@@ -1312,6 +1320,9 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     const resolvedWorkId = workId ?? auth.resolveWorkId(request.path) ?? undefined;
     if (!resolvedWorkId) return fullWorkModulePermissions();
     return auth.workModulePermissions(request.authUser, resolvedWorkId, request.authMethod !== "api-key") ?? fullWorkModulePermissions();
+  };
+  const assertRequestAiConversationOwner = (request: Request, conversationId: string): void => {
+    if (request.authUser) store.assertAiConversationOwner(conversationId, request.authUser.userId);
   };
   const resolveConversationModelId = (workId: string, conversationId: string | undefined, requestedModelId: string | undefined): string | undefined => {
     if (!conversationId) return requestedModelId;
@@ -2649,6 +2660,15 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     const query = parse(aiUsageQuerySchema, request.query);
     data(response, ai.getPlatformTokenUsage(query.timezoneOffset));
   });
+  app.get("/api/platform/ai-conversations", (request, response) => {
+    const query = parse(adminAiConversationQuerySchema, request.query);
+    const pagination = parsePagination(request.query) ?? { page: 1, limit: 30, offset: 0 };
+    data(response, store.listAdminAiConversationsPage(pagination, {
+      query: query.q,
+      workId: query.workId,
+      userId: query.userId
+    }));
+  });
   app.get("/api/ui-settings", (_request, response) => data(response, store.getPlatformUiSettings()));
   app.get("/api/platform/ui-settings", (_request, response) => data(response, store.getPlatformUiSettings()));
   app.patch("/api/platform/ui-settings", (request, response) => {
@@ -2735,7 +2755,11 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       limit: request.query.limit ?? "20"
     }) ?? { page: 1, limit: 20, offset: 0 };
     const permissions = requestPermissions(request, request.params.workId);
-    data(response, mapRecords(store.listAiConversationsPage(request.params.workId, pagination), (conversation) => (
+    data(response, mapRecords(store.listAiConversationsPage(
+      request.params.workId,
+      pagination,
+      request.authUser?.userId
+    ), (conversation) => (
       redactAiConversation(conversation, permissions)
     )));
   });
@@ -2745,6 +2769,10 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       taskType: aiConversationTaskTypeSchema.optional()
     }).strict(), request.body ?? {});
     data(response, store.createAiConversation(request.params.workId, input.title, input.taskType), 201);
+  });
+  app.use("/api/ai-conversations/:conversationId", (request, _response, next) => {
+    assertRequestAiConversationOwner(request, request.params.conversationId);
+    next();
   });
   app.get("/api/ai-conversations/:conversationId", (request, response) => {
     const pagination = parsePagination(request.query);
@@ -2942,6 +2970,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     for (const citation of citations) {
       if (store.getChapter(citation.chapterId).workId !== request.params.workId) throw new AppError(400, "CITATION_WORK_MISMATCH", "引用章节不属于当前作品");
     }
+    if (input.conversationId) assertRequestAiConversationOwner(request, input.conversationId);
     const modelId = resolveConversationModelId(request.params.workId, input.conversationId, input.modelId);
     data(response, redactSuggestion(await ai.createSuggestion({
       workId: request.params.workId,
@@ -2984,6 +3013,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       : input.conversationId
         ? store.getAiConversationSummary(input.conversationId)
         : store.createAiConversation(request.params.workId);
+    assertRequestAiConversationOwner(request, String(conversation.id));
     if (String(conversation.workId) !== request.params.workId) {
       throw new AppError(400, "CONVERSATION_WORK_MISMATCH", "AI 对话不属于当前作品");
     }
@@ -3233,7 +3263,8 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     data(response, await ai.searchWork(request.params.workId, query.q, {
       type: query.type,
       limit: query.limit,
-      allowedTypes: readableHybridSearchTypes(permissions)
+      allowedTypes: readableHybridSearchTypes(permissions),
+      conversationOwnerUserId: request.authUser?.userId
     }));
   });
   app.head("/api/works/:workId/export", (request, response) => {

--- a/src/database.ts
+++ b/src/database.ts
@@ -7,9 +7,9 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询；版本 94 增加模型思考强度；版本 95 增加供应商最大输出参数选择；版本 96 扩展模型思考强度档位；版本 97 增加人物性别字段；版本 98 增加正文稳定等待配置；版本 99 持久化关系扮演中的用户角色；版本 100 增加平台 AI 流事件空闲超时配置；版本 101 将平台 AI 流事件空闲超时上限提升至 600 秒；版本 102 创建角色头像元数据表。
+// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询；版本 94 增加模型思考强度；版本 95 增加供应商最大输出参数选择；版本 96 扩展模型思考强度档位；版本 97 增加人物性别字段；版本 98 增加正文稳定等待配置；版本 99 持久化关系扮演中的用户角色；版本 100 增加平台 AI 流事件空闲超时配置；版本 101 将平台 AI 流事件空闲超时上限提升至 600 秒；版本 102 创建角色头像元数据表；版本 103 回填历史 AI 对话归属并建立用户列表索引。
 export const ENTITY_VERSION_BASELINE_MIGRATION_VERSION = 82;
-export const DATABASE_SCHEMA_VERSION = 102;
+export const DATABASE_SCHEMA_VERSION = 103;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -3803,6 +3803,28 @@ export class Database {
         )`);
         this.run("CREATE INDEX IF NOT EXISTS idx_character_avatars_storage_key ON character_avatars(storage_key)");
         this.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (102, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    if (!applied.has(103)) {
+      this.transaction(() => {
+        this.run(`UPDATE ai_conversations
+          SET created_by_user_id = (
+            SELECT work.owner_user_id FROM works work WHERE work.id = ai_conversations.work_id
+          )
+          WHERE created_by_user_id IS NULL
+            AND EXISTS (
+              SELECT 1 FROM works work
+              WHERE work.id = ai_conversations.work_id AND work.owner_user_id IS NOT NULL
+            )`);
+        this.run(`CREATE INDEX IF NOT EXISTS idx_ai_conversations_work_creator
+          ON ai_conversations(work_id, created_by_user_id, is_favorite, updated_at DESC, created_at DESC)`);
+        this.run("INSERT INTO schema_migrations (version, applied_at) VALUES (103, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -238,6 +238,9 @@ let chapterAnnotationCounts = new Map();
 let chapterAnnotationsLineIndex = null;
 let workAuditRecords = [];
 let workAuditNextPage = null;
+let adminAiConversationRecords = [];
+let adminAiConversationNextPage = null;
+let adminAiConversationFiltersOpen = false;
 const chapterBatchSelectedIds = new Set();
 let chapterMovePending = false;
 const readingRequestGate = createReadingRequestGate();
@@ -5413,6 +5416,7 @@ function renderSettingsHub() {
   $("#platform-ai-button").classList.toggle("hidden", !isAdmin);
   $("#platform-usage-button").classList.toggle("hidden", !isAdmin);
   $("#user-management-button").classList.toggle("hidden", !isAdmin);
+  $("#admin-ai-conversations-button").classList.toggle("hidden", !isAdmin);
   $("#platform-ui-settings-button").classList.toggle("hidden", !isAdmin);
   $("#s3-backup-button").classList.toggle("hidden", !isAdmin);
   $("#collaboration-button").disabled = !canManageWork;
@@ -5766,6 +5770,86 @@ async function openUsersDialog() {
   $("#users-dialog").showModal();
   try { renderUsers((await apiPage("/api/users")).items); }
   catch (error) { $("#users-dialog").close(); toast(error.message, "error"); }
+}
+
+function renderAdminAiConversationFilterOptions(works, users) {
+  const workSelect = $("#admin-ai-conversations-work");
+  const userSelect = $("#admin-ai-conversations-user");
+  const selectedWorkId = workSelect.value;
+  const selectedUserId = userSelect.value;
+  workSelect.innerHTML = `<option value="">全部作品</option>${works
+    .map((work) => `<option value="${esc(work.id)}">${esc(work.title)}</option>`).join("")}`;
+  userSelect.innerHTML = `<option value="">全部用户</option>${users
+    .map((user) => `<option value="${esc(user.userId)}">${esc(user.displayName)} · @${esc(user.username)}</option>`).join("")}`;
+  if ([...workSelect.options].some((option) => option.value === selectedWorkId)) workSelect.value = selectedWorkId;
+  if ([...userSelect.options].some((option) => option.value === selectedUserId)) userSelect.value = selectedUserId;
+}
+
+function renderAdminAiConversations() {
+  const host = $("#admin-ai-conversations-list");
+  host.innerHTML = adminAiConversationRecords.length ? adminAiConversationRecords.map((conversation) => {
+    const creator = conversation.creator
+      ? `${esc(conversation.creator.displayName)} · @${esc(conversation.creator.username)}`
+      : "未归属历史对话";
+    const work = conversation.work ?? { id: conversation.workId, title: "作品已删除", deleted: true };
+    const preview = String(conversation.preview || "").trim() || "暂无对话消息";
+    return `<article class="admin-ai-conversation-row" data-admin-ai-conversation="${esc(conversation.id)}">
+      <div class="admin-ai-conversation-heading"><div><strong>${esc(conversation.title || "新对话")}</strong><small>${creator}</small></div><span>${Number(conversation.messageCount ?? 0)} 条消息</span></div>
+      <dl class="admin-ai-conversation-meta">
+        <div><dt>作品</dt><dd>${esc(work.title)}${work.deleted ? "（回收站）" : ""}</dd></div>
+        <div><dt>任务类型</dt><dd>${esc(aiConversationTaskTypeLabel(conversation.taskType || "chat"))}</dd></div>
+        <div><dt>最后更新</dt><dd>${esc(formatDateTime(conversation.updatedAt))}</dd></div>
+      </dl>
+      <p>${esc(preview)}</p>
+    </article>`;
+  }).join("") : '<p class="empty-state">没有符合当前筛选条件的对话。</p>';
+  $("#admin-ai-conversations-summary").textContent = adminAiConversationRecords.length
+    ? `已显示 ${adminAiConversationRecords.length} 条对话${adminAiConversationNextPage === null ? "，已加载全部记录" : "，还有更多记录可继续加载"}`
+    : "当前筛选条件下没有对话记录。";
+  $("#admin-ai-conversations-load-more").classList.toggle("hidden", adminAiConversationNextPage === null);
+}
+
+function adminAiConversationListPath() {
+  const parameters = new URLSearchParams();
+  const query = $("#admin-ai-conversations-query").value.trim();
+  const workId = $("#admin-ai-conversations-work").value;
+  const userId = $("#admin-ai-conversations-user").value;
+  if (query) parameters.set("q", query);
+  if (workId) parameters.set("workId", workId);
+  if (userId) parameters.set("userId", userId);
+  const serialized = parameters.toString();
+  return `/api/platform/ai-conversations${serialized ? `?${serialized}` : ""}`;
+}
+
+async function loadAdminAiConversationPage(page = 1, append = false) {
+  const result = await apiPage(adminAiConversationListPath(), page, 30);
+  adminAiConversationRecords = append ? [...adminAiConversationRecords, ...result.items] : result.items;
+  adminAiConversationNextPage = result.nextPage;
+  renderAdminAiConversations();
+}
+
+async function openAdminAiConversationsDialog() {
+  if (state.user?.role !== "admin") {
+    toast("需要系统管理员权限", "error");
+    return;
+  }
+  adminAiConversationRecords = [];
+  adminAiConversationNextPage = null;
+  adminAiConversationFiltersOpen = false;
+  $("#admin-ai-conversations-filter-panel").classList.add("hidden");
+  $("#admin-ai-conversations-filter-toggle").setAttribute("aria-expanded", "false");
+  $("#admin-ai-conversations-filter-panel").reset();
+  $("#admin-ai-conversations-list").innerHTML = '<p class="empty-state">正在读取对话……</p>';
+  $("#admin-ai-conversations-summary").textContent = "正在读取对话……";
+  $("#admin-ai-conversations-dialog").showModal();
+  try {
+    const [works, users] = await Promise.all([apiAllPages("/api/works", 100), apiAllPages("/api/users", 100)]);
+    renderAdminAiConversationFilterOptions(works, users);
+    await loadAdminAiConversationPage();
+  } catch (error) {
+    $("#admin-ai-conversations-dialog").close();
+    toast(error.message, "error");
+  }
 }
 
 async function openPlatformUiSettingsDialog() {
@@ -16882,6 +16966,7 @@ $("#platform-usage-refresh").addEventListener("click", async () => {
   }
 });
 $("#user-management-button").addEventListener("click", openUsersDialog);
+$("#admin-ai-conversations-button").addEventListener("click", () => openAdminAiConversationsDialog().catch((error) => toast(error.message, "error")));
 $("#writing-progress-button").addEventListener("click", () => openWritingProgressDialog().catch((error) => toast(error.message, "error")));
 $("#writing-progress-close").addEventListener("click", () => $("#writing-progress-dialog").close());
 $("#writing-progress-refresh").addEventListener("click", () => loadWritingProgress().catch((error) => toast(error.message, "error")));
@@ -16913,6 +16998,34 @@ $("#presence-button").addEventListener("click", () => {
 });
 $("#users-dialog-close").addEventListener("click", () => $("#users-dialog").close());
 $("#users-settings-return").addEventListener("click", () => returnToSettingsHub("#user-management-button", "#users-dialog").catch((error) => toast(error.message, "error")));
+$("#admin-ai-conversations-close").addEventListener("click", () => $("#admin-ai-conversations-dialog").close());
+$("#admin-ai-conversations-settings-return").addEventListener("click", () => returnToSettingsHub("#admin-ai-conversations-button", "#admin-ai-conversations-dialog").catch((error) => toast(error.message, "error")));
+$("#admin-ai-conversations-filter-toggle").addEventListener("click", () => {
+  adminAiConversationFiltersOpen = !adminAiConversationFiltersOpen;
+  $("#admin-ai-conversations-filter-panel").classList.toggle("hidden", !adminAiConversationFiltersOpen);
+  $("#admin-ai-conversations-filter-toggle").setAttribute("aria-expanded", String(adminAiConversationFiltersOpen));
+  if (adminAiConversationFiltersOpen) $("#admin-ai-conversations-query").focus();
+});
+$("#admin-ai-conversations-filter-panel").addEventListener("submit", (event) => {
+  event.preventDefault();
+  loadAdminAiConversationPage().catch((error) => toast(error.message, "error"));
+});
+$("#admin-ai-conversations-reset").addEventListener("click", () => {
+  $("#admin-ai-conversations-filter-panel").reset();
+  loadAdminAiConversationPage().catch((error) => toast(error.message, "error"));
+});
+$("#admin-ai-conversations-refresh").addEventListener("click", (event) => {
+  const button = event.currentTarget;
+  button.disabled = true;
+  loadAdminAiConversationPage()
+    .catch((error) => toast(error.message, "error"))
+    .finally(() => { button.disabled = false; });
+});
+$("#admin-ai-conversations-load-more").addEventListener("click", () => {
+  if (adminAiConversationNextPage !== null) {
+    loadAdminAiConversationPage(adminAiConversationNextPage, true).catch((error) => toast(error.message, "error"));
+  }
+});
 $("#platform-ui-settings-close").addEventListener("click", () => $("#platform-ui-settings-dialog").close());
 $("#platform-ui-settings-return").addEventListener("click", () => returnToSettingsHub("#platform-ui-settings-button", "#platform-ui-settings-dialog").catch((error) => toast(error.message, "error")));
 $("#platform-ui-settings-cancel").addEventListener("click", () => $("#platform-ui-settings-dialog").close());

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="/icon.svg?v=20260712" type="image/svg+xml">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="stylesheet" href="/vendor/vditor/dist/index.css?v=3.11.2">
-    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2&feature=galaxy-motion-mode-v2&feature=chapter-search-replace-v3&feature=task-auto-run-ring-center-v3&feature=character-relationship-delete-v1&feature=ai-assistant-workspace-v2&feature=mobile-module-tab-position-v1&feature=volume-detail-icon-v1&feature=editor-actions-flow-v1&feature=reader-controls-subpanel-v1&feature=reader-focus-ring-v1&feature=ai-message-actions-v1&feature=assistant-responsive-navigation-v2&feature=ai-composer-square-controls-v2&feature=annotation-line-counts-v1&feature=line-number-gutter-fill-v1&feature=ai-relationship-roleplay-v1&feature=ai-model-picker-v1&feature=markdown-word-count-five-digit-v2&feature=ai-stream-character-count-stable-v1&feature=annotation-marker-offset-v1&feature=mobile-ai-entry-hidden-v1&feature=phone-client-entry-v1&feature=ai-stream-idle-timeout-v1&feature=toast-click-dismiss-v3&feature=character-avatar-v4">
+    <link rel="stylesheet" href="/styles.css?v=20260816-task-scope-volume-collapse-v2&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v3&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=galaxy-compact-controls-v2&feature=galaxy-motion-mode-v2&feature=chapter-search-replace-v3&feature=task-auto-run-ring-center-v3&feature=character-relationship-delete-v1&feature=ai-assistant-workspace-v2&feature=mobile-module-tab-position-v1&feature=volume-detail-icon-v1&feature=editor-actions-flow-v1&feature=reader-controls-subpanel-v1&feature=reader-focus-ring-v1&feature=ai-message-actions-v1&feature=assistant-responsive-navigation-v2&feature=ai-composer-square-controls-v2&feature=annotation-line-counts-v1&feature=line-number-gutter-fill-v1&feature=ai-relationship-roleplay-v1&feature=ai-model-picker-v1&feature=markdown-word-count-five-digit-v2&feature=ai-stream-character-count-stable-v1&feature=annotation-marker-offset-v1&feature=mobile-ai-entry-hidden-v1&feature=phone-client-entry-v1&feature=ai-stream-idle-timeout-v1&feature=toast-click-dismiss-v3&feature=character-avatar-v4&feature=admin-ai-conversations-v1">
   </head>
   <body class="auth-pending">
     <section id="auth-view" class="auth-view hidden" aria-labelledby="auth-title">
@@ -214,6 +214,7 @@
             <button id="platform-ai-button" class="settings-hub-card hidden" type="button" data-settings-action="ai"><span class="settings-card-mark">AI</span><strong>AI 管理</strong><small>供应商、模型、上下文与全局提示词</small></button>
             <button id="platform-usage-button" class="settings-hub-card hidden" type="button"><span class="settings-card-mark">T</span><strong>Token 用量</strong><small>总消耗、缓存命中率、每日网格与作品明细</small></button>
             <button id="user-management-button" class="settings-hub-card hidden" type="button"><span class="settings-card-mark">人</span><strong>用户管理</strong><small>管理员、普通用户与账户状态</small></button>
+            <button id="admin-ai-conversations-button" class="settings-hub-card hidden" type="button"><span class="settings-card-mark">话</span><strong>Chat 对话</strong><small>查看所有作品、所有用户的对话记录</small></button>
             <button id="platform-ui-settings-button" class="settings-hub-card hidden" type="button"><span class="settings-card-mark">界</span><strong>界面与分页</strong><small>设置通知位置、银河图性能及各模块的单页数量</small></button>
             <button id="s3-backup-button" class="settings-hub-card hidden" type="button"><span class="settings-card-mark">S3</span><strong>S3 备份</strong><small>将整个系统的数据库和图片同步到多个目标</small></button>
             <button id="collaboration-button" class="settings-hub-card" type="button"><span class="settings-card-mark">协</span><strong>作品协作</strong><small>邀请注册用户共同编辑当前作品</small></button>
@@ -920,6 +921,28 @@
       </div>
     </dialog>
 
+    <dialog id="admin-ai-conversations-dialog" class="dialog wide-dialog admin-ai-conversations-dialog" aria-labelledby="admin-ai-conversations-title">
+      <div class="dialog-header">
+        <div><span class="eyebrow">系统管理员</span><h2 id="admin-ai-conversations-title">Chat 对话列表</h2><p class="dialog-header-meta">只读查看平台内所有作品和用户的对话。</p></div>
+        <div class="settings-dialog-header-actions">
+          <button id="admin-ai-conversations-filter-toggle" class="module-filter-toggle" type="button" aria-label="筛选 Chat 对话" aria-controls="admin-ai-conversations-filter-panel" aria-expanded="false" title="筛选 Chat 对话"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 5h16l-6.5 7.2v5.3l-3 1.5v-6.8L4 5Z"></path></svg></button>
+          <button id="admin-ai-conversations-settings-return" class="ghost-button settings-parent-button" type="button">返回设置</button>
+          <button id="admin-ai-conversations-close" class="dialog-close" aria-label="关闭 Chat 对话列表" type="button">×</button>
+        </div>
+      </div>
+      <div class="admin-ai-conversations-body">
+        <form id="admin-ai-conversations-filter-panel" class="admin-ai-conversations-filters hidden" method="get">
+          <label>关键词<input id="admin-ai-conversations-query" name="q" type="search" maxlength="200" placeholder="对话、作品或用户"></label>
+          <label>作品<select id="admin-ai-conversations-work" name="workId"><option value="">全部作品</option></select></label>
+          <label>用户<select id="admin-ai-conversations-user" name="userId"><option value="">全部用户</option></select></label>
+          <div class="admin-ai-conversations-filter-actions"><button id="admin-ai-conversations-reset" class="ghost-button" type="button">重置</button><button class="primary-button" type="submit">应用筛选</button></div>
+        </form>
+        <p id="admin-ai-conversations-summary" class="admin-ai-conversations-summary" role="status" aria-live="polite">正在读取对话……</p>
+        <div id="admin-ai-conversations-list" class="admin-ai-conversations-list" aria-live="polite"></div>
+      </div>
+      <div class="dialog-actions"><button id="admin-ai-conversations-refresh" class="ghost-button" type="button">刷新</button><button id="admin-ai-conversations-load-more" class="primary-button hidden" type="button">加载更多</button></div>
+    </dialog>
+
     <dialog id="chapter-annotations-dialog" class="dialog wide-dialog chapter-annotations-dialog" aria-labelledby="chapter-annotations-title">
       <div class="dialog-header"><div><span class="eyebrow">正文协作</span><h2 id="chapter-annotations-title">正文评论</h2><p id="chapter-annotations-meta" class="dialog-header-meta">在正文行上点击右键即可添加评论。</p></div><button id="chapter-annotations-close" class="dialog-close" aria-label="关闭正文评论" type="button">×</button></div>
       <div id="chapter-annotations-list" class="chapter-annotations-list" aria-live="polite"></div>
@@ -1209,6 +1232,6 @@
     <div id="auth-loading" class="auth-loading" role="status" aria-label="正在载入工作台"></div>
     <script id="vditorIconScript" src="/vendor/vditor/dist/js/icons/ant.js?v=3.11.2"></script>
     <script src="/vendor/vditor/dist/index.min.js?v=3.11.2"></script>
-    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=galaxy-edge-label-threshold-v1&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=chapter-save-toast-v1&feature=character-relationship-delete-v1&feature=character-relationship-group-v1&feature=analysis-task-stability-delay-v1&feature=ai-assistant-workspace-v2&feature=volume-detail-icon-v1&feature=reader-manual-chapter-navigation-v1&feature=ai-message-reference-badges-v1&feature=ai-message-actions-v1&feature=assistant-responsive-navigation-v3&feature=annotation-permissions-v1&feature=annotation-line-counts-v1&feature=ai-relationship-roleplay-v1&feature=ai-roleplay-story-recall-v1&feature=ai-model-picker-v1&feature=ai-fork-model-unlock-v1&feature=context-percent-format-v1&feature=annotation-precise-locate-v1&feature=markdown-word-count-stable-v1&feature=ai-stream-character-count-stable-v2&feature=phone-client-entry-v1&feature=ai-process-empty-intermediate-v1&feature=ai-feed-scroll-follow-v1&feature=ai-message-retry-v1&feature=ai-stream-idle-timeout-v2&feature=ai-config-delete-v1&feature=toast-click-dismiss-v2&feature=system-restart-dialog-delay-v1&feature=character-avatar-v4"></script>
+    <script type="module" src="/app.js?v=20260816-extended-thinking-effort-v1&feature=ai-tool-call-copy-feedback-v2&feature=ai-send-control-v2&feature=analysis-task-queue-refresh-v1&feature=character-gender-v1&feature=character-filter-state-v1&feature=relationship-canvas-scale-v1&feature=relationship-table-scroll-v1&feature=ai-session-id-copy-v2&feature=galaxy-motion-mode-v3&feature=galaxy-edge-label-threshold-v1&feature=calculate-time-tool-v1&feature=analysis-task-expired-toast-v1&feature=global-replace-volume-v1&feature=chapter-search-replace-v1&feature=chapter-save-toast-v1&feature=character-relationship-delete-v1&feature=character-relationship-group-v1&feature=analysis-task-stability-delay-v1&feature=ai-assistant-workspace-v2&feature=volume-detail-icon-v1&feature=reader-manual-chapter-navigation-v1&feature=ai-message-reference-badges-v1&feature=ai-message-actions-v1&feature=assistant-responsive-navigation-v3&feature=annotation-permissions-v1&feature=annotation-line-counts-v1&feature=ai-relationship-roleplay-v1&feature=ai-roleplay-story-recall-v1&feature=ai-model-picker-v1&feature=ai-fork-model-unlock-v1&feature=context-percent-format-v1&feature=annotation-precise-locate-v1&feature=markdown-word-count-stable-v1&feature=ai-stream-character-count-stable-v2&feature=phone-client-entry-v1&feature=ai-process-empty-intermediate-v1&feature=ai-feed-scroll-follow-v1&feature=ai-message-retry-v1&feature=ai-stream-idle-timeout-v2&feature=ai-config-delete-v1&feature=toast-click-dismiss-v2&feature=system-restart-dialog-delay-v1&feature=character-avatar-v4&feature=admin-ai-conversations-v1"></script>
   </body>
 </html>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -809,6 +809,28 @@ body.is-panel-resizing { cursor: col-resize; user-select: none; }
   cursor: not-allowed;
   opacity: .46;
 }
+.dialog.admin-ai-conversations-dialog { width: min(1040px, 94vw); height: min(760px, calc(100dvh - 24px)); max-height: calc(100dvh - 24px); overflow: hidden; }
+.admin-ai-conversations-dialog { grid-template-rows: auto minmax(0, 1fr) auto; }
+.admin-ai-conversations-dialog[open] { display: grid; }
+.admin-ai-conversations-body { display: grid; grid-template-rows: auto auto minmax(0, 1fr); gap: 12px; min-height: 0; padding: 16px 24px 0; }
+.admin-ai-conversations-filters { display: grid; grid-template-columns: minmax(220px, 1.4fr) repeat(2, minmax(160px, 1fr)) auto; align-items: end; gap: 10px; padding: 13px; border: 1px solid var(--line); border-radius: 7px; background: var(--surface-soft); }
+.admin-ai-conversations-filters label { display: grid; gap: 6px; min-width: 0; color: var(--muted); font-size: 10px; font-weight: 650; }
+.admin-ai-conversations-filters :is(input, select) { width: 100%; min-height: 36px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 4px; background-color: var(--surface); color: var(--ink); font-size: 12px; }
+.admin-ai-conversations-filter-actions { display: flex; gap: 7px; }
+.admin-ai-conversations-filter-actions button { min-height: 36px; white-space: nowrap; }
+.admin-ai-conversations-summary { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.5; }
+.admin-ai-conversations-list { display: grid; align-content: start; gap: 9px; min-height: 0; overflow-y: auto; padding: 0 2px 16px 0; }
+.admin-ai-conversation-row { display: grid; gap: 11px; min-width: 0; padding: 14px 15px; border: 1px solid var(--line); border-radius: 7px; background: var(--surface-soft); }
+.admin-ai-conversation-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; min-width: 0; }
+.admin-ai-conversation-heading > div { display: grid; gap: 4px; min-width: 0; }
+.admin-ai-conversation-heading strong { overflow: hidden; color: var(--ink); font-size: 13px; font-weight: 650; line-height: 1.4; text-overflow: ellipsis; white-space: nowrap; }
+.admin-ai-conversation-heading small, .admin-ai-conversation-heading > span { color: var(--muted); font-size: 9px; line-height: 1.5; }
+.admin-ai-conversation-heading > span { flex: 0 0 auto; padding: 3px 7px; border: 1px solid var(--line); border-radius: 999px; background: var(--surface); white-space: nowrap; }
+.admin-ai-conversation-meta { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 7px; margin: 0; }
+.admin-ai-conversation-meta > div { display: grid; gap: 3px; min-width: 0; padding: 7px 9px; border-radius: 5px; background: var(--surface); }
+.admin-ai-conversation-meta dt { color: var(--muted); font-size: 8px; }
+.admin-ai-conversation-meta dd { overflow: hidden; margin: 0; color: var(--ink); font-size: 10px; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
+.admin-ai-conversation-row > p { display: -webkit-box; overflow: hidden; margin: 0; color: var(--muted); font-size: 10px; line-height: 1.6; overflow-wrap: anywhere; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
 .dialog.s3-backup-dialog { width: min(900px, 94vw); }
 .s3-backup-body { display: grid; gap: 18px; max-height: calc(88vh - 86px); overflow-y: auto; padding: 18px 24px 24px; }
 .s3-backup-encryption { display: grid; gap: 12px; min-width: 0; margin: 0; padding: 15px 16px; border: 1px solid var(--line); border-radius: 7px; background: var(--surface-soft); }
@@ -3583,6 +3605,17 @@ select:focus, input:focus, textarea:focus { border-color: #a77768; box-shadow: 0
   .member-permission-form .primary-button { justify-self: stretch; }
   .access-row { grid-template-columns: minmax(0, 1fr); align-items: stretch; }
   .access-row select, .access-row button { width: 100%; }
+  .admin-ai-conversations-dialog .dialog-header { gap: 10px; }
+  .admin-ai-conversations-dialog .dialog-header > div:first-child { min-width: 0; }
+  .admin-ai-conversations-dialog .dialog-header-meta { display: none; }
+  .admin-ai-conversations-dialog .settings-dialog-header-actions { flex-wrap: wrap; justify-content: flex-end; }
+  .admin-ai-conversations-dialog .settings-parent-button { order: 3; width: 100%; }
+  .admin-ai-conversations-body { padding: 12px 16px 0; }
+  .admin-ai-conversations-filters { grid-template-columns: minmax(0, 1fr); align-items: stretch; }
+  .admin-ai-conversations-filter-actions button { flex: 1 1 0; }
+  .admin-ai-conversation-heading { align-items: stretch; flex-direction: column; gap: 7px; }
+  .admin-ai-conversation-heading > span { align-self: flex-start; }
+  .admin-ai-conversation-meta { grid-template-columns: minmax(0, 1fr); }
   .work-access-field { align-items: stretch; flex-direction: column; }
   .onboarding-popover { width: calc(100vw - 24px); }
   .onboarding-popover-header { padding-inline: 15px; }

--- a/src/store.ts
+++ b/src/store.ts
@@ -53,6 +53,12 @@ type WorkListBatch = {
   covers: Map<string, Row>;
 };
 
+export type AdminAiConversationFilters = {
+  query?: string;
+  workId?: string;
+  userId?: string;
+};
+
 const WORK_LIST_BATCH_SIZE = 500;
 const ENTITY_LIST_BATCH_SIZE = 400;
 export const RECYCLE_BIN_RETENTION_DAYS = 30;
@@ -7908,7 +7914,7 @@ export class Store {
     return this.getAiConversation(conversationId);
   }
 
-  listAiConversations(workId: string): Record<string, unknown>[] {
+  listAiConversations(workId: string, userId?: string): Record<string, unknown>[] {
     this.getWork(workId);
     return this.db.all(
       `SELECT conversation.*,
@@ -7916,13 +7922,16 @@ export class Store {
         COALESCE((SELECT content FROM ai_conversation_messages message WHERE message.conversation_id = conversation.id ORDER BY message.created_at DESC, message.rowid DESC LIMIT 1), '') AS preview
        FROM ai_conversations conversation
        WHERE conversation.work_id = ?
+         AND (? IS NULL OR conversation.created_by_user_id = ?)
        ORDER BY conversation.is_favorite DESC, conversation.updated_at DESC, conversation.created_at DESC
        LIMIT 100`,
-      workId
+      workId,
+      userId ?? null,
+      userId ?? null
     ).map((row) => this.mapAiConversation(row));
   }
 
-  listAiConversationsPage(workId: string, pagination: Pagination): PaginatedResult<Record<string, unknown>> {
+  listAiConversationsPage(workId: string, pagination: Pagination, userId?: string): PaginatedResult<Record<string, unknown>> {
     this.getWork(workId);
     const page = paginationSql(pagination);
     const rows = this.db.all(
@@ -7931,11 +7940,89 @@ export class Store {
         COALESCE((SELECT content FROM ai_conversation_messages message WHERE message.conversation_id = conversation.id ORDER BY message.created_at DESC, message.rowid DESC LIMIT 1), '') AS preview
        FROM ai_conversations conversation
        WHERE conversation.work_id = ?
+         AND (? IS NULL OR conversation.created_by_user_id = ?)
        ORDER BY conversation.is_favorite DESC, conversation.updated_at DESC, conversation.created_at DESC${page.sql}`,
       workId,
+      userId ?? null,
+      userId ?? null,
       ...page.params
     );
     return paginated(rows.map((row) => this.mapAiConversation(row)), pagination);
+  }
+
+  assertAiConversationOwner(conversationId: string, userId: string): void {
+    const conversation = this.db.get("SELECT created_by_user_id FROM ai_conversations WHERE id = ?", conversationId);
+    if (!conversation) throw notFound("AI 对话");
+    if (optionalString(conversation, "created_by_user_id") !== userId) {
+      throw new AppError(403, "AI_CONVERSATION_ACCESS_DENIED", "你只能访问自己创建的 AI 对话");
+    }
+  }
+
+  listAdminAiConversationsPage(
+    pagination: Pagination,
+    filters: AdminAiConversationFilters = {}
+  ): PaginatedResult<Record<string, unknown>> {
+    const where: string[] = [];
+    const params: SQLInputValue[] = [];
+    if (filters.workId) {
+      where.push("conversation.work_id = ?");
+      params.push(filters.workId);
+    }
+    if (filters.userId) {
+      where.push("conversation.created_by_user_id = ?");
+      params.push(filters.userId);
+    }
+    const normalizedQuery = filters.query?.normalize("NFKC").trim() ?? "";
+    if (normalizedQuery) {
+      const pattern = `%${escapeSqlLikePattern(normalizedQuery)}%`;
+      where.push(`(
+        conversation.title LIKE ? ESCAPE '\\' COLLATE NOCASE
+        OR work.title LIKE ? ESCAPE '\\' COLLATE NOCASE
+        OR creator.username LIKE ? ESCAPE '\\' COLLATE NOCASE
+        OR creator.display_name LIKE ? ESCAPE '\\' COLLATE NOCASE
+        OR EXISTS (
+          SELECT 1 FROM ai_conversation_messages searched_message
+          WHERE searched_message.conversation_id = conversation.id
+            AND searched_message.content LIKE ? ESCAPE '\\' COLLATE NOCASE
+        )
+      )`);
+      params.push(pattern, pattern, pattern, pattern, pattern);
+    }
+    const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+    const page = paginationSql(pagination);
+    const rows = this.db.all(
+      `SELECT conversation.*,
+        work.title AS work_title,
+        work.deleted_at AS work_deleted_at,
+        creator.username AS creator_username,
+        creator.display_name AS creator_display_name,
+        creator.role AS creator_role,
+        creator.status AS creator_status,
+        (SELECT COUNT(*) FROM ai_conversation_messages message WHERE message.conversation_id = conversation.id) AS message_count,
+        COALESCE((SELECT content FROM ai_conversation_messages message WHERE message.conversation_id = conversation.id ORDER BY message.created_at DESC, message.rowid DESC LIMIT 1), '') AS preview
+       FROM ai_conversations conversation
+       JOIN works work ON work.id = conversation.work_id
+       LEFT JOIN users creator ON creator.id = conversation.created_by_user_id
+       ${whereSql}
+       ORDER BY conversation.updated_at DESC, conversation.created_at DESC${page.sql}`,
+      ...params,
+      ...page.params
+    );
+    return paginated(rows.map((row) => ({
+      ...this.mapAiConversation(row),
+      work: {
+        id: requiredString(row, "work_id"),
+        title: requiredString(row, "work_title"),
+        deleted: Boolean(optionalString(row, "work_deleted_at"))
+      },
+      creator: optionalString(row, "created_by_user_id") ? {
+        userId: requiredString(row, "created_by_user_id"),
+        username: requiredString(row, "creator_username"),
+        displayName: requiredString(row, "creator_display_name"),
+        role: requiredString(row, "creator_role"),
+        status: requiredString(row, "creator_status")
+      } : null
+    })), pagination);
   }
 
   getAiConversationSummary(conversationId: string): Record<string, unknown> {

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -319,6 +319,14 @@ export class UserAuthService {
       if (role === "admin") {
         this.database.run("UPDATE works SET owner_user_id = ? WHERE owner_user_id IS NULL AND id <> ?", userId, PLATFORM_AI_WORK_ID);
         this.database.run(
+          `UPDATE ai_conversations SET created_by_user_id = ?
+           WHERE created_by_user_id IS NULL
+             AND work_id IN (SELECT id FROM works WHERE owner_user_id = ? AND id <> ?)`,
+          userId,
+          userId,
+          PLATFORM_AI_WORK_ID
+        );
+        this.database.run(
           `INSERT OR IGNORE INTO work_memberships (work_id, user_id, role, invited_by_user_id, created_at)
            SELECT id, ?, 'owner', ?, ? FROM works WHERE owner_user_id = ? AND id <> ?`,
           userId,

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -2488,14 +2488,14 @@ describe("用户、作品权限与操作者追踪 API", () => {
         }
       })
       .expect(201);
-    const source = await owner.agent.post(`/api/works/${workId}/ai-conversations`)
-      .set("X-CSRF-Token", owner.csrfToken)
-      .send({ title: "共享历史对话" })
+    const source = await collaborator.agent.post(`/api/works/${workId}/ai-conversations`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ title: "个人历史对话" })
       .expect(201);
     const sourceId = String(source.body.data.id);
-    const message = await owner.agent.post(`/api/ai-conversations/${sourceId}/messages`)
-      .set("X-CSRF-Token", owner.csrfToken)
-      .send({ role: "user", content: "共享历史消息" })
+    const message = await collaborator.agent.post(`/api/ai-conversations/${sourceId}/messages`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ role: "user", content: "个人历史消息" })
       .expect(201);
     const body = { messageId: message.body.data.id, requestId: "authorized-fork-request" };
 
@@ -2527,6 +2527,11 @@ describe("用户、作品权限与操作者追踪 API", () => {
       .set("X-CSRF-Token", owner.csrfToken)
       .send({ role: "user", content: "角色私有上下文" })
       .expect(201);
+    runtime.database.run(
+      "UPDATE ai_conversations SET created_by_user_id = ? WHERE id = ?",
+      collaborator.user.userId,
+      String(roleplaySource.body.data.id)
+    );
     const characterDenied = await collaborator.agent.post(`/api/ai-conversations/${roleplaySource.body.data.id}/fork`)
       .set("X-CSRF-Token", collaborator.csrfToken)
       .send({ messageId: roleplayMessage.body.data.id, requestId: "roleplay-fork-denied" })
@@ -2789,8 +2794,8 @@ describe("用户、作品权限与操作者追踪 API", () => {
         }
       })
       .expect(201);
-    const conversation = await owner.agent.post(`/api/works/${workId}/ai-conversations`)
-      .set("X-CSRF-Token", owner.csrfToken)
+    const conversation = await collaborator.agent.post(`/api/works/${workId}/ai-conversations`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
       .send({})
       .expect(201);
     const conversationId = String(conversation.body.data.id);
@@ -2805,10 +2810,8 @@ describe("用户、作品权限与操作者追踪 API", () => {
       }
     });
 
-    const ownerView = await owner.agent.get(`/api/ai-conversations/${conversationId}`).expect(200);
-    expect(ownerView.body.data.messages[0].metadata.mentionCharacterIds).toEqual([character.body.data.id]);
-    expect(ownerView.body.data.messages[0].metadata.mentionRaceIds).toEqual(["secret-race-id"]);
-    expect(ownerView.body.data.messages[0].metadata.mentionOrganizationIds).toEqual(["secret-organization-id"]);
+    const ownerView = await owner.agent.get(`/api/ai-conversations/${conversationId}`).expect(403);
+    expect(ownerView.body.error.code).toBe("AI_CONVERSATION_ACCESS_DENIED");
 
     const collaboratorView = await collaborator.agent.get(`/api/ai-conversations/${conversationId}`).expect(200);
     expect(collaboratorView.body.data.messages[0]).toMatchObject({
@@ -2898,12 +2901,13 @@ describe("用户、作品权限与操作者追踪 API", () => {
       now
     );
     runtime.database.run(
-      `INSERT INTO ai_conversations (id, work_id, title, compacted_summary, compacted_message_count, created_at, updated_at)
-       VALUES (?, ?, 'TOP_SECRET_CHAT_TITLE', '', 0, ?, ?)`,
+      `INSERT INTO ai_conversations (id, work_id, title, compacted_summary, compacted_message_count, created_at, updated_at, created_by_user_id)
+       VALUES (?, ?, 'TOP_SECRET_CHAT_TITLE', '', 0, ?, ?, ?)`,
       conversationId,
       workId,
       now,
-      now
+      now,
+      collaborator.user.userId
     );
     runtime.database.run(
       `INSERT INTO ai_conversation_messages (id, conversation_id, role, content, citations_json, metadata_json, created_at)
@@ -3044,7 +3048,7 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(runtime.database.all("PRAGMA foreign_key_check")).toEqual([]);
   });
 
-  it("仅向有权限的已登录用户暴露对话 Session ID，不暴露认证会话 ID", async () => {
+  it("仅向对话创建者暴露对话 Session ID，不暴露认证会话 ID", async () => {
     const owner = await register(runtime, "ai_session_id_owner");
     const reader = await register(runtime, "ai_session_id_reader");
     const outsider = await register(runtime, "ai_session_id_outsider");
@@ -3068,14 +3072,14 @@ describe("用户、作品权限与操作者追踪 API", () => {
           relationships: "none",
           outlines: "none",
           reviews: "none",
-          "ai-chat": "read",
+          "ai-chat": "write",
           "ai-analysis": "none",
           "ai-settings": "none"
         }
       })
       .expect(201);
-    const created = await owner.agent.post(`/api/works/${workId}/ai-conversations`)
-      .set("X-CSRF-Token", owner.csrfToken)
+    const created = await reader.agent.post(`/api/works/${workId}/ai-conversations`)
+      .set("X-CSRF-Token", reader.csrfToken)
       .send({ title: "诊断对话" })
       .expect(201);
     const conversationId = String(created.body.data.id);
@@ -3084,6 +3088,8 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(unauthenticated.body.error.code).toBe("AUTH_REQUIRED");
     const forbidden = await outsider.agent.get(`/api/ai-conversations/${conversationId}`).expect(403);
     expect(forbidden.body.error.code).toBe("WORK_ACCESS_DENIED");
+    const ownerDenied = await owner.agent.get(`/api/ai-conversations/${conversationId}`).expect(403);
+    expect(ownerDenied.body.error.code).toBe("AI_CONVERSATION_ACCESS_DENIED");
 
     const readable = await reader.agent.get(`/api/ai-conversations/${conversationId}`).expect(200);
     expect(readable.body.data.id).toBe(conversationId);
@@ -3098,13 +3104,112 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(authSession.body.data.csrfToken).toBe(reader.csrfToken);
   });
 
+  it("作品 Chat 仅返回当前用户对话，管理员可从系统列表查看全部对话", async () => {
+    const admin = await register(runtime, "conversation_owner_admin");
+    const collaborator = await register(runtime, "conversation_owner_collaborator");
+    const work = await admin.agent.post("/api/works")
+      .set("X-CSRF-Token", admin.csrfToken)
+      .send({ title: "对话归属作品" })
+      .expect(201);
+    const workId = String(work.body.data.id);
+    await admin.agent.post(`/api/works/${workId}/members`)
+      .set("X-CSRF-Token", admin.csrfToken)
+      .send({
+        userId: collaborator.user.userId,
+        permissions: {
+          prose: "read",
+          drafts: "none",
+          settings: "none",
+          characters: "none",
+          races: "none",
+          organizations: "none",
+          timeline: "none",
+          relationships: "none",
+          outlines: "none",
+          reviews: "none",
+          "ai-chat": "write",
+          "ai-analysis": "none",
+          "ai-settings": "none"
+        }
+      })
+      .expect(201);
+
+    const adminConversation = await admin.agent.post(`/api/works/${workId}/ai-conversations`)
+      .set("X-CSRF-Token", admin.csrfToken)
+      .send({ title: "管理员私有对话" })
+      .expect(201);
+    const collaboratorConversation = await collaborator.agent.post(`/api/works/${workId}/ai-conversations`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ title: "协作者私有对话" })
+      .expect(201);
+    await collaborator.agent.post(`/api/ai-conversations/${collaboratorConversation.body.data.id}/messages`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ role: "user", content: "协作者独有搜索词" })
+      .expect(201);
+
+    const adminList = await admin.agent.get(`/api/works/${workId}/ai-conversations`).expect(200);
+    expect(adminList.body.data.items.map((item: { id: string }) => item.id)).toEqual([adminConversation.body.data.id]);
+    const collaboratorList = await collaborator.agent.get(`/api/works/${workId}/ai-conversations`).expect(200);
+    expect(collaboratorList.body.data.items.map((item: { id: string }) => item.id)).toEqual([collaboratorConversation.body.data.id]);
+
+    const adminDirectDenied = await admin.agent.get(`/api/ai-conversations/${collaboratorConversation.body.data.id}`).expect(403);
+    expect(adminDirectDenied.body.error.code).toBe("AI_CONVERSATION_ACCESS_DENIED");
+    const collaboratorDirectDenied = await collaborator.agent.get(`/api/ai-conversations/${adminConversation.body.data.id}`).expect(403);
+    expect(collaboratorDirectDenied.body.error.code).toBe("AI_CONVERSATION_ACCESS_DENIED");
+    const crossWriteDenied = await collaborator.agent.patch(`/api/ai-conversations/${adminConversation.body.data.id}/favorite`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ isFavorite: true })
+      .expect(403);
+    expect(crossWriteDenied.body.error.code).toBe("AI_CONVERSATION_ACCESS_DENIED");
+    const crossStreamDenied = await collaborator.agent.post(`/api/works/${workId}/chat/stream`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ instruction: "继续", scope: { type: "none" }, conversationId: adminConversation.body.data.id })
+      .expect(403);
+    expect(crossStreamDenied.body.error.code).toBe("AI_CONVERSATION_ACCESS_DENIED");
+
+    const collaboratorSearch = await collaborator.agent
+      .get(`/api/works/${workId}/search?q=${encodeURIComponent("协作者独有搜索词")}&type=agent-history`)
+      .expect(200);
+    expect(collaboratorSearch.body.data).toEqual(expect.arrayContaining([
+      expect.objectContaining({ conversationId: collaboratorConversation.body.data.id })
+    ]));
+    const adminSearch = await admin.agent
+      .get(`/api/works/${workId}/search?q=${encodeURIComponent("协作者独有搜索词")}&type=agent-history`)
+      .expect(200);
+    expect(adminSearch.body.data).toEqual([]);
+
+    const platformList = await admin.agent.get("/api/platform/ai-conversations?page=1&limit=20").expect(200);
+    expect(platformList.body.data.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: adminConversation.body.data.id,
+        work: expect.objectContaining({ id: workId, title: "对话归属作品" }),
+        creator: expect.objectContaining({ userId: admin.user.userId })
+      }),
+      expect.objectContaining({
+        id: collaboratorConversation.body.data.id,
+        creator: expect.objectContaining({ userId: collaborator.user.userId })
+      })
+    ]));
+    const filteredPlatformList = await admin.agent
+      .get(`/api/platform/ai-conversations?q=${encodeURIComponent("协作者独有搜索词")}&userId=${encodeURIComponent(collaborator.user.userId)}`)
+      .expect(200);
+    expect(filteredPlatformList.body.data.items.map((item: { id: string }) => item.id)).toEqual([collaboratorConversation.body.data.id]);
+    const nonAdminPlatformDenied = await collaborator.agent.get("/api/platform/ai-conversations").expect(403);
+    expect(nonAdminPlatformDenied.body.error.code).toBe("ADMIN_REQUIRED");
+  });
+
   it("首位管理员注册时自动接管迁移前的现有作品", async () => {
     const legacyWork = runtime.store.createWork({ title: "既有作品" });
+    const legacyConversation = runtime.store.createAiConversation(String(legacyWork.id), "既有历史对话");
     const admin = await register(runtime, "first_admin");
     const works = await admin.agent.get("/api/works").expect(200);
     expect(works.body.data).toEqual(expect.arrayContaining([expect.objectContaining({ id: legacyWork.id, accessRole: "owner" })]));
     expect(runtime.database.get("SELECT owner_user_id FROM works WHERE id = ?", String(legacyWork.id))?.owner_user_id).toBe(admin.user.userId);
     expect(runtime.database.get("SELECT role FROM work_memberships WHERE work_id = ? AND user_id = ?", String(legacyWork.id), admin.user.userId)?.role).toBe("owner");
+    expect(runtime.database.get(
+      "SELECT created_by_user_id FROM ai_conversations WHERE id = ?",
+      String(legacyConversation.id)
+    )?.created_by_user_id).toBe(admin.user.userId);
   });
 
   it("管理员可管理账户，但不能停用自己或移除最后一名管理员", async () => {

--- a/tests/system/admin-ai-conversations-ui.test.ts
+++ b/tests/system/admin-ai-conversations-ui.test.ts
@@ -1,0 +1,51 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { createRuntime } from "../../src/app.js";
+
+const runtime = createRuntime({
+  databasePath: ":memory:",
+  masterSecret: "admin-ai-conversations-ui-system-test-secret",
+  disableUserAuth: true,
+  serveUi: true
+});
+
+afterAll(() => runtime.close());
+
+describe("管理员 Chat 对话列表界面", () => {
+  it("提供系统设置入口、默认收起筛选、只读列表和响应式布局", async () => {
+    const [page, application, styles] = await Promise.all([
+      request(runtime.app).get("/").expect(200),
+      request(runtime.app).get("/app.js").expect(200),
+      request(runtime.app).get("/styles.css").expect(200)
+    ]);
+
+    expect(page.text).toContain('id="admin-ai-conversations-button" class="settings-hub-card hidden"');
+    expect(page.text).toContain("查看所有作品、所有用户的对话记录");
+    expect(page.text).toContain('id="admin-ai-conversations-dialog"');
+    expect(page.text).toContain('id="admin-ai-conversations-filter-toggle" class="module-filter-toggle"');
+    expect(page.text).toContain('aria-controls="admin-ai-conversations-filter-panel" aria-expanded="false"');
+    expect(page.text).toContain('id="admin-ai-conversations-filter-panel" class="admin-ai-conversations-filters hidden"');
+    expect(page.text).toContain('id="admin-ai-conversations-query"');
+    expect(page.text).toContain('id="admin-ai-conversations-work"');
+    expect(page.text).toContain('id="admin-ai-conversations-user"');
+    expect(page.text).toContain('id="admin-ai-conversations-list"');
+    expect(page.text).toContain('id="admin-ai-conversations-load-more"');
+    expect(page.text).toContain("feature=admin-ai-conversations-v1");
+
+    expect(application.text).toContain('$("#admin-ai-conversations-button").classList.toggle("hidden", !isAdmin);');
+    expect(application.text).toContain('async function openAdminAiConversationsDialog()');
+    expect(application.text).toContain('apiPage(adminAiConversationListPath(), page, 30)');
+    expect(application.text).toContain('apiAllPages("/api/users", 100)');
+    expect(application.text).toContain('adminAiConversationFiltersOpen = !adminAiConversationFiltersOpen;');
+    expect(application.text).toContain('setAttribute("aria-expanded", String(adminAiConversationFiltersOpen))');
+    expect(application.text).toContain('class="admin-ai-conversation-row"');
+    expect(application.text).toContain("未归属历史对话");
+    expect(application.text).not.toContain('data-admin-ai-conversation-delete');
+
+    expect(styles.text).toContain('.dialog.admin-ai-conversations-dialog { width: min(1040px, 94vw);');
+    expect(styles.text).toContain('.admin-ai-conversations-filters { display: grid;');
+    expect(styles.text).toContain('.admin-ai-conversation-meta { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));');
+    expect(styles.text).toContain('.admin-ai-conversations-filters { grid-template-columns: minmax(0, 1fr); align-items: stretch; }');
+    expect(styles.text).toContain('.admin-ai-conversation-meta { grid-template-columns: minmax(0, 1fr); }');
+  });
+});

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -1669,4 +1669,38 @@ describe("数据库版本化迁移", () => {
     expect(migrated.get("SELECT COUNT(*) AS count FROM ai_connectivity_test_states WHERE object_id = 'model-extended-thinking-effort'")).toEqual({ count: 0 });
     migrated.close();
   });
+
+  it("迁移 103 将无归属历史对话回填给作品创建者并建立列表索引", () => {
+    const root = mkdtempSync(join(tmpdir(), "ai-novel-migration-conversation-owner-"));
+    roots.push(root);
+    const filename = join(root, "conversation-owner.db");
+    const timestamp = "2026-08-20T00:00:00.000Z";
+    const current = new Database(filename);
+    const store = new Store(current);
+    current.run(
+      `INSERT INTO users (
+        id, username, normalized_username, display_name, password_hash, password_salt,
+        role, status, created_at, updated_at
+      ) VALUES ('migration-owner', 'migration_owner', 'migration_owner', '迁移创建者', 'hash', 'salt', 'admin', 'active', ?, ?)`,
+      timestamp,
+      timestamp
+    );
+    const work = store.createWork({ title: "历史对话迁移作品" });
+    current.run("UPDATE works SET owner_user_id = 'migration-owner' WHERE id = ?", String(work.id));
+    const conversation = store.createAiConversation(String(work.id), "待回填对话");
+    expect(current.get("SELECT created_by_user_id FROM ai_conversations WHERE id = ?", String(conversation.id))).toEqual({
+      created_by_user_id: null
+    });
+    current.run("DELETE FROM schema_migrations WHERE version = 103");
+    current.close();
+
+    const migrated = new Database(filename);
+    expect(migrated.get("SELECT created_by_user_id FROM ai_conversations WHERE id = ?", String(conversation.id))).toEqual({
+      created_by_user_id: "migration-owner"
+    });
+    expect(migrated.all("PRAGMA index_list(ai_conversations)").some((index) => index.name === "idx_ai_conversations_work_creator")).toBe(true);
+    expect(migrated.all("PRAGMA integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(migrated.all("PRAGMA foreign_key_check")).toEqual([]);
+    migrated.close();
+  });
 });


### PR DESCRIPTION
Closes MUXUE-86

- isolate work chat history and direct conversation access by creator
- add an admin-only global conversation list with work and user filters
- migrate legacy conversations to their work owner and cover permissions, migration, and UI