### PR TITLE
feat(server): support Scriverse Desktop clients

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -436,6 +436,23 @@ type GenerateResult = {
   contextUsage: Record<string, unknown>;
 };
 
+export type DesktopLocalAiPreparationInput = {
+  workId: string;
+  taskType: "chat" | "continue" | "polish";
+  instruction: string;
+  scope: ContextScope;
+  contextWindow: number;
+  maxOutputTokens: number;
+  conversationId?: string;
+  excludeConversationMessageId?: string;
+};
+
+export type DesktopLocalAiPreparationResult = {
+  remoteSystemPrompt: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+  contextUsage: Record<string, unknown>;
+};
+
 export type AiContextCompactionEvent = {
   contextUsage: Record<string, unknown>;
   sourceMessageCount: number;
@@ -5815,6 +5832,74 @@ export class AiManager {
     };
   }
 
+  prepareDesktopLocalAiCompletion(input: DesktopLocalAiPreparationInput): DesktopLocalAiPreparationResult {
+    const model: ModelRow = {
+      id: "desktop-local-model",
+      provider_id: "desktop-local-provider",
+      display_name: "Desktop Local AI",
+      model_id: "desktop-local-model",
+      enabled: 1,
+      context_window: input.contextWindow,
+      preset_json: JSON.stringify({ max_tokens: input.maxOutputTokens })
+    };
+    const scope = input.taskType === "continue"
+      ? this.enrichContinuationScope(input.workId, input.scope, input.instruction)
+      : input.scope;
+    const preparedInput: GenerateInput = {
+      workId: input.workId,
+      taskType: input.taskType,
+      instruction: input.instruction,
+      scope,
+      agentToolIds: [],
+      disableTools: true,
+      ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+      ...(input.excludeConversationMessageId ? { excludeConversationMessageId: input.excludeConversationMessageId } : {})
+    };
+    const conversation = preparedInput.conversationId
+      ? this.store.getAiConversationContext(
+        preparedInput.conversationId,
+        preparedInput.workId,
+        preparedInput.excludeConversationMessageId
+      )
+      : null;
+    const budget = this.contextBudget(preparedInput, model, conversation);
+    const context = this.buildContext(preparedInput, model, budget);
+    const completionMessages = this.buildMessages(preparedInput, context, conversation);
+    const systemMessage = completionMessages[0];
+    if (systemMessage?.role !== "system" || typeof systemMessage.content !== "string") {
+      throw new AppError(500, "LOCAL_AI_CONTEXT_INVALID", "无法为 Desktop 本地 AI 构建系统提示词");
+    }
+    const messages = completionMessages.slice(1).map((message) => {
+      if ((message.role !== "user" && message.role !== "assistant") || typeof message.content !== "string") {
+        throw new AppError(409, "LOCAL_AI_CONTENT_UNSUPPORTED", "当前上下文包含本地 AI 暂不支持的消息内容");
+      }
+      return { role: message.role, content: message.content };
+    });
+    const contextWindow = Math.max(32_768, Math.min(2_000_000, Number(input.contextWindow) || 128_000));
+    const inputTokens = estimateCompletionMessageTokens(completionMessages);
+    const systemPromptTokens = estimateAiTokens(systemMessage.content);
+    const remainingTokens = Math.max(0, contextWindow - inputTokens);
+    return {
+      remoteSystemPrompt: systemMessage.content,
+      messages,
+      contextUsage: {
+        modelId: "desktop-local-model",
+        contextWindow,
+        inputTokens,
+        remainingTokens,
+        usagePercent: Math.min(100, Math.round(inputTokens / contextWindow * 100)),
+        maxOutputTokens: input.maxOutputTokens,
+        tokenDistribution: {
+          systemPromptTokens,
+          functionTokens: 0,
+          skillsTokens: 0,
+          contextTokens: Math.max(0, inputTokens - systemPromptTokens),
+          leftTokens: remainingTokens
+        }
+      }
+    };
+  }
+
   private completionContextUsage(
     input: Pick<GenerateInput, "workId" | "taskType" | "modelId" | "scope" | "instruction" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">,
     model: ModelRow,
@@ -6570,8 +6655,9 @@ export class AiManager {
       ? this.roleplayCharacterId(workId, conversationId)
       : roleplayCharacterIdOverride;
     const permissions = this.store.getWork(workId).modulePermissions as WorkModulePermissions;
+    const requested = requestedToolIds ? new Set(requestedToolIds) : null;
+    if (requested?.size === 0) return [];
     if (roleplayCharacterId) {
-      const requested = requestedToolIds ? new Set(requestedToolIds) : null;
       if (!canReadWorkModule(permissions, "characters")) return [];
       const roleplayTools: AgentToolId[] = [];
       if (!requested || requested.has("recall_self")) roleplayTools.push("recall_self");
@@ -6604,7 +6690,6 @@ export class AiManager {
       : this.store.getWorkAiSettings(workId).agentTools;
     const enabled = new Set((sourceTools as unknown[])
       .filter((item): item is ConfiguredAgentToolId => typeof item === "string" && CONFIGURED_AGENT_TOOL_IDS.includes(item as ConfiguredAgentToolId)));
-    const requested = requestedToolIds ? new Set(requestedToolIds) : null;
     return CONFIGURED_AGENT_TOOL_IDS.filter((toolId) => enabled.has(toolId)
       && (!requested || requested.has(toolId))
       && this.canReadWithAgentTool(permissions, toolId));

--- a/src/app.ts
+++ b/src/app.ts
@@ -903,8 +903,8 @@ export type RuntimeOptions = {
   serveUi?: boolean;
   publicPath?: string;
   security?: RuntimeSecurityOptions;
-  /** 仅供受信任的本机嵌入运行时：保留 URL/协议校验，但不按 DNS 结果拦截 AI 地址。 */
-  trustAiEndpointNetwork?: boolean;
+  /** 仅供受信任的本机嵌入运行时：完全不安装 AI endpoint validator。 */
+  disableAiEndpointValidation?: boolean;
   disableUserAuth?: boolean;
   /** 开发环境专用：使用已有的第一个活动账户进入工作台，不创建会话。 */
   devAuthBypass?: boolean;
@@ -1474,13 +1474,9 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     store,
     credentialVault,
     options.fetchImpl ?? fetch,
-    options.developmentServer === true
+    options.developmentServer === true || options.disableAiEndpointValidation === true
       ? undefined
-      : options.security ? (url) => assertSafeAiEndpoint(
-        url,
-        options.security?.allowPrivateAiEndpoints,
-        options.trustAiEndpointNetwork === true
-      ) : undefined,
+      : options.security ? (url) => assertSafeAiEndpoint(url, options.security?.allowPrivateAiEndpoints) : undefined,
     (task, actor) => {
       const requiredModules = analysisTaskReadModules(task.taskType, task.scope);
       const creator = actor ? null : database.get(

--- a/src/app.ts
+++ b/src/app.ts
@@ -903,6 +903,8 @@ export type RuntimeOptions = {
   serveUi?: boolean;
   publicPath?: string;
   security?: RuntimeSecurityOptions;
+  /** 仅供受信任的本机嵌入运行时：保留 URL/协议校验，但不按 DNS 结果拦截 AI 地址。 */
+  trustAiEndpointNetwork?: boolean;
   disableUserAuth?: boolean;
   /** 开发环境专用：使用已有的第一个活动账户进入工作台，不创建会话。 */
   devAuthBypass?: boolean;
@@ -1474,7 +1476,11 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     options.fetchImpl ?? fetch,
     options.developmentServer === true
       ? undefined
-      : options.security ? (url) => assertSafeAiEndpoint(url, options.security?.allowPrivateAiEndpoints) : undefined,
+      : options.security ? (url) => assertSafeAiEndpoint(
+        url,
+        options.security?.allowPrivateAiEndpoints,
+        options.trustAiEndpointNetwork === true
+      ) : undefined,
     (task, actor) => {
       const requiredModules = analysisTaskReadModules(task.taskType, task.scope);
       const creator = actor ? null : database.get(

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,6 +46,7 @@ import { paginated, parsePagination } from "./pagination.js";
 import { normalizeUploadFileName } from "./utils.js";
 import { assertSafeAiEndpoint, assertSafeS3Endpoint, createApiRateLimitMiddleware, createAuthenticationRateLimitMiddleware, createBasicAuthMiddleware, createCaptchaRateLimitMiddleware, createExpensiveApiRateLimitMiddleware, createSameOriginMiddleware, createSecurityHeadersMiddleware, createUploadRateLimitMiddleware, enforceCaseInsensitiveRouting, normalizeApiPath, resolveTrustProxySetting, verifySetupToken, type RuntimeSecurityOptions } from "./security.js";
 import { ImageCaptchaService } from "./image-captcha.js";
+import { OfflineSyncService } from "./offline-sync.js";
 import { assertSafeImportedPlainText, decodeUtf8ImportedText } from "./import-security.js";
 import { InvalidRasterImageError, readRasterImageMetadata } from "./image-metadata.js";
 import { createRequestLoggingMiddleware, sanitizeRequestPath } from "./http-logging.js";
@@ -53,6 +54,7 @@ import { accountReference, logger, sanitizeError } from "./logger.js";
 import { currentRequestActor, runWithRequestActor } from "./request-context.js";
 import { S3BackupManager, type S3BackupManagerOptions } from "./s3-backup.js";
 import { APP_VERSION } from "./version.js";
+import { DESKTOP_SYNC_PROTOCOL, desktopCompatibilityMetadata } from "./desktop-protocol.js";
 import { ReleaseUpdateChecker } from "./release-update.js";
 import { CHARACTER_AVATAR_IMAGE_MAX_BYTES, DEFAULT_IMAGE_UPLOAD_LIMITS, formatUploadLimit, type ImageUploadLimits } from "./upload-limits.js";
 import { canReadWorkModule, canWriteWorkModule, chapterAnnotationPermissionModule, fullWorkModulePermissions, proseReplacementPermissionModules, type WorkModulePermissions } from "./work-permissions.js";
@@ -160,6 +162,14 @@ const loginSchema = z.object({
   password: z.string().max(200),
   ...captchaFields
 }).strict();
+const desktopLoginSchema = z.object({
+  username: z.string().trim().min(1).max(100),
+  password: z.string().max(200),
+  desktopId: z.string().uuid(),
+  profileId: z.string().uuid(),
+  clientVersion: z.string().trim().min(1).max(80),
+  ...captchaFields
+}).strict();
 const userUpdateSchema = z.object({ role: z.enum(["admin", "user"]).optional(), status: z.enum(["active", "disabled"]).optional() }).strict();
 const memberRoleValueSchema = z.enum(["editor", "settings-editor", "viewer"]);
 const moduleAccessSchema = z.enum(["none", "read", "write"]);
@@ -238,6 +248,7 @@ const workSchema = z.object({
   coverUrl: z.string().url().nullable().optional(),
   tags: optionalStrings
 });
+const workOfflineAccessSchema = z.object({ enabled: z.boolean() }).strict();
 
 const settingSchema = z.object({
   title: nonEmpty.max(200),
@@ -249,6 +260,31 @@ const settingSchema = z.object({
   evidence: z.array(z.unknown()).optional(),
   scope: jsonObject.optional(),
   authorNote: z.string().max(20_000).optional()
+});
+const chapterSyncSnapshotSchema = z.object({
+  title: nonEmpty.max(300),
+  content: z.string().max(2_000_000),
+  chapterType: chapterTypeSchema
+}).strict();
+const settingSyncSnapshotSchema = settingSchema.strict();
+const syncMutationBaseFields = {
+  mutationId: z.string().uuid(),
+  entityId: identifier,
+  operation: z.literal("update"),
+  baseVersionNo: z.number().int().positive(),
+  changeNote: z.string().trim().min(1).max(500).default("Desktop 离线修改")
+};
+const syncPushSchema = z.object({
+  clientId: z.string().uuid(),
+  mutations: z.array(z.discriminatedUnion("entityType", [
+    z.object({ ...syncMutationBaseFields, entityType: z.literal("chapter"), localSnapshot: chapterSyncSnapshotSchema }).strict(),
+    z.object({ ...syncMutationBaseFields, entityType: z.literal("setting"), localSnapshot: settingSyncSnapshotSchema }).strict()
+  ])).min(1).max(20)
+}).strict().superRefine((input, context) => {
+  const mutationIds = input.mutations.map((mutation) => mutation.mutationId);
+  if (new Set(mutationIds).size !== mutationIds.length) {
+    context.addIssue({ code: z.ZodIssueCode.custom, path: ["mutations"], message: "同一批次不能重复 mutationId" });
+  }
 });
 
 const globalReplaceSchema = z.object({
@@ -686,6 +722,20 @@ const contextSchema = z.object({
   includeSettingInfo: z.boolean().optional()
 });
 
+const desktopLocalAiPreparationSchema = z.object({
+  taskType: z.enum(["chat", "continue", "polish"]),
+  instruction: nonEmpty.max(100_000),
+  scope: contextSchema,
+  contextWindow: z.number().int().min(32_768).max(2_000_000),
+  maxOutputTokens: z.number().int().min(1).max(2_000_000),
+  conversationId: identifier.optional(),
+  currentMessageId: identifier.optional(),
+  citations: aiCitationsSchema.optional()
+}).strict().refine((input) => input.maxOutputTokens < input.contextWindow, {
+  path: ["maxOutputTokens"],
+  message: "本地 AI 最大输出令牌数必须小于上下文窗口"
+});
+
 /** 创建任务 API 的分析类型校验：仅允许可新建类型，历史类型在运行层保留防御性拒绝。 */
 export const creatableAnalysisTaskTypeSchema = z.enum(CREATABLE_ANALYSIS_TASK_TYPES);
 const relationshipSourceRefSchema = z.object({
@@ -888,6 +938,7 @@ export type Runtime = {
   liteLlmPriceCache: LiteLlmPriceCache;
   backups: S3BackupManager;
   auth: UserAuthService;
+  offlineSync: OfflineSyncService;
   attachmentStorage: AttachmentStorage;
   characterAvatarStorage: AttachmentStorage;
   cleanupAttachments: () => Promise<void>;
@@ -902,6 +953,10 @@ function data(response: Response, value: unknown, status = 200): void {
 
 function noContent(response: Response): void {
   response.status(204).end();
+}
+
+function hasInteractiveSession(request: Request): boolean {
+  return request.authMethod === "session" || request.authMethod === "desktop-session";
 }
 
 async function sendEpub(response: Response, archive: Readable, title: string, fallbackStem: string): Promise<void> {
@@ -1335,6 +1390,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     ? auth.listUsers().find((user) => user.status === "active") ?? null
     : null;
   const store = new Store(database);
+  const offlineSync = new OfflineSyncService(database, store);
   const platformAiSettings = store.getPlatformAiSettings();
   const platformAiStreamIdleTimeoutMs = normalizeAiStreamIdleTimeoutSeconds(
     Number(platformAiSettings.streamIdleTimeoutSeconds)
@@ -1487,6 +1543,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       status: "ok",
       bootId,
       version: APP_VERSION,
+      ...desktopCompatibilityMetadata(),
       versionLabel: options.betaVersionLabel ?? null,
       protocol: "openai-chat-completions",
       protocols: [...AI_PROVIDER_PROTOCOLS],
@@ -1504,10 +1561,12 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   app.use(createCaptchaRateLimitMiddleware());
   app.use(createApiRateLimitMiddleware(options.security?.apiRateLimit, options.security?.apiRateWindowMs));
   if (options.security?.enforceSameOrigin ?? true) app.use(createSameOriginMiddleware());
+  app.use("/api/sync/works", express.json({ limit: "3mb" }));
   app.use(express.json({ limit: "2mb" }));
 
   app.get("/api/auth/session", (request, response) => {
-    const session = auth.authenticate(request);
+    const desktopSession = auth.authenticateDesktop(request);
+    const session = desktopSession ? null : auth.authenticate(request);
     const registrationOpen = options.security?.allowRegistration === true;
     const setupRequired = !auth.hasUsers();
     const setupTokenRequired = setupRequired && Boolean(options.security?.setupToken);
@@ -1516,8 +1575,17 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       data(response, { authenticated: true, user: developmentUser, csrfToken: null, bootId, setupRequired: false, setupTokenRequired: false, registrationOpen });
       return;
     }
-    data(response, session
-      ? { authenticated: true, user: session.user, csrfToken: session.csrfToken, bootId, setupRequired: false, setupTokenRequired: false, registrationOpen }
+    const interactiveSession = desktopSession ?? session;
+    data(response, interactiveSession
+      ? {
+          authenticated: true,
+          user: interactiveSession.user,
+          csrfToken: desktopSession ? null : session!.csrfToken,
+          bootId,
+          setupRequired: false,
+          setupTokenRequired: false,
+          registrationOpen
+        }
       : { authenticated: false, user: null, csrfToken: null, bootId, setupRequired, setupTokenRequired, registrationOpen });
   });
   app.get("/api/auth/captcha", (_request, response) => {
@@ -1547,6 +1615,19 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     logger.info("auth.login.succeeded", { actorRef: accountReference(result.session.user.userId) });
     data(response, { user: result.session.user, csrfToken: result.session.csrfToken });
   });
+  app.post("/api/desktop/auth/login", (request, response) => {
+    const input = parse(desktopLoginSchema, request.body);
+    captcha.consume(input.captchaId, input.captchaAnswer);
+    const result = auth.loginDesktop(input.username, input.password, {
+      desktopId: input.desktopId,
+      profileId: input.profileId,
+      clientVersion: input.clientVersion
+    });
+    response.setHeader("Cache-Control", "no-store");
+    runWithRequestActor(result.session.user, () => store.audit(null, "user.logged-in", "user", result.session.user.userId, { source: "desktop" }));
+    logger.info("auth.desktop_login.succeeded", { actorRef: accountReference(result.session.user.userId) });
+    data(response, { token: result.token, expiresAt: result.session.expiresAt, user: result.session.user });
+  });
   app.use(createUserSessionMiddleware(auth, {
     disabled: options.disableUserAuth === true,
     resolveBypassUser: getDevelopmentUser
@@ -1560,12 +1641,15 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     data(response, { authenticated: true, user: request.authUser, apiKeyPrefix: request.authApiKey?.prefix ?? null });
   });
   app.delete("/api/auth/session", (request, response) => {
-    if (request.authSession) auth.revoke(request.authSession.id);
-    clearSessionCookie(response, request.secure);
+    if (request.authDesktopSession) auth.revokeDesktop(request.authDesktopSession.id);
+    if (request.authSession) {
+      auth.revoke(request.authSession.id);
+      clearSessionCookie(response, request.secure);
+    }
     noContent(response);
   });
   app.post("/api/auth/onboarding/complete", (request, response) => {
-    if (!request.authUser || request.authMethod !== "session") throw new AppError(401, "SESSION_REQUIRED", "请使用网页会话完成新手引导");
+    if (!request.authUser || !hasInteractiveSession(request)) throw new AppError(401, "SESSION_REQUIRED", "请使用交互式会话完成新手引导");
     parse(z.object({}).strict(), request.body ?? {});
     const updated = auth.completeOnboarding(request.authUser.userId);
     store.audit(null, "user.onboarding-completed", "user", updated.userId);
@@ -1609,18 +1693,23 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     data(response, updated);
   });
   app.patch("/api/auth/password", (request, response) => {
-    if (!request.authUser || !request.authSession) throw new AppError(401, "AUTH_REQUIRED", "请先登录");
+    const activeSession = request.authDesktopSession
+      ? { id: request.authDesktopSession.id, kind: "desktop" as const }
+      : request.authSession
+        ? { id: request.authSession.id, kind: "browser" as const }
+        : null;
+    if (!request.authUser || !activeSession) throw new AppError(401, "AUTH_REQUIRED", "请先登录");
     const input = parse(passwordChangeSchema, request.body);
-    auth.changePassword(request.authUser.userId, request.authSession.id, input.currentPassword, input.newPassword);
+    auth.changePassword(request.authUser.userId, activeSession.id, input.currentPassword, input.newPassword, activeSession.kind);
     store.audit(null, "user.password-changed", "user", request.authUser.userId);
     noContent(response);
   });
   app.get("/api/auth/api-key", (request, response) => {
-    if (!request.authUser || request.authMethod !== "session") throw new AppError(401, "SESSION_REQUIRED", "请使用网页会话管理 API Key");
+    if (!request.authUser || !hasInteractiveSession(request)) throw new AppError(401, "SESSION_REQUIRED", "请使用交互式会话管理 API Key");
     data(response, auth.getApiKeyStatus(request.authUser.userId));
   });
   app.post("/api/auth/api-key/reveal", (request, response) => {
-    if (!request.authUser || request.authMethod !== "session") throw new AppError(401, "SESSION_REQUIRED", "请使用网页会话管理 API Key");
+    if (!request.authUser || !hasInteractiveSession(request)) throw new AppError(401, "SESSION_REQUIRED", "请使用交互式会话管理 API Key");
     parse(z.object({}).strict(), request.body ?? {});
     const userId = request.authUser.userId;
     const revealed = database.transaction(() => {
@@ -1631,7 +1720,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     data(response, revealed);
   });
   app.post("/api/auth/api-key/reset", (request, response) => {
-    if (!request.authUser || request.authMethod !== "session") throw new AppError(401, "SESSION_REQUIRED", "请使用网页会话管理 API Key");
+    if (!request.authUser || !hasInteractiveSession(request)) throw new AppError(401, "SESSION_REQUIRED", "请使用交互式会话管理 API Key");
     parse(z.object({}).strict(), request.body ?? {});
     const userId = request.authUser.userId;
     const result = database.transaction(() => {
@@ -1715,7 +1804,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     data(response, pagination ? store.getWorkDirectoryPage(request.params.workId, pagination) : store.getWorkDirectory(request.params.workId));
   });
   app.post("/api/works/:workId/presence", (request, response) => {
-    if (!request.authUser || request.authMethod !== "session") throw new AppError(401, "SESSION_REQUIRED", "请使用网页会话上报协作状态");
+    if (!request.authUser || !hasInteractiveSession(request)) throw new AppError(401, "SESSION_REQUIRED", "请使用交互式会话上报协作状态");
     const input = parse(presenceHeartbeatSchema, request.body);
     data(response, collaborationPresence.heartbeat(request.params.workId, input.clientId, {
       userId: request.authUser.userId,
@@ -1767,6 +1856,82 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       request.body
     );
     data(response, store.updateWork(request.params.workId, input, expectedVersionNo, "manual", null, changeNote));
+  });
+  app.patch("/api/works/:workId/offline-access", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用网页或 Desktop 登录管理离线访问");
+    }
+    const input = parse(workOfflineAccessSchema, request.body);
+    data(response, store.setWorkOfflineAccess(request.params.workId, input.enabled));
+  });
+  app.post("/api/sync/works/:workId/snapshots", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用 Desktop 或网页登录创建同步快照");
+    }
+    parse(z.object({}).strict(), request.body ?? {});
+    response.setHeader("Cache-Control", "no-store");
+    data(response, offlineSync.createSnapshot(request.params.workId, request.authUser.userId), 201);
+  });
+  app.get("/api/sync/works/:workId/changes", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用 Desktop 或网页登录读取同步变更");
+    }
+    const query = parse(z.object({
+      after: z.coerce.number().int().min(0).max(Number.MAX_SAFE_INTEGER).default(0),
+      limit: z.coerce.number().int().min(1).max(200).default(200)
+    }).strict(), request.query);
+    response.setHeader("Cache-Control", "no-store");
+    data(response, offlineSync.listChanges(request.params.workId, query.after, query.limit));
+  });
+  app.post("/api/sync/works/:workId/push", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用 Desktop 或网页登录提交离线变更");
+    }
+    if (Buffer.byteLength(JSON.stringify(request.body ?? {}), "utf8") > DESKTOP_SYNC_PROTOCOL.maxMutationBytes) {
+      throw new AppError(413, "SYNC_PUSH_TOO_LARGE", `同步批次不能超过 ${DESKTOP_SYNC_PROTOCOL.maxMutationBytes} bytes`);
+    }
+    const input = parse(syncPushSchema, request.body);
+    response.setHeader("Cache-Control", "no-store");
+    data(response, offlineSync.pushMutations(
+      request.params.workId,
+      request.authUser.userId,
+      input.clientId,
+      input.mutations
+    ));
+  });
+  app.get("/api/sync/works/:workId/mutations/:mutationId", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用 Desktop 或网页登录读取同步变更结果");
+    }
+    const mutationId = parse(z.string().uuid(), request.params.mutationId);
+    response.setHeader("Cache-Control", "no-store");
+    data(response, offlineSync.getMutationResult(request.params.workId, request.authUser.userId, mutationId));
+  });
+  app.get("/api/sync/snapshots/:snapshotId/items", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用 Desktop 或网页登录读取同步快照");
+    }
+    const snapshotId = parse(z.string().uuid(), request.params.snapshotId);
+    const snapshot = offlineSync.describeOwnedSnapshot(snapshotId, request.authUser.userId);
+    auth.assertActiveWork(snapshot.workId);
+    auth.assertWorkAccess(request.authUser, snapshot.workId, { read: ["prose", "settings"] }, false, true);
+    const query = parse(z.object({
+      after: z.coerce.number().int().min(0).max(Number.MAX_SAFE_INTEGER).default(0),
+      limit: z.coerce.number().int().min(1).max(100).default(100)
+    }).strict(), request.query);
+    response.setHeader("Cache-Control", "no-store");
+    data(response, offlineSync.readSnapshotPage(snapshotId, request.authUser.userId, query.after, query.limit));
+  });
+  app.delete("/api/sync/snapshots/:snapshotId", (request, response) => {
+    if (!request.authUser || !hasInteractiveSession(request)) {
+      throw new AppError(401, "SESSION_REQUIRED", "请使用 Desktop 或网页登录删除同步快照");
+    }
+    const snapshotId = parse(z.string().uuid(), request.params.snapshotId);
+    const snapshot = offlineSync.describeOwnedSnapshot(snapshotId, request.authUser.userId);
+    auth.assertActiveWork(snapshot.workId);
+    auth.assertWorkAccess(request.authUser, snapshot.workId, { read: ["prose", "settings"] }, false, true);
+    offlineSync.deleteSnapshot(snapshotId, request.authUser.userId);
+    noContent(response);
   });
   app.delete("/api/works/:workId", async (request, response) => {
     const input = parse(z.object({ expectedVersionNo: expectedVersionNoSchema }).strict(), request.body ?? {});
@@ -3091,6 +3256,36 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       ? mapRecords(ai.listSuggestionsPage(request.params.workId, pagination, status), (suggestion) => redactSuggestion(suggestion, permissions))
       : ai.listSuggestions(request.params.workId, status).map((suggestion) => redactSuggestion(suggestion, permissions)));
   });
+  app.post("/api/works/:workId/desktop-local-ai/prepare", (request, response) => {
+    const input = parse(desktopLocalAiPreparationSchema, request.body);
+    const permissions = requestPermissions(request, request.params.workId);
+    if (!canWriteWorkModule(permissions, "ai-chat")) {
+      throw new AppError(403, "WORK_MODULE_WRITE_DENIED", "你没有使用创作助手的权限");
+    }
+    const citations = input.citations ?? [];
+    for (const citation of citations) {
+      if (store.getChapter(citation.chapterId).workId !== request.params.workId) {
+        throw new AppError(400, "CITATION_WORK_MISMATCH", "引用章节不属于当前作品");
+      }
+    }
+    if (input.conversationId) {
+      assertRequestAiConversationOwner(request, input.conversationId);
+      const conversation = store.getAiConversationSummary(input.conversationId);
+      if (String(conversation.workId) !== request.params.workId) {
+        throw new AppError(400, "CONVERSATION_WORK_MISMATCH", "AI 对话不属于当前作品");
+      }
+    }
+    data(response, ai.prepareDesktopLocalAiCompletion({
+      workId: request.params.workId,
+      taskType: input.taskType,
+      instruction: instructionWithCitations(input.instruction, citations),
+      scope: input.scope as ContextScope,
+      contextWindow: input.contextWindow,
+      maxOutputTokens: input.maxOutputTokens,
+      ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+      ...(input.currentMessageId ? { excludeConversationMessageId: input.currentMessageId } : {})
+    }));
+  });
   app.post("/api/works/:workId/suggestions", async (request, response) => {
     const input = parse(z.object({
       taskType: z.enum(TASK_TYPES),
@@ -3610,6 +3805,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       backups.dispose();
       liteLlmPriceCache.dispose();
       ai.dispose();
+      offlineSync.dispose();
       const cancelledStreamRequests = store.cancelActiveAiConversationStreamRequests();
       if (cancelledStreamRequests > 0) logger.info("ai.stream.requests_cancelled", { count: cancelledStreamRequests });
     }
@@ -3630,5 +3826,5 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     })();
     return closePromise;
   };
-  return { app, database, store, ai, liteLlmPriceCache, backups, auth, attachmentStorage, characterAvatarStorage, cleanupAttachments, close };
+  return { app, database, store, ai, liteLlmPriceCache, backups, auth, offlineSync, attachmentStorage, characterAvatarStorage, cleanupAttachments, close };
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -7,9 +7,9 @@ import { documentShortSearchTerms, normalizeDocumentSearchText, splitDocumentPar
 
 export type Row = Record<string, unknown>;
 export const PLATFORM_AI_WORK_ID = "__scriverse_platform_ai__";
-// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询；版本 94 增加模型思考强度；版本 95 增加供应商最大输出参数选择；版本 96 扩展模型思考强度档位；版本 97 增加人物性别字段；版本 98 增加正文稳定等待配置；版本 99 持久化关系扮演中的用户角色；版本 100 增加平台 AI 流事件空闲超时配置；版本 101 将平台 AI 流事件空闲超时上限提升至 600 秒；版本 102 创建角色头像元数据表；版本 103 回填历史 AI 对话归属并建立用户列表索引；版本 104 扩大供应商协议约束以支持 OpenAI Responses；版本 105 增加独立分卷剧情顺序；版本 106 增加供应商思考类型配置；版本 107 增加 AI Cache Write 输入 Token 统计；版本 108 增加作品 AI 每月 Token 额度；版本 109 增加供应商日、月 Token 额度；版本 110 将日、月 Token 额度下限调整为大于 0；版本 111 扩展模型思考强度为 auto；版本 112 为 CLI API Key 增加可复制的加密密文；版本 113 增加角色收藏状态与列表索引；版本 114 增加组织、设定档案与想法收藏状态及列表索引；版本 115 增加 AI 对话会话级场景钉。
+// 版本 81 用于列表查询索引；版本 82 由 Store 写入实体版本基线标记；版本 83 创建协作状态表；版本 84 创建备份加密表；版本 85 持久化协作变更动作；版本 86 扩展直接图片上传格式；版本 87 增加作品与分卷回收站；版本 88 持久化 AI 对话分支幂等键；版本 89 持久化 AI 对话流请求锁与幂等状态；版本 90 持久化 AI 连通性测试冷却状态；版本 91 建立章节段落行号索引；版本 92 增加 AI 对话收藏状态；版本 93 优化伏笔计划回收章节查询；版本 94 增加模型思考强度；版本 95 增加供应商最大输出参数选择；版本 96 扩展模型思考强度档位；版本 97 增加人物性别字段；版本 98 增加正文稳定等待配置；版本 99 持久化关系扮演中的用户角色；版本 100 增加平台 AI 流事件空闲超时配置；版本 101 将平台 AI 流事件空闲超时上限提升至 600 秒；版本 102 创建角色头像元数据表；版本 103 回填历史 AI 对话归属并建立用户列表索引；版本 104 扩大供应商协议约束以支持 OpenAI Responses；版本 105 增加独立分卷剧情顺序；版本 106 增加供应商思考类型配置；版本 107 增加 AI Cache Write 输入 Token 统计；版本 108 增加作品 AI 每月 Token 额度；版本 109 增加供应商日、月 Token 额度；版本 110 将日、月 Token 额度下限调整为大于 0；版本 111 扩展模型思考强度为 auto；版本 112 为 CLI API Key 增加可复制的加密密文；版本 113 增加角色收藏状态与列表索引；版本 114 增加组织、设定档案与想法收藏状态及列表索引；版本 115 增加 AI 对话会话级场景钉；版本 116 增加可持久化且可撤销的 Desktop Bearer 会话；版本 117 增加作品离线授权、同步变更游标与幂等变更结果。
 export const ENTITY_VERSION_BASELINE_MIGRATION_VERSION = 82;
-export const DATABASE_SCHEMA_VERSION = 115;
+export const DATABASE_SCHEMA_VERSION = 117;
 export const SQLITE_IOERR_SHMSIZE = 4874;
 
 export type AvailableDiskSpace = {
@@ -188,6 +188,7 @@ export class Database {
         cover_url TEXT,
         tags_json TEXT NOT NULL DEFAULT '[]',
         is_internal INTEGER NOT NULL DEFAULT 0,
+        offline_access_enabled INTEGER NOT NULL DEFAULT 0 CHECK(offline_access_enabled IN (0, 1)),
         version_no INTEGER NOT NULL DEFAULT 1,
         deleted_at TEXT,
         created_at TEXT NOT NULL,
@@ -4219,6 +4220,101 @@ export class Database {
           this.run("ALTER TABLE ai_conversations ADD COLUMN scene_pin_json TEXT NOT NULL DEFAULT '{}'");
         }
         this.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (115, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    const desktopSessionTablePresent = this.get(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'user_desktop_sessions'"
+    ) !== undefined;
+    const desktopSessionIndexesPresent = [
+      "idx_user_desktop_sessions_token",
+      "idx_user_desktop_sessions_user",
+      "idx_user_desktop_sessions_active_profile"
+    ].every((index) => this.get(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'index' AND name = ?",
+      index
+    ) !== undefined);
+    if (!applied.has(116) || !desktopSessionTablePresent || !desktopSessionIndexesPresent) {
+      this.transaction(() => {
+        this.run(`CREATE TABLE IF NOT EXISTS user_desktop_sessions (
+          id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          token_hash TEXT NOT NULL UNIQUE,
+          desktop_id TEXT NOT NULL,
+          profile_id TEXT NOT NULL,
+          client_version TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          expires_at TEXT NOT NULL,
+          last_seen_at TEXT NOT NULL,
+          revoked_at TEXT
+        )`);
+        this.run("CREATE INDEX IF NOT EXISTS idx_user_desktop_sessions_token ON user_desktop_sessions(token_hash)");
+        this.run("CREATE INDEX IF NOT EXISTS idx_user_desktop_sessions_user ON user_desktop_sessions(user_id, expires_at)");
+        this.run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_user_desktop_sessions_active_profile
+          ON user_desktop_sessions(desktop_id, profile_id) WHERE revoked_at IS NULL`);
+        this.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (116, ?)", new Date().toISOString());
+      });
+      const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
+      if (integrity.some((row) => row.integrity_check !== "ok")) {
+        throw new Error(`数据库完整性检查失败：${integrity.map((row) => row.integrity_check).join("；")}`);
+      }
+      const foreignKeys = this.all("PRAGMA foreign_key_check");
+      if (foreignKeys.length > 0) throw new Error(`数据库外键检查失败：发现 ${foreignKeys.length} 条异常记录`);
+    }
+    const workOfflineAccessPresent = this.all("PRAGMA table_info(works)").some((row) => String(row.name) === "offline_access_enabled");
+    const syncChangesTablePresent = this.get(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'sync_changes'"
+    ) !== undefined;
+    const syncMutationResultsTablePresent = this.get(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'sync_mutation_results'"
+    ) !== undefined;
+    const syncIndexesPresent = [
+      "idx_sync_changes_work_cursor",
+      "idx_sync_changes_entity",
+      "idx_sync_mutation_results_client"
+    ].every((index) => this.get(
+      "SELECT 1 AS present FROM sqlite_master WHERE type = 'index' AND name = ?",
+      index
+    ) !== undefined);
+    if (!applied.has(117) || !workOfflineAccessPresent || !syncChangesTablePresent || !syncMutationResultsTablePresent || !syncIndexesPresent) {
+      this.transaction(() => {
+        const workColumns = new Set(this.all("PRAGMA table_info(works)").map((row) => String(row.name)));
+        if (!workColumns.has("offline_access_enabled")) {
+          this.run("ALTER TABLE works ADD COLUMN offline_access_enabled INTEGER NOT NULL DEFAULT 0 CHECK(offline_access_enabled IN (0, 1))");
+        }
+        this.run(`CREATE TABLE IF NOT EXISTS sync_changes (
+          cursor INTEGER PRIMARY KEY AUTOINCREMENT,
+          work_id TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+          entity_type TEXT NOT NULL CHECK(entity_type IN ('chapter', 'setting')),
+          entity_id TEXT NOT NULL,
+          operation TEXT NOT NULL CHECK(operation IN ('upsert', 'delete')),
+          version_no INTEGER NOT NULL CHECK(version_no > 0),
+          changed_by_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+          changed_at TEXT NOT NULL
+        )`);
+        this.run(`CREATE TABLE IF NOT EXISTS sync_mutation_results (
+          mutation_id TEXT PRIMARY KEY,
+          client_id TEXT NOT NULL,
+          user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+          work_id TEXT NOT NULL REFERENCES works(id) ON DELETE CASCADE,
+          request_hash TEXT NOT NULL,
+          status TEXT NOT NULL CHECK(status IN ('applied', 'conflict', 'rejected')),
+          applied_version_no INTEGER,
+          conflict_version_no INTEGER,
+          error_code TEXT,
+          result_json TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )`);
+        this.run("CREATE INDEX IF NOT EXISTS idx_sync_changes_work_cursor ON sync_changes(work_id, cursor)");
+        this.run("CREATE INDEX IF NOT EXISTS idx_sync_changes_entity ON sync_changes(work_id, entity_type, entity_id, cursor)");
+        this.run("CREATE INDEX IF NOT EXISTS idx_sync_mutation_results_client ON sync_mutation_results(client_id, user_id, work_id, created_at)");
+        this.run("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (117, ?)", new Date().toISOString());
       });
       const integrity = this.all<{ integrity_check: string }>("PRAGMA integrity_check");
       if (integrity.some((row) => row.integrity_check !== "ok")) {

--- a/src/desktop-protocol.ts
+++ b/src/desktop-protocol.ts
@@ -1,0 +1,29 @@
+import { APP_VERSION } from "./version.js";
+
+export const DESKTOP_PRODUCT_ID = "scriverse";
+export const DESKTOP_MINIMUM_VERSION = "0.0.1";
+export const DESKTOP_SHELL_PROTOCOL = Object.freeze({ min: 1, max: 1 });
+export const DESKTOP_SYNC_PROTOCOL = Object.freeze({
+  min: 1,
+  max: 1,
+  entityTypes: Object.freeze(["chapter", "setting"] as const),
+  maxMutationBytes: 2_500_000
+});
+
+export function desktopCompatibilityMetadata(): {
+  product: typeof DESKTOP_PRODUCT_ID;
+  serverVersion: string;
+  webAssetVersion: string;
+  shellProtocol: typeof DESKTOP_SHELL_PROTOCOL;
+  minimumDesktopVersion: typeof DESKTOP_MINIMUM_VERSION;
+  syncProtocol: typeof DESKTOP_SYNC_PROTOCOL;
+} {
+  return {
+    product: DESKTOP_PRODUCT_ID,
+    serverVersion: APP_VERSION,
+    webAssetVersion: APP_VERSION,
+    shellProtocol: DESKTOP_SHELL_PROTOCOL,
+    minimumDesktopVersion: DESKTOP_MINIMUM_VERSION,
+    syncProtocol: DESKTOP_SYNC_PROTOCOL
+  };
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,7 +11,7 @@ export type LogRecord = {
   event: string;
   requestId?: string;
   actorRef?: string;
-  authentication?: "session" | "api-key";
+  authentication?: "session" | "desktop-session" | "api-key";
   [key: string]: unknown;
 };
 

--- a/src/offline-sync.ts
+++ b/src/offline-sync.ts
@@ -1,0 +1,652 @@
+import { createHash, randomUUID } from "node:crypto";
+import { Database } from "./database.js";
+import { AppError } from "./errors.js";
+import { Store } from "./store.js";
+import { countWords } from "./utils.js";
+
+export const SYNC_SNAPSHOT_TTL_MS = 15 * 60 * 1_000;
+export const SYNC_SNAPSHOT_PAGE_BYTE_LIMIT = 4 * 1024 * 1024;
+const MAX_ACTIVE_SYNC_SNAPSHOTS = 128;
+
+export type SyncSnapshotDescriptor = {
+  snapshotId: string;
+  workId: string;
+  cutoffCursor: number;
+  itemCount: number;
+  expiresAt: string;
+  syncProtocol: 1;
+};
+
+type SyncSnapshotItem = {
+  sequence: number;
+  entityType: "work" | "volume" | "chapter" | "setting";
+  entityId: string;
+  versionNo: number;
+  data: Record<string, unknown>;
+};
+
+type StoredSyncSnapshotItem = SyncSnapshotItem & { byteLength: number };
+
+type StoredSyncSnapshot = SyncSnapshotDescriptor & {
+  userId: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+  items: StoredSyncSnapshotItem[];
+};
+
+export type SyncSnapshotPage = {
+  snapshotId: string;
+  workId: string;
+  cutoffCursor: number;
+  after: number;
+  nextAfter: number | null;
+  hasMore: boolean;
+  items: SyncSnapshotItem[];
+};
+
+export type SyncChangeItem = {
+  cursor: number;
+  entityType: "chapter" | "setting";
+  entityId: string;
+  operation: "upsert" | "delete";
+  versionNo: number;
+  changedByUserId: string | null;
+  changedAt: string;
+  data: Record<string, unknown> | null;
+};
+
+export type SyncChangePage = {
+  workId: string;
+  after: number;
+  nextCursor: number;
+  latestCursor: number;
+  hasMore: boolean;
+  items: SyncChangeItem[];
+};
+
+export type ChapterSyncSnapshot = {
+  title: string;
+  content: string;
+  chapterType: "正文" | "设定" | "作者的话" | "其他";
+};
+
+export type SettingSyncSnapshot = {
+  title: string;
+  category: string;
+  content: string;
+  tags?: string[];
+  status?: "draft" | "pending" | "confirmed" | "deprecated";
+  locked?: boolean;
+  evidence?: unknown[];
+  scope?: Record<string, unknown>;
+  authorNote?: string;
+};
+
+export type SyncMutation = {
+  mutationId: string;
+  entityId: string;
+  operation: "update";
+  baseVersionNo: number;
+  changeNote: string;
+} & (
+  | { entityType: "chapter"; localSnapshot: ChapterSyncSnapshot }
+  | { entityType: "setting"; localSnapshot: SettingSyncSnapshot }
+);
+
+export type SyncMutationResult = {
+  mutationId: string;
+  entityType: "chapter" | "setting";
+  entityId: string;
+  status: "applied" | "conflict" | "rejected";
+  baseVersionNo: number;
+  appliedVersionNo: number | null;
+  conflictVersionNo: number | null;
+  errorCode: string | null;
+  baseSnapshot: Record<string, unknown> | null;
+  localSnapshot: Record<string, unknown> | null;
+  serverSnapshot: Record<string, unknown> | null;
+  replayed: boolean;
+};
+
+export type SyncPushResult = {
+  clientId: string;
+  results: SyncMutationResult[];
+  summary: {
+    applied: number;
+    conflict: number;
+    rejected: number;
+    replayed: number;
+  };
+};
+
+type OfflineSyncOptions = {
+  now?: () => number;
+  snapshotTtlMs?: number;
+};
+
+function recordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object" && !Array.isArray(item))
+    : [];
+}
+
+function snapshotItem(
+  sequence: number,
+  entityType: SyncSnapshotItem["entityType"],
+  data: Record<string, unknown>
+): StoredSyncSnapshotItem {
+  const item: SyncSnapshotItem = {
+    sequence,
+    entityType,
+    entityId: String(data.id ?? ""),
+    versionNo: Number(data.versionNo ?? 0),
+    data
+  };
+  return { ...item, byteLength: Buffer.byteLength(JSON.stringify(item), "utf8") };
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+export class OfflineSyncService {
+  private readonly snapshots = new Map<string, StoredSyncSnapshot>();
+  private readonly now: () => number;
+  private readonly snapshotTtlMs: number;
+
+  constructor(
+    private readonly database: Database,
+    private readonly store: Store,
+    options: OfflineSyncOptions = {}
+  ) {
+    this.now = options.now ?? Date.now;
+    this.snapshotTtlMs = options.snapshotTtlMs ?? SYNC_SNAPSHOT_TTL_MS;
+  }
+
+  createSnapshot(workId: string, userId: string): SyncSnapshotDescriptor {
+    const captured = this.database.transaction(() => {
+      this.assertOfflineAccessEnabled(workId);
+      const tree = this.store.getWorkTree(workId);
+      const volumes = recordArray(tree.volumes);
+      const { volumes: _volumes, modulePermissions: _modulePermissions, accessRole: _accessRole, ...work } = tree;
+      const rawItems: Array<{ entityType: SyncSnapshotItem["entityType"]; data: Record<string, unknown> }> = [
+        { entityType: "work", data: work }
+      ];
+      for (const volumeWithChapters of volumes) {
+        const chapters = recordArray(volumeWithChapters.chapters);
+        const { chapters: _chapters, ...volume } = volumeWithChapters;
+        rawItems.push({ entityType: "volume", data: volume });
+        for (const chapter of chapters) rawItems.push({ entityType: "chapter", data: chapter });
+      }
+      for (const setting of this.store.listSettings(workId, true)) {
+        rawItems.push({ entityType: "setting", data: setting });
+      }
+      const cutoffCursor = Number(this.database.get(
+        "SELECT COALESCE(MAX(cursor), 0) AS cursor FROM sync_changes WHERE work_id = ?",
+        workId
+      )?.cursor ?? 0);
+      return {
+        cutoffCursor,
+        items: rawItems.map((item, index) => snapshotItem(index + 1, item.entityType, item.data))
+      };
+    });
+    const createdAtMs = this.now();
+    this.pruneExpired(createdAtMs);
+    for (const [snapshotId, snapshot] of this.snapshots) {
+      if (snapshot.userId === userId && snapshot.workId === workId) this.snapshots.delete(snapshotId);
+    }
+    while (this.snapshots.size >= MAX_ACTIVE_SYNC_SNAPSHOTS) {
+      const oldest = [...this.snapshots.values()].sort((left, right) => left.createdAtMs - right.createdAtMs)[0];
+      if (!oldest) break;
+      this.snapshots.delete(oldest.snapshotId);
+    }
+    const snapshot: StoredSyncSnapshot = {
+      snapshotId: randomUUID(),
+      workId,
+      userId,
+      cutoffCursor: captured.cutoffCursor,
+      itemCount: captured.items.length,
+      createdAtMs,
+      expiresAtMs: createdAtMs + this.snapshotTtlMs,
+      expiresAt: new Date(createdAtMs + this.snapshotTtlMs).toISOString(),
+      syncProtocol: 1,
+      items: captured.items
+    };
+    this.snapshots.set(snapshot.snapshotId, snapshot);
+    return this.descriptor(snapshot);
+  }
+
+  describeOwnedSnapshot(snapshotId: string, userId: string): SyncSnapshotDescriptor {
+    return this.descriptor(this.ownedSnapshot(snapshotId, userId));
+  }
+
+  readSnapshotPage(snapshotId: string, userId: string, after: number, limit: number): SyncSnapshotPage {
+    const snapshot = this.ownedSnapshot(snapshotId, userId);
+    this.assertOfflineAccessEnabled(snapshot.workId);
+    const candidates = snapshot.items.filter((item) => item.sequence > after).slice(0, limit);
+    const selected: StoredSyncSnapshotItem[] = [];
+    let selectedBytes = 0;
+    for (const item of candidates) {
+      if (selected.length > 0 && selectedBytes + item.byteLength > SYNC_SNAPSHOT_PAGE_BYTE_LIMIT) break;
+      selected.push(item);
+      selectedBytes += item.byteLength;
+    }
+    const lastSequence = selected.at(-1)?.sequence ?? after;
+    const hasMore = snapshot.items.some((item) => item.sequence > lastSequence);
+    return {
+      snapshotId,
+      workId: snapshot.workId,
+      cutoffCursor: snapshot.cutoffCursor,
+      after,
+      nextAfter: hasMore ? lastSequence : null,
+      hasMore,
+      items: selected.map(({ byteLength: _byteLength, ...item }) => item)
+    };
+  }
+
+  deleteSnapshot(snapshotId: string, userId: string): void {
+    this.ownedSnapshot(snapshotId, userId);
+    this.snapshots.delete(snapshotId);
+  }
+
+  listChanges(workId: string, after: number, limit: number): SyncChangePage {
+    return this.database.transaction(() => {
+      this.assertOfflineAccessEnabled(workId);
+      const rows = this.database.all(
+        `SELECT cursor, entity_type, entity_id, operation, version_no, changed_by_user_id, changed_at
+         FROM sync_changes WHERE work_id = ? AND cursor > ? ORDER BY cursor LIMIT ?`,
+        workId,
+        after,
+        limit + 1
+      );
+      const hasMore = rows.length > limit;
+      const pageRows = rows.slice(0, limit);
+      const items = pageRows.map((row) => this.mapChange(row));
+      const latestCursor = Number(this.database.get(
+        "SELECT COALESCE(MAX(cursor), 0) AS cursor FROM sync_changes WHERE work_id = ?",
+        workId
+      )?.cursor ?? 0);
+      return {
+        workId,
+        after,
+        nextCursor: items.at(-1)?.cursor ?? after,
+        latestCursor,
+        hasMore,
+        items
+      };
+    });
+  }
+
+  pushMutations(
+    workId: string,
+    userId: string,
+    clientId: string,
+    mutations: SyncMutation[]
+  ): SyncPushResult {
+    this.assertOfflineAccessEnabled(workId);
+    const results = mutations.map((mutation) => this.processMutation(workId, userId, clientId, mutation));
+    return {
+      clientId,
+      results,
+      summary: {
+        applied: results.filter((result) => result.status === "applied").length,
+        conflict: results.filter((result) => result.status === "conflict").length,
+        rejected: results.filter((result) => result.status === "rejected").length,
+        replayed: results.filter((result) => result.replayed).length
+      }
+    };
+  }
+
+  getMutationResult(workId: string, userId: string, mutationId: string): SyncMutationResult {
+    this.assertOfflineAccessEnabled(workId);
+    const row = this.database.get(
+      `SELECT result_json FROM sync_mutation_results
+       WHERE mutation_id = ? AND work_id = ? AND user_id = ?`,
+      mutationId,
+      workId,
+      userId
+    );
+    if (!row) throw new AppError(404, "SYNC_MUTATION_NOT_FOUND", "同步变更结果不存在");
+    return this.parseMutationResult(String(row.result_json));
+  }
+
+  dispose(): void {
+    this.snapshots.clear();
+  }
+
+  private ownedSnapshot(snapshotId: string, userId: string): StoredSyncSnapshot {
+    const snapshot = this.snapshots.get(snapshotId);
+    if (!snapshot || snapshot.userId !== userId) {
+      throw new AppError(404, "SYNC_SNAPSHOT_NOT_FOUND", "同步快照不存在");
+    }
+    if (snapshot.expiresAtMs <= this.now()) {
+      this.snapshots.delete(snapshotId);
+      throw new AppError(410, "SYNC_SNAPSHOT_EXPIRED", "同步快照已过期，请重新创建");
+    }
+    return snapshot;
+  }
+
+  private assertOfflineAccessEnabled(workId: string): void {
+    const work = this.database.get("SELECT offline_access_enabled FROM works WHERE id = ? AND deleted_at IS NULL", workId);
+    if (!work) throw new AppError(404, "WORK_NOT_FOUND", "作品不存在");
+    if (Number(work.offline_access_enabled) !== 1) {
+      throw new AppError(403, "OFFLINE_ACCESS_DISABLED", "作品所有者尚未允许 Desktop 离线访问");
+    }
+  }
+
+  private mapChange(row: Record<string, unknown>): SyncChangeItem {
+    const entityType = String(row.entity_type) === "setting" ? "setting" : "chapter";
+    const operation = String(row.operation) === "delete" ? "delete" : "upsert";
+    const entityId = String(row.entity_id);
+    const versionNo = Number(row.version_no);
+    return {
+      cursor: Number(row.cursor),
+      entityType,
+      entityId,
+      operation,
+      versionNo,
+      changedByUserId: row.changed_by_user_id === null || row.changed_by_user_id === undefined
+        ? null
+        : String(row.changed_by_user_id),
+      changedAt: String(row.changed_at),
+      data: operation === "delete" ? null : entityType === "chapter"
+        ? this.chapterVersionData(entityId, versionNo)
+        : this.settingVersionData(entityId, versionNo)
+    };
+  }
+
+  private processMutation(
+    workId: string,
+    userId: string,
+    clientId: string,
+    mutation: SyncMutation
+  ): SyncMutationResult {
+    const requestHash = createHash("sha256")
+      .update(stableJson({ workId, userId, clientId, mutation }))
+      .digest("hex");
+    return this.database.transaction(() => {
+      const existing = this.database.get(
+        "SELECT request_hash, result_json FROM sync_mutation_results WHERE mutation_id = ?",
+        mutation.mutationId
+      );
+      if (existing) {
+        if (String(existing.request_hash) !== requestHash) {
+          throw new AppError(409, "MUTATION_ID_REUSED", "mutationId 已用于不同的同步请求");
+        }
+        return { ...this.parseMutationResult(String(existing.result_json)), replayed: true };
+      }
+      const result = this.applyMutation(workId, mutation);
+      const timestamp = new Date(this.now()).toISOString();
+      this.database.run(
+        `INSERT INTO sync_mutation_results (
+           mutation_id, client_id, user_id, work_id, request_hash, status, applied_version_no,
+           conflict_version_no, error_code, result_json, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        mutation.mutationId,
+        clientId,
+        userId,
+        workId,
+        requestHash,
+        result.status,
+        result.appliedVersionNo,
+        result.conflictVersionNo,
+        result.errorCode,
+        JSON.stringify(result),
+        timestamp,
+        timestamp
+      );
+      return result;
+    });
+  }
+
+  private applyMutation(workId: string, mutation: SyncMutation): SyncMutationResult {
+    const state = this.currentMutationEntityState(mutation.entityType, mutation.entityId);
+    if (!state) return this.rejectedMutation(mutation, "SYNC_ENTITY_NOT_FOUND");
+    if (state.workId !== workId) return this.rejectedMutation(mutation, "SYNC_ENTITY_NOT_FOUND");
+    const baseSnapshot = this.mutationVersionData(mutation.entityType, mutation.entityId, mutation.baseVersionNo);
+    const serverSnapshot = state.active
+      ? this.mutationVersionData(mutation.entityType, mutation.entityId, state.versionNo)
+      : { id: mutation.entityId, workId, versionNo: state.versionNo, deleted: true };
+    if (!baseSnapshot) {
+      return this.rejectedMutation(mutation, "SYNC_BASE_VERSION_MISSING", null, serverSnapshot);
+    }
+    const localSnapshot = { ...baseSnapshot, ...mutation.localSnapshot, versionNo: mutation.baseVersionNo };
+    if (!state.active || state.versionNo !== mutation.baseVersionNo) {
+      return {
+        mutationId: mutation.mutationId,
+        entityType: mutation.entityType,
+        entityId: mutation.entityId,
+        status: "conflict",
+        baseVersionNo: mutation.baseVersionNo,
+        appliedVersionNo: null,
+        conflictVersionNo: state.versionNo,
+        errorCode: "VERSION_CONFLICT",
+        baseSnapshot,
+        localSnapshot,
+        serverSnapshot,
+        replayed: false
+      };
+    }
+    try {
+      const updated = mutation.entityType === "chapter"
+        ? this.store.saveChapter(
+          mutation.entityId,
+          mutation.localSnapshot,
+          "desktop-sync",
+          mutation.mutationId,
+          mutation.changeNote,
+          mutation.baseVersionNo
+        )
+        : this.store.updateSetting(
+          mutation.entityId,
+          mutation.localSnapshot,
+          "desktop-sync",
+          mutation.mutationId,
+          mutation.changeNote,
+          mutation.baseVersionNo
+        );
+      return {
+        mutationId: mutation.mutationId,
+        entityType: mutation.entityType,
+        entityId: mutation.entityId,
+        status: "applied",
+        baseVersionNo: mutation.baseVersionNo,
+        appliedVersionNo: Number(updated.versionNo),
+        conflictVersionNo: null,
+        errorCode: null,
+        baseSnapshot,
+        localSnapshot,
+        serverSnapshot: updated,
+        replayed: false
+      };
+    } catch (error) {
+      if (!(error instanceof AppError)) throw error;
+      const latest = this.currentMutationEntityState(mutation.entityType, mutation.entityId);
+      if (error.code === "VERSION_CONFLICT" && latest) {
+        return {
+          mutationId: mutation.mutationId,
+          entityType: mutation.entityType,
+          entityId: mutation.entityId,
+          status: "conflict",
+          baseVersionNo: mutation.baseVersionNo,
+          appliedVersionNo: null,
+          conflictVersionNo: latest.versionNo,
+          errorCode: error.code,
+          baseSnapshot,
+          localSnapshot,
+          serverSnapshot: latest.active
+            ? this.mutationVersionData(mutation.entityType, mutation.entityId, latest.versionNo)
+            : { id: mutation.entityId, workId, versionNo: latest.versionNo, deleted: true },
+          replayed: false
+        };
+      }
+      return this.rejectedMutation(mutation, error.code, baseSnapshot, serverSnapshot, localSnapshot);
+    }
+  }
+
+  private rejectedMutation(
+    mutation: SyncMutation,
+    errorCode: string,
+    baseSnapshot: Record<string, unknown> | null = null,
+    serverSnapshot: Record<string, unknown> | null = null,
+    localSnapshot: Record<string, unknown> | null = null
+  ): SyncMutationResult {
+    return {
+      mutationId: mutation.mutationId,
+      entityType: mutation.entityType,
+      entityId: mutation.entityId,
+      status: "rejected",
+      baseVersionNo: mutation.baseVersionNo,
+      appliedVersionNo: null,
+      conflictVersionNo: null,
+      errorCode,
+      baseSnapshot,
+      localSnapshot,
+      serverSnapshot,
+      replayed: false
+    };
+  }
+
+  private currentMutationEntityState(
+    entityType: "chapter" | "setting",
+    entityId: string
+  ): { workId: string; versionNo: number; active: boolean } | null {
+    if (entityType === "chapter") {
+      const chapter = this.database.get(
+        "SELECT work_id, version_no, deleted_at FROM chapters WHERE id = ?",
+        entityId
+      );
+      if (chapter) {
+        return {
+          workId: String(chapter.work_id),
+          versionNo: Number(chapter.version_no),
+          active: chapter.deleted_at === null || chapter.deleted_at === undefined
+        };
+      }
+      const version = this.database.get(
+        "SELECT work_id, MAX(version_no) AS version_no FROM chapter_versions WHERE chapter_id = ?",
+        entityId
+      );
+      return version?.work_id
+        ? { workId: String(version.work_id), versionNo: Number(version.version_no), active: false }
+        : null;
+    }
+    const setting = this.database.get("SELECT work_id FROM settings WHERE id = ?", entityId);
+    const version = this.database.get(
+      `SELECT work_id, MAX(version_no) AS version_no FROM entity_versions
+       WHERE entity_type = 'setting' AND entity_id = ?`,
+      entityId
+    );
+    if (!version?.work_id) return null;
+    return {
+      workId: String(version.work_id),
+      versionNo: Number(version.version_no),
+      active: Boolean(setting)
+    };
+  }
+
+  private mutationVersionData(
+    entityType: "chapter" | "setting",
+    entityId: string,
+    versionNo: number
+  ): Record<string, unknown> | null {
+    try {
+      return entityType === "chapter"
+        ? this.chapterVersionData(entityId, versionNo)
+        : this.settingVersionData(entityId, versionNo);
+    } catch (error) {
+      if (error instanceof AppError && error.code === "SYNC_CHANGE_HISTORY_MISSING") return null;
+      throw error;
+    }
+  }
+
+  private parseMutationResult(value: string): SyncMutationResult {
+    try {
+      const parsed = JSON.parse(value) as Partial<SyncMutationResult>;
+      if (!parsed || typeof parsed !== "object" || !parsed.mutationId || !parsed.entityId) throw new Error("Invalid mutation result");
+      if (!(["applied", "conflict", "rejected"] as const).includes(parsed.status as SyncMutationResult["status"])) {
+        throw new Error("Invalid mutation status");
+      }
+      return { ...parsed, replayed: false } as SyncMutationResult;
+    } catch {
+      throw new AppError(500, "SYNC_MUTATION_RESULT_INVALID", "同步变更结果无法解析");
+    }
+  }
+
+  private chapterVersionData(chapterId: string, versionNo: number): Record<string, unknown> {
+    const version = this.database.get(
+      `SELECT work_id, chapter_id, version_no, title, content, volume_id, sort_order, chapter_type, created_at
+       FROM chapter_versions WHERE chapter_id = ? AND version_no = ?`,
+      chapterId,
+      versionNo
+    );
+    if (!version) {
+      throw new AppError(500, "SYNC_CHANGE_HISTORY_MISSING", "章节同步历史不完整，请重新下载离线副本");
+    }
+    const content = String(version.content);
+    return {
+      id: String(version.chapter_id),
+      workId: String(version.work_id),
+      volumeId: version.volume_id === null || version.volume_id === undefined ? null : String(version.volume_id),
+      title: String(version.title),
+      content,
+      chapterType: String(version.chapter_type ?? "正文"),
+      sortOrder: version.sort_order === null || version.sort_order === undefined ? null : Number(version.sort_order),
+      wordCount: countWords(content),
+      versionNo: Number(version.version_no),
+      updatedAt: String(version.created_at)
+    };
+  }
+
+  private settingVersionData(settingId: string, versionNo: number): Record<string, unknown> {
+    const version = this.database.get(
+      `SELECT work_id, entity_id, version_no, snapshot_json, created_at
+       FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ? AND version_no = ?`,
+      settingId,
+      versionNo
+    );
+    if (!version) {
+      throw new AppError(500, "SYNC_CHANGE_HISTORY_MISSING", "设定同步历史不完整，请重新下载离线副本");
+    }
+    let snapshot: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(String(version.snapshot_json)) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Invalid setting snapshot");
+      snapshot = parsed as Record<string, unknown>;
+    } catch {
+      throw new AppError(500, "SYNC_CHANGE_HISTORY_INVALID", "设定同步历史无法解析，请重新下载离线副本");
+    }
+    return {
+      id: String(version.entity_id),
+      workId: String(version.work_id),
+      ...snapshot,
+      versionNo: Number(version.version_no),
+      updatedAt: String(version.created_at)
+    };
+  }
+
+  private pruneExpired(timestamp: number): void {
+    for (const [snapshotId, snapshot] of this.snapshots) {
+      if (snapshot.expiresAtMs <= timestamp) this.snapshots.delete(snapshotId);
+    }
+  }
+
+  private descriptor(snapshot: StoredSyncSnapshot): SyncSnapshotDescriptor {
+    return {
+      snapshotId: snapshot.snapshotId,
+      workId: snapshot.workId,
+      cutoffCursor: snapshot.cutoffCursor,
+      itemCount: snapshot.itemCount,
+      expiresAt: snapshot.expiresAt,
+      syncProtocol: 1
+    };
+  }
+}

--- a/src/request-context.ts
+++ b/src/request-context.ts
@@ -5,7 +5,7 @@ export type RequestActor = {
   username: string;
   displayName: string;
   role: "admin" | "user";
-  authentication?: "session" | "api-key";
+  authentication?: "session" | "desktop-session" | "api-key";
 };
 
 export type RequestContext = {

--- a/src/security.ts
+++ b/src/security.ts
@@ -421,7 +421,11 @@ export async function aiEndpointUsesPrivateNetwork(value: string): Promise<boole
   }
 }
 
-export async function assertSafeAiEndpoint(value: string, allowPrivateNetwork = false): Promise<SafeAiEndpointAddress[]> {
+export async function assertSafeAiEndpoint(
+  value: string,
+  allowPrivateNetwork = false,
+  trustResolvedNetwork = false
+): Promise<SafeAiEndpointAddress[]> {
   const endpoint = new URL(value);
   if (!['http:', 'https:'].includes(endpoint.protocol) || endpoint.username || endpoint.password) {
     throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商地址必须是无内嵌凭据的 HTTP 或 HTTPS 地址");
@@ -431,7 +435,7 @@ export async function assertSafeAiEndpoint(value: string, allowPrivateNetwork = 
   if (!addresses.length) throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商域名无法解析");
   for (const { address } of addresses) {
     const kind = unsafeIpKind(address);
-    if (kind === "blocked" || (kind === "private" && !allowPrivateNetwork)) {
+    if (!trustResolvedNetwork && (kind === "blocked" || (kind === "private" && !allowPrivateNetwork))) {
       logger.warn("security.ai_endpoint.blocked", { hostname, addressKind: kind });
       throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商地址指向受保护的本机、内网或链路本地网络");
     }

--- a/src/security.ts
+++ b/src/security.ts
@@ -421,11 +421,7 @@ export async function aiEndpointUsesPrivateNetwork(value: string): Promise<boole
   }
 }
 
-export async function assertSafeAiEndpoint(
-  value: string,
-  allowPrivateNetwork = false,
-  trustResolvedNetwork = false
-): Promise<SafeAiEndpointAddress[]> {
+export async function assertSafeAiEndpoint(value: string, allowPrivateNetwork = false): Promise<SafeAiEndpointAddress[]> {
   const endpoint = new URL(value);
   if (!['http:', 'https:'].includes(endpoint.protocol) || endpoint.username || endpoint.password) {
     throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商地址必须是无内嵌凭据的 HTTP 或 HTTPS 地址");
@@ -435,7 +431,7 @@ export async function assertSafeAiEndpoint(
   if (!addresses.length) throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商域名无法解析");
   for (const { address } of addresses) {
     const kind = unsafeIpKind(address);
-    if (!trustResolvedNetwork && (kind === "blocked" || (kind === "private" && !allowPrivateNetwork))) {
+    if (kind === "blocked" || (kind === "private" && !allowPrivateNetwork)) {
       logger.warn("security.ai_endpoint.blocked", { hostname, addressKind: kind });
       throw new AppError(400, "UNSAFE_PROVIDER_ENDPOINT", "AI 供应商地址指向受保护的本机、内网或链路本地网络");
     }

--- a/src/security.ts
+++ b/src/security.ts
@@ -152,7 +152,7 @@ export function createBasicAuthMiddleware(options: BasicAuthOptions): RequestHan
 
 export function createSecurityHeadersMiddleware(): RequestHandler {
   return (request, response, next) => {
-    response.setHeader("Content-Security-Policy", "default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'none'");
+    response.setHeader("Content-Security-Policy", "default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'none'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self'");
     response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
     response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
     response.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()");
@@ -212,7 +212,8 @@ export function createAuthenticationRateLimitMiddleware(limit = 10, windowMs = 1
   const entries = new Map<string, RateEntry>();
   return (request, response, next) => {
     const path = normalizeApiPath(request.path);
-    const authenticationWrite = request.method === "POST" && ["/api/auth/login", "/api/auth/register"].includes(path);
+    const authenticationWrite = request.method === "POST"
+      && ["/api/auth/login", "/api/auth/register", "/api/desktop/auth/login"].includes(path);
     if (!authenticationWrite) return next();
     const rate = consumeRate(entries, `${requestKey(request)}:${path}`, limit, windowMs);
     if (rate.allowed) return next();

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -22,7 +22,7 @@ export type LocalServerOptions = {
   databasePath: string;
   env: NodeJS.ProcessEnv;
   /** 仅由受信任的本机嵌入端设置，不从 Server 环境变量读取。 */
-  trustAiEndpointNetwork?: boolean;
+  disableAiEndpointValidation?: boolean;
 };
 
 export type RunningLocalServer = {
@@ -243,7 +243,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
       masterSecret: loadMasterSecret(join(options.dataDirectory, "master.key"), options.env.AI_NOVEL_MASTER_KEY),
       publicPath,
       security,
-      trustAiEndpointNetwork: options.trustAiEndpointNetwork === true,
+      disableAiEndpointValidation: options.disableAiEndpointValidation === true,
       disableUserAuth: devAuthBypass,
       devAuthBypass,
       developmentServer: isDevelopmentServer(options.env),

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -13,6 +13,7 @@ import { logger, sanitizeError } from "./logger.js";
 import { resolveReleaseCheckIntervalMs, resolveReleaseCheckRetries, resolveReleaseCheckTimeoutMs } from "./release-update.js";
 import { resolveImageUploadLimits } from "./upload-limits.js";
 import { resolveBetaVersionLabel } from "./version.js";
+import { claimServerDataDirectory, STORAGE_MANIFEST_FILENAME } from "./storage-manifest.js";
 
 export type LocalServerOptions = {
   host: string;
@@ -187,6 +188,12 @@ export function createPreMigrationBackup(
     cpSync(masterKeyPath, target, { preserveTimestamps: true });
     chmodSync(target, 0o600);
   }
+  const storageManifestPath = join(options.dataDirectory, STORAGE_MANIFEST_FILENAME);
+  if (existsSync(storageManifestPath)) {
+    const target = join(incompleteDirectory, STORAGE_MANIFEST_FILENAME);
+    cpSync(storageManifestPath, target, { preserveTimestamps: true });
+    chmodSync(target, 0o600);
+  }
   const attachmentsPath = join(options.dataDirectory, "attachments");
   if (existsSync(attachmentsPath)) {
     cpSync(attachmentsPath, join(incompleteDirectory, "attachments"), { recursive: true, preserveTimestamps: true });
@@ -217,6 +224,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
   try {
     mkdirSync(options.dataDirectory, { recursive: true, mode: 0o700 });
     chmodSync(options.dataDirectory, 0o700);
+    claimServerDataDirectory(options.dataDirectory, options.databasePath);
     recordStartupAttempt(options.dataDirectory, options.env);
     security = resolveRuntimeSecurity(options.env);
     warnIfPrivateAiEndpointsEnabled(options.env);

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -265,10 +265,13 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
     const server = runtime.app.listen(options.port, options.host);
     const handleStartupError = (error: Error): void => {
       logger.error("server.start_failed", { host: options.host, port: options.port, error: sanitizeError(error) });
-      void runtime.close().catch((closeError: unknown) => {
-        logger.error("server.runtime_close_failed", { error: sanitizeError(closeError) });
-      });
-      rejectStart(error);
+      void runtime.close().then(
+        () => rejectStart(error),
+        (closeError: unknown) => {
+          logger.error("server.runtime_close_failed", { error: sanitizeError(closeError) });
+          rejectStart(error);
+        }
+      );
     };
     server.once("error", handleStartupError);
     server.once("listening", () => {

--- a/src/server-runtime.ts
+++ b/src/server-runtime.ts
@@ -21,6 +21,8 @@ export type LocalServerOptions = {
   dataDirectory: string;
   databasePath: string;
   env: NodeJS.ProcessEnv;
+  /** 仅由受信任的本机嵌入端设置，不从 Server 环境变量读取。 */
+  trustAiEndpointNetwork?: boolean;
 };
 
 export type RunningLocalServer = {
@@ -241,6 +243,7 @@ export async function startLocalServer(options: LocalServerOptions): Promise<Run
       masterSecret: loadMasterSecret(join(options.dataDirectory, "master.key"), options.env.AI_NOVEL_MASTER_KEY),
       publicPath,
       security,
+      trustAiEndpointNetwork: options.trustAiEndpointNetwork === true,
       disableUserAuth: devAuthBypass,
       devAuthBypass,
       developmentServer: isDevelopmentServer(options.env),

--- a/src/storage-manifest.ts
+++ b/src/storage-manifest.ts
@@ -1,0 +1,134 @@
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { readDatabaseSchemaVersion } from "./database.js";
+
+export const STORAGE_MANIFEST_FILENAME = "storage-manifest.json";
+export const SERVER_STORAGE_KIND = "scriverse-server-data";
+export const STORAGE_MANIFEST_VERSION = 1;
+
+export type ServerStorageManifest = {
+  kind: typeof SERVER_STORAGE_KIND;
+  storageVersion: typeof STORAGE_MANIFEST_VERSION;
+  serverId: string;
+  createdAt: string;
+};
+
+export class StorageManifestError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = "StorageManifestError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertUuid(value: unknown, field: string): string {
+  if (typeof value !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value)) {
+    throw new StorageManifestError("STORAGE_MANIFEST_INVALID", `存储清单的 ${field} 无效`);
+  }
+  return value;
+}
+
+function assertCreatedAt(value: unknown): string {
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    throw new StorageManifestError("STORAGE_MANIFEST_INVALID", "存储清单的 createdAt 无效");
+  }
+  return value;
+}
+
+export function parseServerStorageManifest(value: unknown): ServerStorageManifest {
+  if (!isRecord(value)) throw new StorageManifestError("STORAGE_MANIFEST_INVALID", "存储清单格式无效");
+  if (value.kind !== SERVER_STORAGE_KIND) {
+    throw new StorageManifestError("STORAGE_KIND_MISMATCH", "该目录不属于 Scriverse Server，已拒绝打开");
+  }
+  if (value.storageVersion !== STORAGE_MANIFEST_VERSION) {
+    throw new StorageManifestError("STORAGE_VERSION_UNSUPPORTED", "该存储目录版本暂不受当前 Scriverse Server 支持");
+  }
+  return {
+    kind: SERVER_STORAGE_KIND,
+    storageVersion: STORAGE_MANIFEST_VERSION,
+    serverId: assertUuid(value.serverId, "serverId"),
+    createdAt: assertCreatedAt(value.createdAt)
+  };
+}
+
+function syncDirectory(directory: string): void {
+  if (process.platform === "win32") return;
+  const descriptor = openSync(directory, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+export function writeJsonAtomically(path: string, value: unknown): void {
+  const directory = join(path, "..");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  const temporaryPath = `${path}.tmp-${process.pid}-${randomUUID()}`;
+  const descriptor = openSync(temporaryPath, "wx", 0o600);
+  try {
+    writeFileSync(descriptor, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  chmodSync(temporaryPath, 0o600);
+  renameSync(temporaryPath, path);
+  chmodSync(path, 0o600);
+  syncDirectory(directory);
+}
+
+export function readServerStorageManifest(dataDirectory: string): ServerStorageManifest | null {
+  const path = join(dataDirectory, STORAGE_MANIFEST_FILENAME);
+  if (!existsSync(path)) return null;
+  try {
+    return parseServerStorageManifest(JSON.parse(readFileSync(path, "utf8")) as unknown);
+  } catch (error) {
+    if (error instanceof StorageManifestError) throw error;
+    throw new StorageManifestError("STORAGE_MANIFEST_INVALID", "存储清单无法读取或不是有效 JSON");
+  }
+}
+
+export function claimServerDataDirectory(dataDirectory: string, databasePath: string): ServerStorageManifest {
+  mkdirSync(dataDirectory, { recursive: true, mode: 0o700 });
+  chmodSync(dataDirectory, 0o700);
+  const existing = readServerStorageManifest(dataDirectory);
+  if (existing) return existing;
+
+  if (existsSync(databasePath)) {
+    const schemaVersion = readDatabaseSchemaVersion(databasePath);
+    if (schemaVersion === null || schemaVersion < 1) {
+      throw new StorageManifestError("STORAGE_DIRECTORY_UNCLAIMED", "现有数据库无法确认属于 Scriverse Server，已拒绝认领");
+    }
+  } else {
+    const entries = readdirSync(dataDirectory).filter((entry) => !entry.startsWith(`${STORAGE_MANIFEST_FILENAME}.tmp-`));
+    if (entries.length > 0) {
+      throw new StorageManifestError("STORAGE_DIRECTORY_UNCLAIMED", "非空目录缺少可验证的 Scriverse Server 数据库，已拒绝认领");
+    }
+  }
+
+  const manifest: ServerStorageManifest = {
+    kind: SERVER_STORAGE_KIND,
+    storageVersion: STORAGE_MANIFEST_VERSION,
+    serverId: randomUUID(),
+    createdAt: new Date().toISOString()
+  };
+  writeJsonAtomically(join(dataDirectory, STORAGE_MANIFEST_FILENAME), manifest);
+  return manifest;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1171,7 +1171,39 @@ export class Store {
       timestamp ?? now(),
       currentRequestActor()?.userId ?? null
     );
+    if (type === "setting") {
+      this.recordSyncChange(
+        String(entity.workId),
+        "setting",
+        entityId,
+        source === "delete" ? "delete" : "upsert",
+        versionNo,
+        timestamp
+      );
+    }
     return versionNo;
+  }
+
+  private recordSyncChange(
+    workId: string,
+    entityType: "chapter" | "setting",
+    entityId: string,
+    operation: "upsert" | "delete",
+    versionNo: number,
+    timestamp?: string
+  ): void {
+    this.db.run(
+      `INSERT INTO sync_changes (
+         work_id, entity_type, entity_id, operation, version_no, changed_by_user_id, changed_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      workId,
+      entityType,
+      entityId,
+      operation,
+      versionNo,
+      currentRequestActor()?.userId ?? null,
+      timestamp ?? now()
+    );
   }
 
   private backfillEntityVersionBaselines(): void {
@@ -1897,6 +1929,30 @@ export class Store {
       );
       this.recordEntityVersion("work", workId, source, sourceRef, changeNote || "更新作品信息", timestamp);
       this.audit(workId, "work.updated", "work", workId, { fields: Object.keys(input), versionNo: Number(current.versionNo) + 1, source, sourceRef, changeNote });
+    });
+    return this.getWork(workId);
+  }
+
+  setWorkOfflineAccess(workId: string, enabled: boolean): Record<string, unknown> {
+    this.db.transaction(() => {
+      const current = this.getWork(workId);
+      if (Boolean(current.offlineAccessEnabled) === enabled) return;
+      const timestamp = now();
+      this.db.run(
+        "UPDATE works SET offline_access_enabled = ?, version_no = version_no + 1, updated_at = ? WHERE id = ?",
+        enabled ? 1 : 0,
+        timestamp,
+        workId
+      );
+      this.recordEntityVersion(
+        "work",
+        workId,
+        "manual",
+        null,
+        enabled ? "允许 Desktop 离线访问" : "禁止 Desktop 离线访问",
+        timestamp
+      );
+      this.audit(workId, enabled ? "work.offline-access.enabled" : "work.offline-access.disabled", "work", workId, { enabled });
     });
     return this.getWork(workId);
   }
@@ -2908,6 +2964,7 @@ export class Store {
     changeNote: string;
     timestamp?: string;
   }): void {
+    const timestamp = input.timestamp ?? now();
     this.db.run(
       `INSERT INTO chapter_versions (
          id, work_id, chapter_id, version_no, title, content, volume_id, sort_order, chapter_type,
@@ -2925,8 +2982,16 @@ export class Store {
       input.source,
       input.sourceRef,
       input.changeNote.trim(),
-      input.timestamp ?? now(),
+      timestamp,
       currentRequestActor()?.userId ?? null
+    );
+    this.recordSyncChange(
+      input.workId,
+      "chapter",
+      input.chapterId,
+      input.source === "delete" ? "delete" : "upsert",
+      input.versionNo,
+      timestamp
     );
   }
 
@@ -3042,7 +3107,7 @@ export class Store {
     const hasOtherChange = nextExcluded !== current.excludedFromAnalysis || hasTypeChange;
     if (!hasTextChange && !hasOtherChange) return current;
     const timestamp = now();
-    const versionNo = Number(current.versionNo) + (hasTextChange ? 1 : 0);
+    const versionNo = Number(current.versionNo) + (hasTextChange || hasTypeChange ? 1 : 0);
     this.db.transaction(() => {
       const lockedCurrent = this.getChapter(chapterId);
       this.assertExpectedRevision("chapter", chapterId, expectedVersionNo, "章节", Number(lockedCurrent.versionNo));
@@ -3060,7 +3125,8 @@ export class Store {
         chapterId
       );
       if (hasTextChange) this.syncChapterParagraphSearch(String(current.workId), chapterId, nextContent);
-      if (hasTextChange) {
+      else if (hasTypeChange) this.syncChapterParagraphSearchVersion(chapterId, versionNo);
+      if (hasTextChange || hasTypeChange) {
         this.insertChapterVersionRow({
           workId: String(current.workId),
           chapterId,
@@ -3072,7 +3138,7 @@ export class Store {
           chapterType: nextChapterType,
           source,
           sourceRef,
-          changeNote: changeNote || "更新章节正文",
+          changeNote: changeNote || (hasTextChange ? "更新章节正文" : "更新章节类型"),
           timestamp
         });
       }
@@ -3715,9 +3781,33 @@ export class Store {
         }
       } else if (action.type === "setType") {
         for (const chapter of currentChapters) {
-          this.db.run("UPDATE chapters SET chapter_type = ?, analysis_status = 'expired', updated_at = ? WHERE id = ?", action.chapterType, timestamp, String(chapter.id));
-          this.invalidateChapter(workId, String(chapter.id), Number(chapter.versionNo));
-          this.audit(workId, "chapter.saved", "chapter", String(chapter.id), { chapterType: action.chapterType, batch: true });
+          if (chapter.chapterType === action.chapterType) continue;
+          const chapterId = String(chapter.id);
+          const versionNo = Number(chapter.versionNo) + 1;
+          this.db.run(
+            "UPDATE chapters SET chapter_type = ?, version_no = ?, analysis_status = 'expired', updated_at = ? WHERE id = ?",
+            action.chapterType,
+            versionNo,
+            timestamp,
+            chapterId
+          );
+          this.syncChapterParagraphSearchVersion(chapterId, versionNo);
+          this.insertChapterVersionRow({
+            workId,
+            chapterId,
+            versionNo,
+            title: String(chapter.title),
+            content: String(chapter.content),
+            volumeId: String(chapter.volumeId),
+            sortOrder: Number(chapter.sortOrder),
+            chapterType: action.chapterType,
+            source: "manual",
+            sourceRef: null,
+            changeNote: "批量更新章节类型",
+            timestamp
+          });
+          this.invalidateChapter(workId, chapterId, versionNo);
+          this.audit(workId, "chapter.saved", "chapter", chapterId, { chapterType: action.chapterType, versionNo, batch: true });
         }
       } else if (action.type === "setAnalysisExclusion") {
         for (const chapter of currentChapters) {
@@ -4247,6 +4337,7 @@ export class Store {
         ? `/api/works/${encodeURIComponent(workId)}/cover?v=${encodeURIComponent(requiredString(cover, "updated_at"))}`
         : optionalString(row, "cover_url"),
       tags: json(requiredString(row, "tags_json"), []),
+      offlineAccessEnabled: numberValue(row, "offline_access_enabled") === 1,
       versionNo: numberValue(row, "version_no") || this.currentEntityVersionNo("work", workId),
       ownerUserId,
       accessRole,

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -64,6 +64,15 @@ export type AuthSession = {
   csrfToken: string;
 };
 
+export type AuthDesktopSession = {
+  id: string;
+  user: AuthUser;
+  desktopId: string;
+  profileId: string;
+  clientVersion: string;
+  expiresAt: string;
+};
+
 export type AuthApiKey = {
   user: AuthUser;
   prefix: string;
@@ -86,15 +95,18 @@ declare global {
   namespace Express {
     interface Request {
       authSession?: AuthSession;
+      authDesktopSession?: AuthDesktopSession;
       authUser?: AuthUser;
-      authMethod?: "session" | "api-key";
+      authMethod?: "session" | "desktop-session" | "api-key";
       authApiKey?: AuthApiKey;
     }
   }
 }
 
-const sessionCookieName = "scriverse_session";
-const sessionLifetimeMs = 30 * 24 * 60 * 60_000;
+export const SESSION_COOKIE_NAME = "scriverse_session";
+export const SESSION_LIFETIME_MS = 30 * 24 * 60 * 60_000;
+export const DESKTOP_SESSION_TOKEN_PREFIX = "scrvd_";
+export const DESKTOP_SESSION_LIFETIME_MS = 30 * 24 * 60 * 60_000;
 const apiKeyPrefix = "scrv_";
 function membershipAccessRole(row: Row | undefined): PublicWorkAccessRole | null {
   const role = String(row?.role ?? "");
@@ -139,12 +151,23 @@ function parseCookies(header: string | undefined): Map<string, string> {
   return result;
 }
 
+function bearerCredential(request: Request): string | null {
+  const authorization = request.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) return null;
+  const token = authorization.slice(7).trim();
+  return token.length > 0 && token.length <= 200 ? token : null;
+}
+
 function apiKeyCredential(request: Request): string | null {
   const direct = request.get("x-scriverse-api-key")?.trim();
   if (direct) return direct;
-  const authorization = request.get("authorization");
-  if (!authorization?.startsWith("Bearer ")) return null;
-  return authorization.slice(7).trim();
+  const bearer = bearerCredential(request);
+  return bearer?.startsWith(apiKeyPrefix) ? bearer : null;
+}
+
+function desktopSessionCredential(request: Request): string | null {
+  const bearer = bearerCredential(request);
+  return bearer?.startsWith(DESKTOP_SESSION_TOKEN_PREFIX) ? bearer : null;
 }
 
 function mapUser(row: Row): AuthUser {
@@ -177,6 +200,7 @@ function workIdFromPath(database: Database, pathname: string): string | null {
   const resource = (decoded[2] ?? "").toLocaleLowerCase("en-US");
   if (root !== "api") return null;
   if (resource === "works" && decoded[3] && decoded[3].toLocaleLowerCase("en-US") !== "import") return decoded[3];
+  if (resource === "sync" && decoded[3]?.toLocaleLowerCase("en-US") === "works" && decoded[4]) return decoded[4];
   const tableByResource: Record<string, string> = {
     volumes: "volumes",
     chapters: "chapters",
@@ -301,11 +325,55 @@ export class UserAuthService {
       sha256(token),
       csrfToken,
       timestamp.toISOString(),
-      new Date(timestamp.getTime() + sessionLifetimeMs).toISOString(),
+      new Date(timestamp.getTime() + SESSION_LIFETIME_MS).toISOString(),
       timestamp.toISOString()
     );
     const user = this.getUser(userId);
     return { token, session: { id: sessionId, user, csrfToken } };
+  }
+
+  private createDesktopSession(userId: string, input: {
+    desktopId: string;
+    profileId: string;
+    clientVersion: string;
+  }): { token: string; session: AuthDesktopSession } {
+    const token = `${DESKTOP_SESSION_TOKEN_PREFIX}${randomBytes(32).toString("base64url")}`;
+    const sessionId = randomUUID();
+    const timestamp = new Date();
+    const createdAt = timestamp.toISOString();
+    const expiresAt = new Date(timestamp.getTime() + DESKTOP_SESSION_LIFETIME_MS).toISOString();
+    this.database.run(
+      `UPDATE user_desktop_sessions SET revoked_at = ?
+       WHERE desktop_id = ? AND profile_id = ? AND revoked_at IS NULL`,
+      createdAt,
+      input.desktopId,
+      input.profileId
+    );
+    this.database.run(
+      `INSERT INTO user_desktop_sessions (
+         id, user_id, token_hash, desktop_id, profile_id, client_version, created_at, expires_at, last_seen_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      sessionId,
+      userId,
+      sha256(token),
+      input.desktopId,
+      input.profileId,
+      input.clientVersion,
+      createdAt,
+      expiresAt,
+      createdAt
+    );
+    return {
+      token,
+      session: {
+        id: sessionId,
+        user: this.getUser(userId),
+        desktopId: input.desktopId,
+        profileId: input.profileId,
+        clientVersion: input.clientVersion,
+        expiresAt
+      }
+    };
   }
 
   register(input: { username: string; password: string }): { token: string; session: AuthSession } {
@@ -353,9 +421,12 @@ export class UserAuthService {
     });
   }
 
-  login(username: string, password: string): { token: string; session: AuthSession } {
+  private validateLoginCredentials(username: string, password: string): {
+    user: AuthUser;
+    normalizedUsername: string;
+    loginAt: string;
+  } {
     const normalizedUsername = normalizeUsername(username);
-    const timestamp = new Date();
     const row = this.database.get(
       "SELECT * FROM users WHERE normalized_username = ?",
       normalizedUsername
@@ -372,16 +443,43 @@ export class UserAuthService {
       logger.warn("auth.login.failed", { reason: "account_disabled", actorRef: accountReference(user.userId) });
       throw new AppError(403, "ACCOUNT_DISABLED", "该账户已被停用");
     }
+    return { user, normalizedUsername, loginAt: new Date().toISOString() };
+  }
+
+  login(username: string, password: string): { token: string; session: AuthSession } {
+    const validated = this.validateLoginCredentials(username, password);
     return this.database.transaction(() => {
-      const loginAt = timestamp.toISOString();
-      this.database.run("DELETE FROM login_attempts WHERE normalized_username = ?", normalizedUsername);
-      this.database.run("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?", loginAt, loginAt, user.userId);
-      return this.createSession(user.userId);
+      this.database.run("DELETE FROM login_attempts WHERE normalized_username = ?", validated.normalizedUsername);
+      this.database.run(
+        "UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?",
+        validated.loginAt,
+        validated.loginAt,
+        validated.user.userId
+      );
+      return this.createSession(validated.user.userId);
+    });
+  }
+
+  loginDesktop(username: string, password: string, input: {
+    desktopId: string;
+    profileId: string;
+    clientVersion: string;
+  }): { token: string; session: AuthDesktopSession } {
+    const validated = this.validateLoginCredentials(username, password);
+    return this.database.transaction(() => {
+      this.database.run("DELETE FROM login_attempts WHERE normalized_username = ?", validated.normalizedUsername);
+      this.database.run(
+        "UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?",
+        validated.loginAt,
+        validated.loginAt,
+        validated.user.userId
+      );
+      return this.createDesktopSession(validated.user.userId, input);
     });
   }
 
   authenticate(request: Request): AuthSession | null {
-    const token = parseCookies(request.get("cookie")).get(sessionCookieName);
+    const token = parseCookies(request.get("cookie")).get(SESSION_COOKIE_NAME);
     if (!token) return null;
     const row = this.database.get(
       `SELECT session.id AS session_id, session.csrf_token, session.expires_at, session.revoked_at,
@@ -393,6 +491,35 @@ export class UserAuthService {
     if (user.status !== "active") return null;
     this.database.run("UPDATE user_sessions SET last_seen_at = ? WHERE id = ?", new Date().toISOString(), String(row.session_id));
     return { id: String(row.session_id), csrfToken: String(row.csrf_token), user };
+  }
+
+  authenticateDesktop(request: Request): AuthDesktopSession | null {
+    const token = desktopSessionCredential(request);
+    if (!token || token.length !== DESKTOP_SESSION_TOKEN_PREFIX.length + 43) return null;
+    const row = this.database.get(
+      `SELECT session.id AS session_id, session.desktop_id, session.profile_id, session.client_version,
+              session.expires_at, session.revoked_at, user.*
+       FROM user_desktop_sessions session
+       JOIN users user ON user.id = session.user_id
+       WHERE session.token_hash = ?`,
+      sha256(token)
+    );
+    if (!row || row.revoked_at || String(row.expires_at) <= new Date().toISOString()) return null;
+    const user = mapUser(row);
+    if (user.status !== "active") return null;
+    this.database.run(
+      "UPDATE user_desktop_sessions SET last_seen_at = ? WHERE id = ?",
+      new Date().toISOString(),
+      String(row.session_id)
+    );
+    return {
+      id: String(row.session_id),
+      user,
+      desktopId: String(row.desktop_id),
+      profileId: String(row.profile_id),
+      clientVersion: String(row.client_version),
+      expiresAt: String(row.expires_at)
+    };
   }
 
   authenticateApiKey(request: Request): AuthApiKey | null {
@@ -412,6 +539,10 @@ export class UserAuthService {
 
   hasApiKeyCredential(request: Request): boolean {
     return apiKeyCredential(request) !== null;
+  }
+
+  hasDesktopSessionCredential(request: Request): boolean {
+    return desktopSessionCredential(request) !== null;
   }
 
   getApiKeyStatus(userId: string): ApiKeyStatus {
@@ -476,6 +607,10 @@ export class UserAuthService {
     this.database.run("UPDATE user_sessions SET revoked_at = ? WHERE id = ?", new Date().toISOString(), sessionId);
   }
 
+  revokeDesktop(sessionId: string): void {
+    this.database.run("UPDATE user_desktop_sessions SET revoked_at = ? WHERE id = ?", new Date().toISOString(), sessionId);
+  }
+
   getUser(userId: string): AuthUser {
     const row = this.database.get("SELECT * FROM users WHERE id = ?", userId);
     if (!row) throw notFound("用户");
@@ -538,9 +673,15 @@ export class UserAuthService {
     return this.database.transaction(() => {
       this.database.run("UPDATE users SET role = ?, status = ?, updated_at = ? WHERE id = ?", nextRole, nextStatus, new Date().toISOString(), userId);
       if (nextStatus === "disabled") {
+        const revokedAt = new Date().toISOString();
         this.database.run(
           "UPDATE user_sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL",
-          new Date().toISOString(),
+          revokedAt,
+          userId
+        );
+        this.database.run(
+          "UPDATE user_desktop_sessions SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL",
+          revokedAt,
           userId
         );
       }
@@ -614,7 +755,13 @@ export class UserAuthService {
     return this.getUser(userId);
   }
 
-  changePassword(userId: string, sessionId: string, currentPassword: string, newPassword: string): void {
+  changePassword(
+    userId: string,
+    sessionId: string,
+    currentPassword: string,
+    newPassword: string,
+    sessionKind: "browser" | "desktop" = "browser"
+  ): void {
     const row = this.database.get("SELECT * FROM users WHERE id = ?", userId);
     if (!row) throw notFound("用户");
     const calculated = passwordDigest(currentPassword, String(row.password_salt));
@@ -623,7 +770,22 @@ export class UserAuthService {
     const timestamp = new Date().toISOString();
     this.database.transaction(() => {
       this.database.run("UPDATE users SET password_hash = ?, password_salt = ?, updated_at = ? WHERE id = ?", passwordDigest(newPassword, salt), salt, timestamp, userId);
-      this.database.run("UPDATE user_sessions SET revoked_at = ? WHERE user_id = ? AND id <> ? AND revoked_at IS NULL", timestamp, userId, sessionId);
+      this.database.run(
+        `UPDATE user_sessions SET revoked_at = ?
+         WHERE user_id = ? AND (? <> 'browser' OR id <> ?) AND revoked_at IS NULL`,
+        timestamp,
+        userId,
+        sessionKind,
+        sessionId
+      );
+      this.database.run(
+        `UPDATE user_desktop_sessions SET revoked_at = ?
+         WHERE user_id = ? AND (? <> 'desktop' OR id <> ?) AND revoked_at IS NULL`,
+        timestamp,
+        userId,
+        sessionKind,
+        sessionId
+      );
       this.database.run("DELETE FROM login_attempts WHERE normalized_username = ?", String(row.normalized_username));
     });
   }
@@ -792,17 +954,17 @@ export class UserAuthService {
 }
 
 export function setSessionCookie(response: Response, token: string, secure: boolean): void {
-  response.cookie(sessionCookieName, token, {
+  response.cookie(SESSION_COOKIE_NAME, token, {
     httpOnly: true,
     sameSite: "lax",
     secure,
     path: "/",
-    maxAge: sessionLifetimeMs
+    maxAge: SESSION_LIFETIME_MS
   });
 }
 
 export function clearSessionCookie(response: Response, secure: boolean): void {
-  response.clearCookie(sessionCookieName, { httpOnly: true, sameSite: "lax", secure, path: "/" });
+  response.clearCookie(SESSION_COOKIE_NAME, { httpOnly: true, sameSite: "lax", secure, path: "/" });
 }
 
 export function createUserSessionMiddleware(
@@ -822,17 +984,34 @@ export function createUserSessionMiddleware(
       }
       return runWithRequestActor(null, next);
     }
-    const apiKey = auth.authenticateApiKey(request);
-    if (auth.hasApiKeyCredential(request) && !apiKey) {
+    const apiKeyProvided = auth.hasApiKeyCredential(request);
+    const desktopSessionProvided = auth.hasDesktopSessionCredential(request);
+    if (apiKeyProvided && desktopSessionProvided) {
+      logger.warn("auth.request.rejected", { reason: "conflicting_credentials", method: request.method, path: sanitizeRequestPath(request.path) });
+      response.status(400).json({ error: { code: "AUTH_CREDENTIAL_CONFLICT", message: "请求包含相互冲突的身份凭据" } });
+      return;
+    }
+    const apiKey = apiKeyProvided ? auth.authenticateApiKey(request) : null;
+    if (apiKeyProvided && !apiKey) {
       logger.warn("auth.request.rejected", { reason: "invalid_api_key", method: request.method, path: sanitizeRequestPath(request.path) });
       response.status(401).json({ error: { code: "API_KEY_INVALID", message: "API Key 无效或已失效" } });
       return;
     }
-    const session = apiKey ? null : auth.authenticate(request);
+    const desktopSession = desktopSessionProvided ? auth.authenticateDesktop(request) : null;
+    if (desktopSessionProvided && !desktopSession) {
+      logger.warn("auth.request.rejected", { reason: "invalid_desktop_session", method: request.method, path: sanitizeRequestPath(request.path) });
+      response.status(401).json({ error: { code: "DESKTOP_SESSION_INVALID", message: "Desktop 登录已失效，请重新登录" } });
+      return;
+    }
+    const session = apiKey || desktopSession ? null : auth.authenticate(request);
     if (apiKey) {
       request.authApiKey = apiKey;
       request.authUser = apiKey.user;
       request.authMethod = "api-key";
+    } else if (desktopSession) {
+      request.authDesktopSession = desktopSession;
+      request.authUser = desktopSession.user;
+      request.authMethod = "desktop-session";
     } else if (session) {
       request.authSession = session;
       request.authUser = session.user;
@@ -843,8 +1022,9 @@ export function createUserSessionMiddleware(
       || path === "/api/auth/session"
       || (path === "/api/auth/register" && request.method === "POST")
       || (path === "/api/auth/login" && request.method === "POST")
+      || (path === "/api/desktop/auth/login" && request.method === "POST")
       || !path.startsWith("/api/");
-    if (!session && !apiKey && !isPublic) {
+    if (!session && !desktopSession && !apiKey && !isPublic) {
       logger.warn("auth.request.rejected", { reason: "authentication_required", method: request.method, path: sanitizeRequestPath(request.path) });
       response.status(401).json({ error: { code: "AUTH_REQUIRED", message: "请先登录" } });
       return;
@@ -857,9 +1037,10 @@ export function createUserSessionMiddleware(
         return;
       }
     }
-    const user = apiKey?.user ?? session?.user ?? null;
-    return runWithRequestActor(user ? { ...user, authentication: apiKey ? "api-key" : "session" } : null, () => {
-      if (user) logger.debug("auth.request.authenticated", { authMethod: apiKey ? "api-key" : "session" });
+    const user = apiKey?.user ?? desktopSession?.user ?? session?.user ?? null;
+    const authMethod = apiKey ? "api-key" : desktopSession ? "desktop-session" : "session";
+    return runWithRequestActor(user ? { ...user, authentication: authMethod } : null, () => {
+      if (user) logger.debug("auth.request.authenticated", { authMethod });
       next();
     });
   };
@@ -983,12 +1164,30 @@ function globalReplaceWriteModules(request: Request): WorkPermissionModule[] {
   return [];
 }
 
+function syncPushWriteModules(request: Request): WorkPermissionModule[] {
+  const mutations = requestBodyRecord(request).mutations;
+  if (!Array.isArray(mutations)) return [];
+  const modules = new Set<WorkPermissionModule>();
+  for (const mutation of mutations) {
+    if (!mutation || typeof mutation !== "object" || Array.isArray(mutation)) continue;
+    const entityType = (mutation as Record<string, unknown>).entityType;
+    if (entityType === "chapter") modules.add("prose");
+    if (entityType === "setting") modules.add("settings");
+  }
+  return [...modules];
+}
+
 function workModuleRequirements(request: Request, write: boolean, annotationAccess?: { kind: "note" | "todo"; createdByUserId: string | null }): WorkAuthorizationRequirements {
   const pathname = normalizeApiPath(request.path);
   const direct = (module: WorkPermissionModule, extraWrite: WorkPermissionModule[] = []): WorkAuthorizationRequirements => (
     write ? { write: [module, ...extraWrite] } : { read: [module] }
   );
+  if (/^\/api\/sync\/works\/[^/]+\/snapshots$/u.test(pathname)) return { read: ["prose", "settings"] };
+  if (/^\/api\/sync\/works\/[^/]+\/changes$/u.test(pathname)) return { read: ["prose", "settings"] };
+  if (/^\/api\/sync\/works\/[^/]+\/push$/u.test(pathname)) return { write: syncPushWriteModules(request) };
+  if (/^\/api\/sync\/works\/[^/]+\/mutations\/[^/]+$/u.test(pathname)) return { read: ["prose", "settings"] };
   if (/^\/api\/works\/[^/]+$/u.test(pathname)) return write ? { ownerOnly: true } : {};
+  if (/^\/api\/works\/[^/]+\/offline-access$/u.test(pathname)) return { ownerOnly: true };
   if (/^\/api\/works\/[^/]+\/cover$/u.test(pathname)) return write ? { ownerOnly: true } : {};
   if (/^\/api\/works\/[^/]+\/members(?:\/[^/]+)?$/u.test(pathname)) return { ownerOnly: true };
   if (/^\/api\/works\/[^/]+\/presence$/u.test(pathname)) return {};

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -90,6 +90,56 @@ describe("AI 供应商、模型与建议 API", () => {
     runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", contextWindow, modelId);
   }
 
+  it("为 Desktop 本地模型准备 Server Prompt 和作品上下文但不调用远端供应商", async () => {
+    await request(runtime.app).patch("/api/platform/ai/settings").send({
+      systemPrompt: "平台远端 Prompt"
+    }).expect(200);
+    await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
+      systemPrompt: "作品远端 Prompt"
+    }).expect(200);
+    const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
+    const conversationId = String(conversation.body.data.id);
+    await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({
+      role: "user",
+      content: "上一轮问题"
+    }).expect(201);
+    await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({
+      role: "assistant",
+      content: "上一轮回答"
+    }).expect(201);
+    const current = await request(runtime.app).post(`/api/ai-conversations/${conversationId}/messages`).send({
+      role: "user",
+      content: "请结合跃迁限制继续讨论"
+    }).expect(201);
+
+    const prepared = await request(runtime.app).post(`/api/works/${workId}/desktop-local-ai/prepare`).send({
+      taskType: "chat",
+      instruction: "请结合跃迁限制继续讨论",
+      scope: { type: "chapter", chapterId },
+      contextWindow: 128_000,
+      maxOutputTokens: 4_096,
+      conversationId,
+      currentMessageId: current.body.data.id
+    }).expect(200);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(prepared.body.data.remoteSystemPrompt).toContain("<platform_system_prompt>");
+    expect(prepared.body.data.remoteSystemPrompt).toContain("平台远端 Prompt");
+    expect(prepared.body.data.remoteSystemPrompt).toContain("<work_system_prompt>");
+    expect(prepared.body.data.remoteSystemPrompt).toContain("作品远端 Prompt");
+    expect(prepared.body.data.remoteSystemPrompt).not.toContain("desktop_local_ai_prompt");
+    expect(prepared.body.data.messages).toEqual(expect.arrayContaining([
+      { role: "user", content: "上一轮问题" },
+      { role: "assistant", content: "上一轮回答" }
+    ]));
+    expect(JSON.stringify(prepared.body.data.messages)).toContain("跃迁后必须冷却十二小时");
+    expect(JSON.stringify(prepared.body.data.messages)).toContain("<author_instruction>");
+    expect(prepared.body.data.contextUsage).toMatchObject({
+      modelId: "desktop-local-model",
+      contextWindow: 128_000
+    });
+  });
+
   it.each([
     ["openai-chat-completions", "OpenAI Chat"],
     ["openai-responses", "OpenAI Responses"]

--- a/tests/integration/ai-development-endpoint.test.ts
+++ b/tests/integration/ai-development-endpoint.test.ts
@@ -11,7 +11,7 @@ afterEach(async () => {
 async function testProviderConnection(options: {
   developmentServer: boolean;
   allowPrivateAiEndpoints?: boolean;
-  trustAiEndpointNetwork?: boolean;
+  disableAiEndpointValidation?: boolean;
   baseUrl: string;
 }): Promise<{
   result: Record<string, unknown>;
@@ -36,7 +36,7 @@ async function testProviderConnection(options: {
       allowPrivateAiEndpoints: options.allowPrivateAiEndpoints === true,
       enforceSameOrigin: false
     },
-    trustAiEndpointNetwork: options.trustAiEndpointNetwork === true,
+    disableAiEndpointValidation: options.disableAiEndpointValidation === true,
     developmentServer: options.developmentServer
   });
   runtimes.push(runtime);
@@ -121,11 +121,11 @@ describe("私有网络 AI 供应商地址", () => {
     expect(result.requestedUrls).toEqual([]);
   });
 
-  it("受信任本机运行时允许代理 fake-IP 保留网段", async () => {
+  it("受信任本机运行时完全禁用 AI endpoint validator", async () => {
     const result = await testProviderConnection({
       developmentServer: false,
       allowPrivateAiEndpoints: true,
-      trustAiEndpointNetwork: true,
+      disableAiEndpointValidation: true,
       baseUrl: "https://198.18.0.7/v1"
     });
 

--- a/tests/integration/ai-development-endpoint.test.ts
+++ b/tests/integration/ai-development-endpoint.test.ts
@@ -11,6 +11,7 @@ afterEach(async () => {
 async function testProviderConnection(options: {
   developmentServer: boolean;
   allowPrivateAiEndpoints?: boolean;
+  trustAiEndpointNetwork?: boolean;
   baseUrl: string;
 }): Promise<{
   result: Record<string, unknown>;
@@ -35,6 +36,7 @@ async function testProviderConnection(options: {
       allowPrivateAiEndpoints: options.allowPrivateAiEndpoints === true,
       enforceSameOrigin: false
     },
+    trustAiEndpointNetwork: options.trustAiEndpointNetwork === true,
     developmentServer: options.developmentServer
   });
   runtimes.push(runtime);
@@ -117,5 +119,20 @@ describe("私有网络 AI 供应商地址", () => {
     expect(result.result.error).toContain("AI 供应商地址指向受保护的本机、内网或链路本地网络");
     expect(result.result.privateNetworkAllowed).toBeUndefined();
     expect(result.requestedUrls).toEqual([]);
+  });
+
+  it("受信任本机运行时允许代理 fake-IP 保留网段", async () => {
+    const result = await testProviderConnection({
+      developmentServer: false,
+      allowPrivateAiEndpoints: true,
+      trustAiEndpointNetwork: true,
+      baseUrl: "https://198.18.0.7/v1"
+    });
+
+    expect(result.result).toMatchObject({ ok: true, availableModels: ["development-model"] });
+    expect(result.requestedUrls).toEqual([
+      "https://198.18.0.7/v1/models",
+      "https://198.18.0.7/v1/chat/completions"
+    ]);
   });
 });

--- a/tests/integration/offline-sync-api.test.ts
+++ b/tests/integration/offline-sync-api.test.ts
@@ -1,0 +1,556 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRuntime, type Runtime } from "../../src/app.js";
+
+type WebSession = {
+  agent: ReturnType<typeof request.agent>;
+  csrfToken: string;
+  userId: string;
+  username: string;
+};
+
+const setupToken = "offline-sync-test-setup-token-with-at-least-32-characters";
+
+async function solveCaptcha(runtime: Runtime): Promise<{ captchaId: string; captchaAnswer: string }> {
+  const response = await request(runtime.app).get("/api/auth/captcha").expect(200);
+  return {
+    captchaId: String(response.body.data.captchaId),
+    captchaAnswer: String(response.body.data.answer)
+  };
+}
+
+async function register(runtime: Runtime, username: string): Promise<WebSession> {
+  const agent = request.agent(runtime.app);
+  const response = await agent.post("/api/auth/register").send({
+    username,
+    password: "secure-password-123",
+    passwordConfirmation: "secure-password-123",
+    setupToken,
+    ...await solveCaptcha(runtime)
+  }).expect(201);
+  return {
+    agent,
+    csrfToken: String(response.body.data.csrfToken),
+    userId: String(response.body.data.user.userId),
+    username
+  };
+}
+
+async function desktopAuthorization(runtime: Runtime, username: string, profileId: string): Promise<string> {
+  const response = await request(runtime.app).post("/api/desktop/auth/login").send({
+    username,
+    password: "secure-password-123",
+    desktopId: "22222222-2222-4222-8222-222222222222",
+    profileId,
+    clientVersion: "0.8.7",
+    ...await solveCaptcha(runtime)
+  }).expect(200);
+  expect(response.headers["set-cookie"]).toBeUndefined();
+  return `Bearer ${String(response.body.data.token)}`;
+}
+
+async function createOfflineFixture(runtime: Runtime, owner: WebSession) {
+  const workResponse = await owner.agent.post("/api/works")
+    .set("X-CSRF-Token", owner.csrfToken)
+    .send({ title: "离线快照作品", author: "测试作者" })
+    .expect(201);
+  const workId = String(workResponse.body.data.id);
+  const volumeResponse = await owner.agent.post(`/api/works/${workId}/volumes`)
+    .set("X-CSRF-Token", owner.csrfToken)
+    .send({ title: "第一卷" })
+    .expect(201);
+  const volumeId = String(volumeResponse.body.data.id);
+  const chapterResponse = await owner.agent.post(`/api/works/${workId}/chapters`)
+    .set("X-CSRF-Token", owner.csrfToken)
+    .send({ volumeId, title: "第一章", content: "快照旧正文", chapterType: "正文" })
+    .expect(201);
+  const settingResponse = await owner.agent.post(`/api/works/${workId}/settings`)
+    .set("X-CSRF-Token", owner.csrfToken)
+    .send({ title: "星球", category: "地理", content: "快照旧设定" })
+    .expect(201);
+  await owner.agent.patch(`/api/works/${workId}/offline-access`)
+    .set("X-CSRF-Token", owner.csrfToken)
+    .send({ enabled: true })
+    .expect(200);
+  return {
+    workId,
+    volumeId,
+    chapterId: String(chapterResponse.body.data.id),
+    settingId: String(settingResponse.body.data.id)
+  };
+}
+
+describe("Desktop 离线同步快照 API", () => {
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    runtime = createRuntime({
+      databasePath: ":memory:",
+      masterSecret: "offline-sync-test-master-secret-with-enough-length",
+      serveUi: false,
+      revealCaptchaAnswer: true,
+      security: { allowRegistration: true, enforceSameOrigin: true, setupToken }
+    });
+  });
+
+  afterEach(async () => runtime.close());
+
+  it("通过 Desktop Bearer 分页读取一致快照且不依赖 Cookie", async () => {
+    const owner = await register(runtime, "snapshot_owner");
+    const fixture = await createOfflineFixture(runtime, owner);
+    const authorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "11111111-1111-4111-8111-111111111111"
+    );
+
+    const created = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/snapshots`)
+      .set("Authorization", authorization)
+      .send({})
+      .expect(201);
+    expect(created.headers["set-cookie"]).toBeUndefined();
+    expect(created.headers["cache-control"]).toBe("no-store");
+    expect(created.body.data).toMatchObject({
+      workId: fixture.workId,
+      itemCount: 4,
+      syncProtocol: 1,
+      cutoffCursor: expect.any(Number)
+    });
+    expect(created.body.data.cutoffCursor).toBeGreaterThan(0);
+    const snapshotId = String(created.body.data.snapshotId);
+
+    await owner.agent.patch(`/api/chapters/${fixture.chapterId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "第一章已更新", content: "快照后新正文", expectedVersionNo: 1 })
+      .expect(200);
+    await owner.agent.post(`/api/works/${fixture.workId}/settings`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "新设定", category: "地理", content: "快照之后创建" })
+      .expect(201);
+
+    const items: Array<Record<string, unknown>> = [];
+    let after = 0;
+    while (true) {
+      const page = await request(runtime.app)
+        .get(`/api/sync/snapshots/${snapshotId}/items?after=${after}&limit=2`)
+        .set("Authorization", authorization)
+        .expect(200);
+      expect(page.headers["set-cookie"]).toBeUndefined();
+      items.push(...page.body.data.items);
+      if (!page.body.data.hasMore) break;
+      after = Number(page.body.data.nextAfter);
+    }
+    expect(items.map((item) => item.entityType)).toEqual(["work", "volume", "chapter", "setting"]);
+    const chapter = items.find((item) => item.entityType === "chapter")?.data as Record<string, unknown>;
+    const setting = items.find((item) => item.entityType === "setting")?.data as Record<string, unknown>;
+    expect(chapter).toMatchObject({ id: fixture.chapterId, title: "第一章", content: "快照旧正文", versionNo: 1 });
+    expect(setting).toMatchObject({ id: fixture.settingId, content: "快照旧设定", versionNo: 1 });
+    expect(items.some((item) => (item.data as Record<string, unknown>).title === "新设定")).toBe(false);
+
+    await request(runtime.app)
+      .get(`/api/sync/snapshots/${snapshotId}/items?limit=101`)
+      .set("Authorization", authorization)
+      .expect(400);
+    await request(runtime.app).delete(`/api/sync/snapshots/${snapshotId}`)
+      .set("Authorization", authorization)
+      .expect(204);
+    await request(runtime.app).get(`/api/sync/snapshots/${snapshotId}/items`)
+      .set("Authorization", authorization)
+      .expect(404);
+  });
+
+  it("按单调 cursor 返回章节与设定的历史版本变更", async () => {
+    const owner = await register(runtime, "changes_owner");
+    const fixture = await createOfflineFixture(runtime, owner);
+    const authorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "55555555-5555-4555-8555-555555555555"
+    );
+    const snapshot = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/snapshots`)
+      .set("Authorization", authorization)
+      .send({})
+      .expect(201);
+    const cutoffCursor = Number(snapshot.body.data.cutoffCursor);
+
+    const updatedChapter = await owner.agent.patch(`/api/chapters/${fixture.chapterId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ content: "增量新正文", expectedVersionNo: 1 })
+      .expect(200);
+    expect(updatedChapter.body.data.versionNo).toBe(2);
+    await owner.agent.delete(`/api/chapters/${fixture.chapterId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ expectedVersionNo: 2 })
+      .expect(204);
+    await owner.agent.post(`/api/chapters/${fixture.chapterId}/restore`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ versionNo: 2, expectedVersionNo: 3 })
+      .expect(200);
+    await owner.agent.patch(`/api/settings/${fixture.settingId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ content: "增量新设定", expectedVersionNo: 1 })
+      .expect(200);
+    await owner.agent.delete(`/api/settings/${fixture.settingId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ expectedVersionNo: 2 })
+      .expect(204);
+
+    const changes: Array<Record<string, unknown>> = [];
+    let cursor = cutoffCursor;
+    while (true) {
+      const page = await request(runtime.app)
+        .get(`/api/sync/works/${fixture.workId}/changes?after=${cursor}&limit=2`)
+        .set("Authorization", authorization)
+        .expect(200);
+      expect(page.headers["set-cookie"]).toBeUndefined();
+      changes.push(...page.body.data.items);
+      cursor = Number(page.body.data.nextCursor);
+      if (!page.body.data.hasMore) {
+        expect(page.body.data.latestCursor).toBe(cursor);
+        break;
+      }
+    }
+    expect(changes.map((change) => [change.entityType, change.operation, change.versionNo])).toEqual([
+      ["chapter", "upsert", 2],
+      ["chapter", "delete", 3],
+      ["chapter", "upsert", 4],
+      ["setting", "upsert", 2],
+      ["setting", "delete", 3]
+    ]);
+    expect(changes.every((change) => change.changedByUserId === owner.userId)).toBe(true);
+    expect(changes[0]?.data).toMatchObject({ id: fixture.chapterId, content: "增量新正文", versionNo: 2 });
+    expect(changes[1]?.data).toBeNull();
+    expect(changes[2]?.data).toMatchObject({ id: fixture.chapterId, content: "增量新正文", versionNo: 4 });
+    expect(changes[3]?.data).toMatchObject({ id: fixture.settingId, content: "增量新设定", versionNo: 2 });
+    expect(changes[4]?.data).toBeNull();
+    await request(runtime.app)
+      .get(`/api/sync/works/${fixture.workId}/changes?after=-1`)
+      .set("Authorization", authorization)
+      .expect(400);
+  });
+
+  it("逐条事务应用离线变更并幂等重放已存结果", async () => {
+    const owner = await register(runtime, "push_owner");
+    const fixture = await createOfflineFixture(runtime, owner);
+    const authorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "66666666-6666-4666-8666-666666666666"
+    );
+    const snapshot = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/snapshots`)
+      .set("Authorization", authorization)
+      .send({})
+      .expect(201);
+    const cutoffCursor = Number(snapshot.body.data.cutoffCursor);
+    const body = {
+      clientId: "77777777-7777-4777-8777-777777777777",
+      mutations: [
+        {
+          mutationId: "88888888-8888-4888-8888-888888888888",
+          entityType: "chapter",
+          entityId: fixture.chapterId,
+          operation: "update",
+          baseVersionNo: 1,
+          localSnapshot: { title: "Desktop 第一章", content: "Desktop 离线正文", chapterType: "正文" },
+          changeNote: "Desktop 离线修改"
+        },
+        {
+          mutationId: "99999999-9999-4999-8999-999999999999",
+          entityType: "setting",
+          entityId: fixture.settingId,
+          operation: "update",
+          baseVersionNo: 1,
+          localSnapshot: { title: "星球", category: "地理", content: "Desktop 离线设定", status: "confirmed" },
+          changeNote: "Desktop 离线修改"
+        }
+      ]
+    };
+    const pushed = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send(body)
+      .expect(200);
+    expect(pushed.headers["set-cookie"]).toBeUndefined();
+    expect(pushed.body.data.summary).toEqual({ applied: 2, conflict: 0, rejected: 0, replayed: 0 });
+    expect(pushed.body.data.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ mutationId: body.mutations[0]!.mutationId, status: "applied", appliedVersionNo: 2, replayed: false }),
+      expect.objectContaining({ mutationId: body.mutations[1]!.mutationId, status: "applied", appliedVersionNo: 2, replayed: false })
+    ]));
+    expect((await owner.agent.get(`/api/chapters/${fixture.chapterId}`).expect(200)).body.data).toMatchObject({
+      title: "Desktop 第一章",
+      content: "Desktop 离线正文",
+      versionNo: 2
+    });
+    expect((await owner.agent.get(`/api/settings/${fixture.settingId}`).expect(200)).body.data).toMatchObject({
+      content: "Desktop 离线设定",
+      status: "confirmed",
+      versionNo: 2
+    });
+
+    const replayed = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send(body)
+      .expect(200);
+    expect(replayed.body.data.summary).toEqual({ applied: 2, conflict: 0, rejected: 0, replayed: 2 });
+    expect(runtime.database.get("SELECT COUNT(*) AS count FROM sync_mutation_results WHERE work_id = ?", fixture.workId)).toEqual({ count: 2 });
+    expect(runtime.database.get("SELECT COUNT(*) AS count FROM chapter_versions WHERE chapter_id = ?", fixture.chapterId)).toEqual({ count: 2 });
+    expect(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'setting' AND entity_id = ?",
+      fixture.settingId
+    )).toEqual({ count: 2 });
+
+    const stored = await request(runtime.app)
+      .get(`/api/sync/works/${fixture.workId}/mutations/${body.mutations[0]!.mutationId}`)
+      .set("Authorization", authorization)
+      .expect(200);
+    expect(stored.body.data).toMatchObject({ status: "applied", replayed: false, appliedVersionNo: 2 });
+    const changes = await request(runtime.app)
+      .get(`/api/sync/works/${fixture.workId}/changes?after=${cutoffCursor}`)
+      .set("Authorization", authorization)
+      .expect(200);
+    expect(changes.body.data.items.map((change: { entityType: string; versionNo: number }) => [change.entityType, change.versionNo])).toEqual([
+      ["chapter", 2],
+      ["setting", 2]
+    ]);
+
+    const reused = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send({
+        clientId: body.clientId,
+        mutations: [{
+          ...body.mutations[0],
+          localSnapshot: { title: "Desktop 第一章", content: "不同请求", chapterType: "正文" }
+        }]
+      })
+      .expect(409);
+    expect(reused.body.error.code).toBe("MUTATION_ID_REUSED");
+  });
+
+  it("冲突时保留 base local server 且不阻断同批其他变更", async () => {
+    const owner = await register(runtime, "conflict_owner");
+    const fixture = await createOfflineFixture(runtime, owner);
+    const authorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    );
+    await owner.agent.patch(`/api/chapters/${fixture.chapterId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ content: "Server 在线正文", expectedVersionNo: 1 })
+      .expect(200);
+    const body = {
+      clientId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      mutations: [
+        {
+          mutationId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          entityType: "chapter",
+          entityId: fixture.chapterId,
+          operation: "update",
+          baseVersionNo: 1,
+          localSnapshot: { title: "第一章", content: "Desktop 离线正文", chapterType: "正文" },
+          changeNote: "Desktop 离线修改"
+        },
+        {
+          mutationId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          entityType: "setting",
+          entityId: "missing-setting",
+          operation: "update",
+          baseVersionNo: 1,
+          localSnapshot: { title: "不存在", category: "地理", content: "不应写入" },
+          changeNote: "Desktop 离线修改"
+        },
+        {
+          mutationId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+          entityType: "setting",
+          entityId: fixture.settingId,
+          operation: "update",
+          baseVersionNo: 1,
+          localSnapshot: { title: "星球", category: "地理", content: "同批正常设定" },
+          changeNote: "Desktop 离线修改"
+        }
+      ]
+    };
+    const pushed = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send(body)
+      .expect(200);
+    expect(pushed.body.data.summary).toEqual({ applied: 1, conflict: 1, rejected: 1, replayed: 0 });
+    const conflict = pushed.body.data.results[0];
+    expect(conflict).toMatchObject({
+      status: "conflict",
+      errorCode: "VERSION_CONFLICT",
+      baseVersionNo: 1,
+      conflictVersionNo: 2,
+      baseSnapshot: { content: "快照旧正文", versionNo: 1 },
+      localSnapshot: { content: "Desktop 离线正文", versionNo: 1 },
+      serverSnapshot: { content: "Server 在线正文", versionNo: 2 }
+    });
+    expect(pushed.body.data.results[1]).toMatchObject({ status: "rejected", errorCode: "SYNC_ENTITY_NOT_FOUND" });
+    expect(pushed.body.data.results[2]).toMatchObject({ status: "applied", appliedVersionNo: 2 });
+    expect((await owner.agent.get(`/api/chapters/${fixture.chapterId}`).expect(200)).body.data.content).toBe("Server 在线正文");
+    expect((await owner.agent.get(`/api/settings/${fixture.settingId}`).expect(200)).body.data.content).toBe("同批正常设定");
+    expect(runtime.database.get("SELECT COUNT(*) AS count FROM sync_mutation_results WHERE work_id = ?", fixture.workId)).toEqual({ count: 3 });
+
+    const replayed = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send(body)
+      .expect(200);
+    expect(replayed.body.data.summary).toEqual({ applied: 1, conflict: 1, rejected: 1, replayed: 3 });
+  });
+
+  it("在解析后拒绝超过 2500000 bytes 的同步批次", async () => {
+    const owner = await register(runtime, "size_owner");
+    const fixture = await createOfflineFixture(runtime, owner);
+    const authorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    );
+    const oversized = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send({
+        clientId: "01234567-89ab-4def-8123-456789abcdef",
+        mutations: [
+          {
+            mutationId: "10000000-0000-4000-8000-000000000001",
+            entityType: "chapter",
+            entityId: fixture.chapterId,
+            operation: "update",
+            baseVersionNo: 1,
+            localSnapshot: { title: "第一章", content: "a".repeat(1_300_000), chapterType: "正文" },
+            changeNote: "Desktop 离线修改"
+          },
+          {
+            mutationId: "10000000-0000-4000-8000-000000000002",
+            entityType: "chapter",
+            entityId: fixture.chapterId,
+            operation: "update",
+            baseVersionNo: 1,
+            localSnapshot: { title: "第一章", content: "b".repeat(1_300_000), chapterType: "正文" },
+            changeNote: "Desktop 离线修改"
+          }
+        ]
+      })
+      .expect(413);
+    expect(oversized.body.error.code).toBe("SYNC_PUSH_TOO_LARGE");
+    expect(runtime.database.get("SELECT COUNT(*) AS count FROM sync_mutation_results WHERE work_id = ?", fixture.workId)).toEqual({ count: 0 });
+
+    const tooMany = Array.from({ length: 21 }, (_, index) => ({
+      mutationId: `20000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      entityType: "chapter",
+      entityId: fixture.chapterId,
+      operation: "update",
+      baseVersionNo: 1,
+      localSnapshot: { title: `标题 ${index}`, content: "快照旧正文", chapterType: "正文" },
+      changeNote: "Desktop 离线修改"
+    }));
+    await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send({ clientId: "01234567-89ab-4def-8123-456789abcdef", mutations: tooMany })
+      .expect(400);
+    await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", authorization)
+      .send({ clientId: "01234567-89ab-4def-8123-456789abcdef", mutations: [tooMany[0], tooMany[0]] })
+      .expect(400);
+  });
+
+  it("要求模块写权限并隔离不同用户的 mutation 结果", async () => {
+    const owner = await register(runtime, "result_owner");
+    const viewer = await register(runtime, "result_viewer");
+    const fixture = await createOfflineFixture(runtime, owner);
+    await owner.agent.post(`/api/works/${fixture.workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ userId: viewer.userId, role: "viewer" })
+      .expect(201);
+    const ownerAuthorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "30000000-0000-4000-8000-000000000001"
+    );
+    const viewerAuthorization = await desktopAuthorization(
+      runtime,
+      viewer.username,
+      "30000000-0000-4000-8000-000000000002"
+    );
+    const mutation = {
+      mutationId: "30000000-0000-4000-8000-000000000003",
+      entityType: "chapter",
+      entityId: fixture.chapterId,
+      operation: "update",
+      baseVersionNo: 1,
+      localSnapshot: { title: "第一章", content: "仅所有者可写", chapterType: "正文" },
+      changeNote: "Desktop 离线修改"
+    };
+    const viewerDenied = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", viewerAuthorization)
+      .send({ clientId: "30000000-0000-4000-8000-000000000004", mutations: [mutation] })
+      .expect(403);
+    expect(viewerDenied.body.error.code).toBe("WORK_EDIT_DENIED");
+    const csrfDenied = await owner.agent.post(`/api/sync/works/${fixture.workId}/push`)
+      .send({ clientId: "30000000-0000-4000-8000-000000000004", mutations: [mutation] })
+      .expect(403);
+    expect(csrfDenied.body.error.code).toBe("CSRF_TOKEN_INVALID");
+
+    await request(runtime.app).post(`/api/sync/works/${fixture.workId}/push`)
+      .set("Authorization", ownerAuthorization)
+      .send({ clientId: "30000000-0000-4000-8000-000000000004", mutations: [mutation] })
+      .expect(200);
+    const privateResult = await request(runtime.app)
+      .get(`/api/sync/works/${fixture.workId}/mutations/${mutation.mutationId}`)
+      .set("Authorization", viewerAuthorization)
+      .expect(404);
+    expect(privateResult.body.error.code).toBe("SYNC_MUTATION_NOT_FOUND");
+  });
+
+  it("在离线授权或作品权限撤销后立即停止快照访问", async () => {
+    const owner = await register(runtime, "permission_owner");
+    const collaborator = await register(runtime, "permission_collaborator");
+    const fixture = await createOfflineFixture(runtime, owner);
+    await owner.agent.post(`/api/works/${fixture.workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ userId: collaborator.userId, role: "editor" })
+      .expect(201);
+    const collaboratorAuthorization = await desktopAuthorization(
+      runtime,
+      collaborator.username,
+      "33333333-3333-4333-8333-333333333333"
+    );
+    const snapshot = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/snapshots`)
+      .set("Authorization", collaboratorAuthorization)
+      .send({})
+      .expect(201);
+    const snapshotId = String(snapshot.body.data.snapshotId);
+
+    await owner.agent.delete(`/api/works/${fixture.workId}/members/${collaborator.userId}`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .expect(200);
+    const revoked = await request(runtime.app).get(`/api/sync/snapshots/${snapshotId}/items`)
+      .set("Authorization", collaboratorAuthorization)
+      .expect(403);
+    expect(revoked.body.error.code).toBe("WORK_ACCESS_DENIED");
+
+    await owner.agent.patch(`/api/works/${fixture.workId}/offline-access`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ enabled: false })
+      .expect(200);
+    const ownerAuthorization = await desktopAuthorization(
+      runtime,
+      owner.username,
+      "44444444-4444-4444-8444-444444444444"
+    );
+    const disabled = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/snapshots`)
+      .set("Authorization", ownerAuthorization)
+      .send({})
+      .expect(403);
+    expect(disabled.body.error.code).toBe("OFFLINE_ACCESS_DISABLED");
+
+    const apiKey = await owner.agent.post("/api/auth/api-key/reset")
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({})
+      .expect(200);
+    const apiKeyDenied = await request(runtime.app).post(`/api/sync/works/${fixture.workId}/snapshots`)
+      .set("Authorization", `Bearer ${String(apiKey.body.data.apiKey)}`)
+      .send({})
+      .expect(403);
+    expect(apiKeyDenied.body.error.code).toBe("CLI_SCOPE_DENIED");
+  });
+});

--- a/tests/integration/server-runtime.test.ts
+++ b/tests/integration/server-runtime.test.ts
@@ -112,6 +112,33 @@ describe("本地服务运行时", () => {
     }
   });
 
+  it("端口监听失败时先完整关闭运行时再返回错误", async () => {
+    const occupiedRoot = mkdtempSync(join(tmpdir(), "scriverse-occupied-port-owner-"));
+    const retryRoot = mkdtempSync(join(tmpdir(), "scriverse-occupied-port-retry-"));
+    roots.push(occupiedRoot, retryRoot);
+    const occupied = await startLocalServer({
+      host: "127.0.0.1",
+      port: 0,
+      dataDirectory: occupiedRoot,
+      databasePath: join(occupiedRoot, "novel.db"),
+      env: { NODE_ENV: "test" }
+    });
+    runningServers.push(occupied);
+    const infoSpy = vi.spyOn(logger, "info");
+    try {
+      await expect(startLocalServer({
+        host: "127.0.0.1",
+        port: occupied.port,
+        dataDirectory: retryRoot,
+        databasePath: join(retryRoot, "novel.db"),
+        env: { NODE_ENV: "test" }
+      })).rejects.toMatchObject({ code: "EADDRINUSE" });
+      expect(infoSpy).toHaveBeenCalledWith("database.closed");
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
   it("仅在非生产环境显式开启时允许开发免登录", () => {
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "true" }, false)).toBe(true);
     expect(isDevelopmentAuthBypassEnabled({ NODE_ENV: "development", APP_DEV_SKIP_AUTH: "1" }, false)).toBe(true);

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -62,6 +62,23 @@ async function submitLogin(runtime: Runtime, username: string, password: string)
   return request(runtime.app).post("/api/auth/login").send({ username, password, ...captcha });
 }
 
+async function submitDesktopLogin(
+  runtime: Runtime,
+  username: string,
+  password: string,
+  profileId = "11111111-1111-4111-8111-111111111111"
+) {
+  const captcha = await solveCaptcha(runtime.app);
+  return request(runtime.app).post("/api/desktop/auth/login").send({
+    username,
+    password,
+    desktopId: "22222222-2222-4222-8222-222222222222",
+    profileId,
+    clientVersion: "0.8.7",
+    ...captcha
+  });
+}
+
 function createUserAuthTestRuntime(allowRegistration = true): Runtime {
   const runtime = createRuntime({
     databasePath: ":memory:",
@@ -807,7 +824,111 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(otherSession.body.data.user.onboardingCompleted).toBe(false);
   });
 
-  it("服务器重启后使旧网页会话失效并要求重新登录", async () => {
+  it("Desktop 登录签发非 Cookie Bearer 会话并保留完整交互权限", async () => {
+    const registered = await register(runtime, "desktop_bearer_user");
+    const login = await submitDesktopLogin(runtime, registered.user.username, "secure-password-123");
+    expect(login.status).toBe(200);
+    expect(login.headers["set-cookie"]).toBeUndefined();
+    expect(login.headers["cache-control"]).toBe("no-store");
+    expect(login.body.data).toMatchObject({
+      token: expect.stringMatching(/^scrvd_[A-Za-z0-9_-]{43}$/u),
+      expiresAt: expect.any(String),
+      user: { userId: registered.user.userId }
+    });
+    const authorization = `Bearer ${String(login.body.data.token)}`;
+    const session = await request(runtime.app)
+      .get("/api/auth/session")
+      .set("Authorization", authorization)
+      .expect(200);
+    expect(session.body.data).toMatchObject({
+      authenticated: true,
+      csrfToken: null,
+      user: { userId: registered.user.userId }
+    });
+
+    const work = await request(runtime.app)
+      .post("/api/works")
+      .set("Authorization", authorization)
+      .send({ title: "Desktop Bearer 作品" })
+      .expect(201);
+    expect(work.body.data.title).toBe("Desktop Bearer 作品");
+    expect(runtime.database.get(
+      "SELECT token_hash = ? AS leaked, desktop_id, profile_id, client_version FROM user_desktop_sessions WHERE user_id = ?",
+      login.body.data.token,
+      registered.user.userId
+    )).toEqual({
+      leaked: 0,
+      desktop_id: "22222222-2222-4222-8222-222222222222",
+      profile_id: "11111111-1111-4111-8111-111111111111",
+      client_version: "0.8.7"
+    });
+
+    await request(runtime.app)
+      .delete("/api/auth/session")
+      .set("Authorization", authorization)
+      .expect(204)
+      .expect((response) => {
+        expect(response.headers["set-cookie"]).toBeUndefined();
+      });
+    const revoked = await request(runtime.app)
+      .get("/api/works")
+      .set("Authorization", authorization)
+      .expect(401);
+    expect(revoked.body.error.code).toBe("DESKTOP_SESSION_INVALID");
+  });
+
+  it("仅允许作品所有者通过网页或 Desktop 会话管理离线访问", async () => {
+    const owner = await register(runtime, "offline_owner");
+    const collaborator = await register(runtime, "offline_collaborator");
+    const work = await owner.agent.post("/api/works")
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ title: "离线授权作品" })
+      .expect(201);
+    const workId = String(work.body.data.id);
+    expect(work.body.data.offlineAccessEnabled).toBe(false);
+    await owner.agent.post(`/api/works/${workId}/members`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ userId: collaborator.user.userId, role: "editor" })
+      .expect(201);
+
+    const csrfDenied = await owner.agent.patch(`/api/works/${workId}/offline-access`)
+      .send({ enabled: true })
+      .expect(403);
+    expect(csrfDenied.body.error.code).toBe("CSRF_TOKEN_INVALID");
+    const collaboratorDenied = await collaborator.agent.patch(`/api/works/${workId}/offline-access`)
+      .set("X-CSRF-Token", collaborator.csrfToken)
+      .send({ enabled: true })
+      .expect(403);
+    expect(collaboratorDenied.body.error.code).toBe("WORK_OWNER_REQUIRED");
+
+    const enabled = await owner.agent.patch(`/api/works/${workId}/offline-access`)
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({ enabled: true })
+      .expect(200);
+    expect(enabled.body.data).toMatchObject({ id: workId, offlineAccessEnabled: true });
+    expect(runtime.database.get("SELECT offline_access_enabled FROM works WHERE id = ?", workId)).toEqual({ offline_access_enabled: 1 });
+
+    const apiKeyReset = await owner.agent.post("/api/auth/api-key/reset")
+      .set("X-CSRF-Token", owner.csrfToken)
+      .send({})
+      .expect(200);
+    const apiKeyDenied = await request(runtime.app).patch(`/api/works/${workId}/offline-access`)
+      .set("Authorization", `Bearer ${String(apiKeyReset.body.data.apiKey)}`)
+      .send({ enabled: false })
+      .expect(403);
+    expect(apiKeyDenied.body.error.code).toBe("CLI_SCOPE_DENIED");
+
+    const desktopLogin = await submitDesktopLogin(runtime, owner.user.username, "secure-password-123");
+    expect(desktopLogin.status).toBe(200);
+    const desktopDisabled = await request(runtime.app).patch(`/api/works/${workId}/offline-access`)
+      .set("Authorization", `Bearer ${String(desktopLogin.body.data.token)}`)
+      .send({ enabled: false })
+      .expect(200);
+    expect(desktopDisabled.headers["set-cookie"]).toBeUndefined();
+    expect(desktopDisabled.body.data.offlineAccessEnabled).toBe(false);
+  });
+
+  it("服务器重启后使旧网页会话失效但保留 Desktop 会话", async () => {
     const root = mkdtempSync(join(tmpdir(), "ai-novel-auth-restart-"));
     const databasePath = join(root, "novel.db");
     let firstRuntime: Runtime | null = null;
@@ -822,6 +943,9 @@ describe("用户、作品权限与操作者追踪 API", () => {
       });
       const user = await register(firstRuntime, "restart_user");
       await user.agent.get("/api/auth/session").expect(200);
+      const desktopLogin = await submitDesktopLogin(firstRuntime, "restart_user", "secure-password-123");
+      expect(desktopLogin.status).toBe(200);
+      const desktopAuthorization = `Bearer ${String(desktopLogin.body.data.token)}`;
       await firstRuntime.close();
       firstRuntime = null;
 
@@ -838,6 +962,15 @@ describe("用户、作品权限与操作者追踪 API", () => {
         .expect(200);
       expect(expiredSession.body.data).toMatchObject({ authenticated: false, user: null, csrfToken: null });
       await request(restartedRuntime.app).get("/api/works").set("Cookie", user.cookie).expect(401);
+      const persistentDesktopSession = await request(restartedRuntime.app)
+        .get("/api/auth/session")
+        .set("Authorization", desktopAuthorization)
+        .expect(200);
+      expect(persistentDesktopSession.body.data).toMatchObject({
+        authenticated: true,
+        csrfToken: null,
+        user: { userId: user.user.userId }
+      });
 
       const captcha = await solveCaptcha(restartedRuntime.app);
       await request(restartedRuntime.app).post("/api/auth/login").send({
@@ -3332,6 +3465,8 @@ describe("用户、作品权限与操作者追踪 API", () => {
   it("管理员可管理账户，但不能停用自己或移除最后一名管理员", async () => {
     const admin = await register(runtime, "root_admin");
     const writer = await register(runtime, "normal_writer");
+    const writerDesktopLogin = await submitDesktopLogin(runtime, "normal_writer", "secure-password-123");
+    expect(writerDesktopLogin.status).toBe(200);
     await admin.agent.patch(`/api/users/${admin.user.userId}`).set("X-CSRF-Token", admin.csrfToken).send({ role: "user" }).expect(409);
     const promoted = await admin.agent.patch(`/api/users/${writer.user.userId}`).set("X-CSRF-Token", admin.csrfToken).send({ role: "admin" }).expect(200);
     expect(promoted.body.data.role).toBe("admin");
@@ -3339,6 +3474,10 @@ describe("用户、作品权限与操作者追踪 API", () => {
     expect(disabled.body.data.status).toBe("disabled");
     expect(runtime.database.get(
       "SELECT COUNT(*) AS count FROM user_sessions WHERE user_id = ? AND revoked_at IS NULL",
+      writer.user.userId
+    )).toEqual({ count: 0 });
+    expect(runtime.database.get(
+      "SELECT COUNT(*) AS count FROM user_desktop_sessions WHERE user_id = ? AND revoked_at IS NULL",
       writer.user.userId
     )).toEqual({ count: 0 });
     await writer.agent.get("/api/works").expect(401);

--- a/tests/integration/work-chapter-api.test.ts
+++ b/tests/integration/work-chapter-api.test.ts
@@ -540,28 +540,29 @@ describe("作品、导入和章节版本 API", () => {
       chapters: movedSelection,
       action: { type: "setType", chapterType: "设定" }
     }).expect(200);
+    const typedSelection = selected.map((chapter) => ({ ...chapter, expectedVersionNo: 3 }));
     await request(runtime.app).post(`/api/works/${work.body.data.id}/chapters/batch`).send({
-      chapters: movedSelection,
+      chapters: typedSelection,
       action: { type: "setAnalysisExclusion", excludedFromAnalysis: true }
     }).expect(200);
 
     const updated = await request(runtime.app).get(`/api/chapters/${first.body.data.id}`).expect(200);
-    expect(updated.body.data).toMatchObject({ chapterType: "设定", excludedFromAnalysis: true, versionNo: 2 });
+    expect(updated.body.data).toMatchObject({ chapterType: "设定", excludedFromAnalysis: true, versionNo: 3 });
 
     const conflict = await request(runtime.app).post(`/api/works/${work.body.data.id}/chapters/batch`).send({
-      chapters: [{ id: first.body.data.id, expectedVersionNo: 2 }, { id: second.body.data.id, expectedVersionNo: 99 }],
+      chapters: [{ id: first.body.data.id, expectedVersionNo: 3 }, { id: second.body.data.id, expectedVersionNo: 99 }],
       action: { type: "delete" }
     }).expect(409);
     expect(conflict.body.error.code).toBe("VERSION_CONFLICT");
     await request(runtime.app).get(`/api/chapters/${first.body.data.id}`).expect(200);
 
     await request(runtime.app).post(`/api/works/${work.body.data.id}/chapters/batch`).send({
-      chapters: movedSelection,
+      chapters: typedSelection,
       action: { type: "delete" }
     }).expect(200, { data: { processed: 2, action: "delete" } });
     await request(runtime.app).get(`/api/chapters/${first.body.data.id}`).expect(404);
     const versions = await request(runtime.app).get(`/api/chapters/${first.body.data.id}/versions`).expect(200);
-    expect(versions.body.data[0]).toMatchObject({ versionNo: 3, content: "第一章正文", source: "delete" });
+    expect(versions.body.data[0]).toMatchObject({ versionNo: 4, content: "第一章正文", source: "delete" });
     expect(runtime.database.get(
       "SELECT COUNT(*) AS count FROM analysis_tasks WHERE work_id = ? AND status = 'pending'",
       work.body.data.id
@@ -731,7 +732,7 @@ describe("作品、导入和章节版本 API", () => {
     expect(tree.body.data.volumes[0]).toMatchObject({ description: "间谍身份开始暴露。", keywords: ["身份暴露", "阵营冲突"], storyOrder: 3 });
   });
 
-  it("支持四种章节类型且只修改类型时不增加正文版本", async () => {
+  it("支持四种章节类型且只修改类型时仍记录新版本", async () => {
     const work = await request(runtime.app).post("/api/works").send({ title: "章节类型作品" }).expect(201);
     const volume = await request(runtime.app).post(`/api/works/${work.body.data.id}/volumes`).send({ title: "正文" }).expect(201);
     const chapter = await request(runtime.app).post(`/api/works/${work.body.data.id}/chapters`).send({
@@ -743,7 +744,9 @@ describe("作品、导入和章节版本 API", () => {
     expect(chapter.body.data).toMatchObject({ chapterType: "设定", versionNo: 1 });
 
     const marked = await request(runtime.app).patch(`/api/chapters/${chapter.body.data.id}`).send({ chapterType: "作者的话" }).expect(200);
-    expect(marked.body.data).toMatchObject({ chapterType: "作者的话", versionNo: 1, analysisStatus: "expired" });
+    expect(marked.body.data).toMatchObject({ chapterType: "作者的话", versionNo: 2, analysisStatus: "expired" });
+    const versions = await request(runtime.app).get(`/api/chapters/${chapter.body.data.id}/versions`).expect(200);
+    expect(versions.body.data[0]).toMatchObject({ versionNo: 2, chapterType: "作者的话", source: "manual" });
     await request(runtime.app).patch(`/api/chapters/${chapter.body.data.id}`).send({ chapterType: "无效类型" }).expect(400);
 
     const exported = await request(runtime.app).get(`/api/works/${work.body.data.id}/export?format=json`).expect(200);

--- a/tests/system/desktop-health-contract.test.ts
+++ b/tests/system/desktop-health-contract.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRuntime, type Runtime } from "../../src/app.js";
+import {
+  DESKTOP_MINIMUM_VERSION,
+  DESKTOP_PRODUCT_ID,
+  DESKTOP_SHELL_PROTOCOL,
+  DESKTOP_SYNC_PROTOCOL
+} from "../../src/desktop-protocol.js";
+import { APP_VERSION } from "../../src/version.js";
+
+describe("Desktop Server 兼容元数据", () => {
+  let runtime: Runtime | null = null;
+
+  afterEach(() => runtime?.close());
+
+  it("在 health 中发布稳定 shell 与 sync 协议范围", async () => {
+    runtime = createRuntime({
+      databasePath: ":memory:",
+      masterSecret: "desktop-health-contract-test-secret-with-enough-length",
+      serveUi: false,
+      disableUserAuth: true
+    });
+    const health = await request(runtime.app).get("/api/health").expect(200);
+    expect(health.body.data).toMatchObject({
+      product: DESKTOP_PRODUCT_ID,
+      serverVersion: APP_VERSION,
+      webAssetVersion: APP_VERSION,
+      shellProtocol: DESKTOP_SHELL_PROTOCOL,
+      minimumDesktopVersion: DESKTOP_MINIMUM_VERSION,
+      syncProtocol: DESKTOP_SYNC_PROTOCOL
+    });
+    expect(health.body.data.syncProtocol.entityTypes).toEqual(["chapter", "setting"]);
+    expect(health.body.data.syncProtocol.maxMutationBytes).toBe(2_500_000);
+    expect(health.body.data.minimumDesktopVersion).toBe("0.0.1");
+  });
+});

--- a/tests/unit/database-migration.test.ts
+++ b/tests/unit/database-migration.test.ts
@@ -88,6 +88,45 @@ describe("数据库版本化迁移", () => {
     expect(first.all("PRAGMA index_list(drafts)").some((index) => index.name === "idx_drafts_favorite")).toBe(true);
     expect(first.all("PRAGMA index_list(settings)").some((index) => index.name === "idx_settings_favorite")).toBe(true);
     expect(first.all("PRAGMA index_list(organizations)").some((index) => index.name === "idx_organizations_favorite")).toBe(true);
+    expect(first.all("PRAGMA table_info(user_desktop_sessions)").map((column) => column.name)).toEqual(expect.arrayContaining([
+      "id",
+      "user_id",
+      "token_hash",
+      "desktop_id",
+      "profile_id",
+      "client_version",
+      "expires_at",
+      "revoked_at"
+    ]));
+    expect(first.all("PRAGMA index_list(user_desktop_sessions)").map((index) => index.name)).toEqual(expect.arrayContaining([
+      "idx_user_desktop_sessions_token",
+      "idx_user_desktop_sessions_user",
+      "idx_user_desktop_sessions_active_profile"
+    ]));
+    expect(first.get("SELECT offline_access_enabled FROM works WHERE id = 'work-old'")).toEqual({ offline_access_enabled: 0 });
+    expect(first.all("PRAGMA table_info(sync_changes)").map((column) => column.name)).toEqual(expect.arrayContaining([
+      "cursor",
+      "work_id",
+      "entity_type",
+      "entity_id",
+      "operation",
+      "version_no",
+      "changed_by_user_id",
+      "changed_at"
+    ]));
+    expect(first.all("PRAGMA table_info(sync_mutation_results)").map((column) => column.name)).toEqual(expect.arrayContaining([
+      "mutation_id",
+      "client_id",
+      "user_id",
+      "work_id",
+      "request_hash",
+      "status",
+      "result_json"
+    ]));
+    expect(first.all("PRAGMA index_list(sync_changes)").map((index) => index.name)).toEqual(expect.arrayContaining([
+      "idx_sync_changes_work_cursor",
+      "idx_sync_changes_entity"
+    ]));
     expect(first.all("PRAGMA table_info(s3_backup_targets)").map((column) => column.name)).toEqual(expect.arrayContaining([
       "id",
       "endpoint",

--- a/tests/unit/offline-sync.test.ts
+++ b/tests/unit/offline-sync.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Database } from "../../src/database.js";
+import { AppError } from "../../src/errors.js";
+import { OfflineSyncService } from "../../src/offline-sync.js";
+import { Store } from "../../src/store.js";
+
+function expectAppError(operation: () => unknown, code: string, status: number): void {
+  let caught: unknown;
+  try {
+    operation();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(AppError);
+  expect(caught).toMatchObject({ code, status });
+}
+
+describe("离线同步快照", () => {
+  let database: Database | null = null;
+
+  afterEach(() => {
+    database?.close();
+    database = null;
+  });
+
+  it("过期后不再允许读取且不将快照分配给其他用户", () => {
+    database = new Database(":memory:");
+    const store = new Store(database);
+    const work = store.createWork({ title: "过期快照作品" });
+    store.setWorkOfflineAccess(String(work.id), true);
+    let timestamp = Date.parse("2026-08-23T00:00:00.000Z");
+    const sync = new OfflineSyncService(database, store, {
+      now: () => timestamp,
+      snapshotTtlMs: 1_000
+    });
+    const snapshot = sync.createSnapshot(String(work.id), "user-a");
+
+    expectAppError(() => sync.describeOwnedSnapshot(snapshot.snapshotId, "user-b"), "SYNC_SNAPSHOT_NOT_FOUND", 404);
+    timestamp += 1_000;
+    expectAppError(() => sync.readSnapshotPage(snapshot.snapshotId, "user-a", 0, 100), "SYNC_SNAPSHOT_EXPIRED", 410);
+    expectAppError(() => sync.describeOwnedSnapshot(snapshot.snapshotId, "user-a"), "SYNC_SNAPSHOT_NOT_FOUND", 404);
+  });
+});

--- a/tests/unit/safe-ai-fetch.test.ts
+++ b/tests/unit/safe-ai-fetch.test.ts
@@ -28,6 +28,12 @@ describe("assertSafeAiEndpoint", () => {
     });
   });
 
+  it("受信任本机运行时允许代理 fake-IP 保留网段", async () => {
+    await expect(assertSafeAiEndpoint("https://198.18.0.1/v1", true, true)).resolves.toEqual([
+      { address: "198.18.0.1", family: 4 }
+    ]);
+  });
+
   it("识别本机与内网供应商地址", async () => {
     await expect(aiEndpointUsesPrivateNetwork("http://127.0.0.1:11434/v1")).resolves.toBe(true);
     await expect(aiEndpointUsesPrivateNetwork("https://192.168.1.10/v1")).resolves.toBe(true);

--- a/tests/unit/safe-ai-fetch.test.ts
+++ b/tests/unit/safe-ai-fetch.test.ts
@@ -28,12 +28,6 @@ describe("assertSafeAiEndpoint", () => {
     });
   });
 
-  it("受信任本机运行时允许代理 fake-IP 保留网段", async () => {
-    await expect(assertSafeAiEndpoint("https://198.18.0.1/v1", true, true)).resolves.toEqual([
-      { address: "198.18.0.1", family: 4 }
-    ]);
-  });
-
   it("识别本机与内网供应商地址", async () => {
     await expect(aiEndpointUsesPrivateNetwork("http://127.0.0.1:11434/v1")).resolves.toBe(true);
     await expect(aiEndpointUsesPrivateNetwork("https://192.168.1.10/v1")).resolves.toBe(true);

--- a/tests/unit/security-rate-limit.test.ts
+++ b/tests/unit/security-rate-limit.test.ts
@@ -110,6 +110,9 @@ describe("安全限速器", () => {
     await authAgent.post("/api/auth/login").expect(200);
     const blockedLogin = await authAgent.post("/API/AUTH/LOGIN").expect(429);
     expect(blockedLogin.body.error.code).toBe("AUTH_RATE_LIMITED");
+    await authAgent.post("/api/desktop/auth/login").expect(200);
+    const blockedDesktopLogin = await authAgent.post("/API/DESKTOP/AUTH/LOGIN").expect(429);
+    expect(blockedDesktopLogin.body.error.code).toBe("AUTH_RATE_LIMITED");
   });
 });
 

--- a/tests/unit/storage-manifest.test.ts
+++ b/tests/unit/storage-manifest.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { Database } from "../../src/database.js";
+import {
+  claimServerDataDirectory,
+  SERVER_STORAGE_KIND,
+  STORAGE_MANIFEST_FILENAME,
+  StorageManifestError
+} from "../../src/storage-manifest.js";
+
+function testDirectory(label: string): string {
+  return join(tmpdir(), `scriverse-storage-manifest-${label}-${process.pid}-${crypto.randomUUID()}`);
+}
+
+describe("Server 存储清单", () => {
+  it("为全新数据目录写入稳定的 Server 标识", () => {
+    const root = testDirectory("fresh");
+    const first = claimServerDataDirectory(root, join(root, "novel.db"));
+    const second = claimServerDataDirectory(root, join(root, "novel.db"));
+    expect(first).toEqual(second);
+    expect(first.kind).toBe(SERVER_STORAGE_KIND);
+    expect(existsSync(join(root, STORAGE_MANIFEST_FILENAME))).toBe(true);
+    if (process.platform !== "win32") {
+      expect((readFileSync(join(root, STORAGE_MANIFEST_FILENAME)).byteLength)).toBeGreaterThan(0);
+    }
+  });
+
+  it("只认领可验证的既有 Scriverse 数据库", () => {
+    const validRoot = testDirectory("valid-existing");
+    mkdirSync(validRoot, { recursive: true });
+    const database = new Database(join(validRoot, "novel.db"));
+    database.close();
+    expect(claimServerDataDirectory(validRoot, join(validRoot, "novel.db")).kind).toBe(SERVER_STORAGE_KIND);
+
+    const unknownRoot = testDirectory("unknown-existing");
+    mkdirSync(unknownRoot, { recursive: true });
+    const unknown = new DatabaseSync(join(unknownRoot, "novel.db"));
+    unknown.exec("CREATE TABLE unrelated (id INTEGER PRIMARY KEY)");
+    unknown.close();
+    expect(() => claimServerDataDirectory(unknownRoot, join(unknownRoot, "novel.db"))).toThrowError(StorageManifestError);
+  });
+
+  it("拒绝 Desktop 清单和未认领的非空目录", () => {
+    const desktopRoot = testDirectory("desktop-kind");
+    mkdirSync(desktopRoot, { recursive: true });
+    writeFileSync(join(desktopRoot, STORAGE_MANIFEST_FILENAME), JSON.stringify({
+      kind: "scriverse-desktop-local-vault",
+      storageVersion: 1,
+      desktopId: crypto.randomUUID(),
+      createdAt: new Date().toISOString()
+    }));
+    expect(() => claimServerDataDirectory(desktopRoot, join(desktopRoot, "novel.db"))).toThrowError(/不属于 Scriverse Server/u);
+
+    const nonemptyRoot = testDirectory("nonempty");
+    mkdirSync(nonemptyRoot, { recursive: true });
+    writeFileSync(join(nonemptyRoot, "master.key"), "not-a-real-key");
+    expect(() => claimServerDataDirectory(nonemptyRoot, join(nonemptyRoot, "novel.db"))).toThrowError(/非空目录/u);
+  });
+});


### PR DESCRIPTION
## 变更

- 增加软件内 Desktop Bearer 登录与系统安全存储所需的持久会话后端
- 增加离线授权、快照、变更游标、幂等写入与冲突返回协议
- 增加 Desktop 本地 AI 的 Server Prompt/作品上下文准备接口
- 在健康检查中发布 Server、Shell 与 Sync 协议兼容元数据
- 增加数据目录存储清单与迁移保护
- 端口监听失败时先完整关闭运行时，供 Desktop 安全探测下一个本地端口
- 为受信任的本机嵌入运行时提供进程内开关，完全不安装 AI endpoint validator；线上 Server 默认 SSRF 策略不变

## 仓库边界

本 PR 只包含 Scriverse Server API、数据库、认证与后端测试；不包含 Electron、clients/desktop、Forge、Desktop 打包工作流或 src/public 前端改动。

## CLI 审计

现有 CLI 只读取 /api/health 的 status，新增字段向后兼容；新增路由均为 Desktop 专用协议，不改变现有 CLI 命令和请求响应契约，因此无需同步 CLI。

## 验证

- Desktop Server 相关测试：9 files / 227 tests passed
- AI 地址禁用校验回归：2 files / 19 tests passed
- 全量测试：230 files / 1184 tests passed
- npm run typecheck
- npm run build
- opencode.ai 实际回归：本地模式不执行 validator，请求到达上游并返回 401 Invalid API key，而非本地网络误判