### PR TITLE
chore(release): bump version to 0.8.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.8.6";
+export const APP_VERSION = "0.8.7";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
### 发布准备

- 同步更新 `package.json`、`package-lock.json` 顶层和根包、`src/version.ts` 的 `APP_VERSION`。
- CLI 审计已完成：develop 相对 main 没有 CLI 契约变化。

### 验证

- `tests/unit/version.test.ts` 通过。
- `npm run typecheck` 通过。
- `npm run build` 通过。