### PR TITLE
feat(cli): expose volume story order

### DIFF
--- a/src/cli-contract.ts
+++ b/src/cli-contract.ts
@@ -73,9 +73,10 @@ export const cliResourceDefinitions = {
         title: "分卷标题，最多 200 字",
         kind: "main | prequel | extra | epilogue | appendix",
         description: "分卷说明，最多 5000 字",
-        keywords: "字符串数组，最多 100 项"
+        keywords: "字符串数组，最多 100 项",
+        storyOrder: "故事顺序，非负整数；与目录排序 sortOrder 独立"
       },
-      example: { title: "第一卷 星港", kind: "main", description: "主角离开故乡的开端", keywords: ["启程", "星港"] }
+      example: { title: "第一卷 星港", kind: "main", description: "主角离开故乡的开端", keywords: ["启程", "星港"], storyOrder: 0 }
     },
     update: {
       properties: {
@@ -83,9 +84,10 @@ export const cliResourceDefinitions = {
         kind: "分卷类型",
         description: "新说明",
         keywords: "完整替换关键词数组",
-        sortOrder: "非负整数排序值"
+        sortOrder: "非负整数目录排序值",
+        storyOrder: "故事顺序，非负整数；与目录排序 sortOrder 独立"
       },
-      example: { description: "补充星港政治冲突", keywords: ["启程", "星港", "议会"] }
+      example: { description: "补充星港政治冲突", keywords: ["启程", "星港", "议会"], storyOrder: 1 }
     },
     notes: ["分卷修改会生成版本历史；更新或删除时可提供 expectedVersionNo，版本不匹配会拒绝写入。"]
   },

--- a/tests/e2e/real-cli.ts
+++ b/tests/e2e/real-cli.ts
@@ -290,12 +290,16 @@ async function run(): Promise<void> {
   const volume = createResource("volume", workId, {
     title: "第一卷",
     kind: "main",
-    description: "初始分卷"
+    description: "初始分卷",
+    storyOrder: 3
   });
   const volumeId = String(volume.id);
   assert.ok(listResource("volume", workId).some((item) => (item as Record<string, unknown>).id === volumeId));
   assert.equal(getResource("volume", volumeId)?.id, volumeId);
-  assert.equal(updateResource("volume", volumeId, { description: "更新后的分卷", keywords: ["启程"] }).description, "更新后的分卷");
+  assert.equal(Number(volume.storyOrder), 3);
+  const updatedVolume = updateResource("volume", volumeId, { description: "更新后的分卷", keywords: ["启程"], storyOrder: 5 });
+  assert.equal(updatedVolume.description, "更新后的分卷");
+  assert.equal(Number(updatedVolume.storyOrder), 5);
 
   const chapter = cliJson([
     "resource", "create", "chapter", workId, "--input", "-"

--- a/tests/unit/cli-core.test.ts
+++ b/tests/unit/cli-core.test.ts
@@ -92,6 +92,8 @@ describe("Scriverse CLI 核心", () => {
     expect(cliResourceDefinitions.draft.create.required).toEqual(["draftType", "title"]);
     expect(cliResourceDefinitions.draft.create.properties.draftType).toBe("prose | setting");
     expect(cliResourceDefinitions.draft.create.properties.volumeId).toContain("分卷 ID");
+    expect(cliResourceDefinitions.volume.create.properties.storyOrder).toContain("故事顺序");
+    expect(cliResourceDefinitions.volume.update.properties.storyOrder).toContain("故事顺序");
     expect(cliResourceDefinitions.draft.actions).toEqual(["list", "get", "create", "update", "history", "restore"]);
   });
 


### PR DESCRIPTION
同步 CLI 的分卷剧情顺序契约：schema show volume 现在说明 storyOrder，并通过编译后真实 CLI E2E 验证创建和更新会持久化该字段。\n\n验证：npm run typecheck；tests/unit/cli-core.test.ts；npm run test:e2e:cli。