### PR TITLE
fix(ai): run Desktop local models through Server tools

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -94,7 +94,7 @@ import {
 } from "./hybrid-search.js";
 import { logger, sanitizeError } from "./logger.js";
 import { paginated, paginationSql, type PaginatedResult, type Pagination } from "./pagination.js";
-import { currentRequestActor } from "./request-context.js";
+import { currentRequestActor, runWithRequestActor, type RequestActor } from "./request-context.js";
 import { aiEndpointUsesPrivateNetwork, fetchSafeAiEndpoint } from "./security.js";
 import { defaultAiConversationTitle, normalizeCharacterName, Store, type AiConversationContext, type AiConversationTitleContext } from "./store.js";
 import {
@@ -424,6 +424,8 @@ type GenerateInput = {
   imageAttachments?: ChatImageAttachment[];
   conversationImageAttachments?: ReadonlyMap<string, ChatImageAttachment[]>;
   sceneDirection?: string;
+  runtime?: DesktopLocalAiGenerateRuntime;
+  onPrepared?: (contextUsage: Record<string, unknown>) => void;
 };
 
 type GenerateResult = {
@@ -441,22 +443,98 @@ type GenerateResult = {
   contextUsage: Record<string, unknown>;
 };
 
-export type DesktopLocalAiPreparationInput = {
+export type DesktopLocalAiRuntimeModelInput = {
+  id: string;
+  providerId: string;
+  providerName: string;
+  protocol: "openai-chat-completions";
+  maxTokensParameter: MaxTokensParameter;
+  thinkingType: AiThinkingType;
+  concurrencyLimit: number;
+  rpmLimit: number;
+  analysisTimeoutSeconds: number;
+  displayName: string;
+  modelId: string;
+  purposes: TaskType[];
+  contextNote: string;
+  contextWindow: number;
+  outputNote: string;
+  preset: {
+    temperature: number;
+    max_tokens: number;
+  };
+  thinkingEnabled: boolean;
+  thinkingEffort: string;
+  multimodalEnabled: boolean;
+  note: string;
+};
+
+export type DesktopLocalAiRunInput = {
   workId: string;
   taskType: "chat" | "continue" | "polish";
   instruction: string;
   scope: ContextScope;
-  contextWindow: number;
-  maxOutputTokens: number;
+  runtimeModel: DesktopLocalAiRuntimeModelInput;
   conversationId?: string;
   excludeConversationMessageId?: string;
+  imageAttachmentIds?: string[];
+  sceneDirection?: string;
 };
 
-export type DesktopLocalAiPreparationResult = {
-  remoteSystemPrompt: string;
-  messages: Array<{ role: "user" | "assistant"; content: string }>;
-  contextUsage: Record<string, unknown>;
+export type DesktopLocalAiCompletionResponseInput = {
+  requestId: string;
+  status: number;
+  body: string;
+  retryAfter?: string;
 };
+
+type DesktopLocalAiCompletionTransportRequest = {
+  requestId: string;
+  localModelId: string;
+  taskType: TaskType;
+  purpose: "generation" | "tool-context-compaction";
+  body: Record<string, unknown>;
+  timeoutMs: number;
+};
+
+type DesktopLocalAiCompletionTransportResponse = {
+  status: number;
+  body: string;
+  retryAfter: string | null;
+};
+
+type DesktopLocalAiGenerateRuntime = {
+  provider: ProviderRow;
+  model: ModelRow;
+  localModelId: string;
+  completionTransport: (request: DesktopLocalAiCompletionTransportRequest) => Promise<DesktopLocalAiCompletionTransportResponse>;
+};
+
+type DesktopLocalAiPendingCompletion = {
+  request: DesktopLocalAiCompletionTransportRequest;
+  resolve: (response: DesktopLocalAiCompletionTransportResponse) => void;
+  reject: (error: Error) => void;
+  dispose: () => void;
+};
+
+type DesktopLocalAiRunRecord = {
+  id: string;
+  workId: string;
+  actorScope: string;
+  actor: RequestActor | null;
+  status: "running" | "awaiting-completion" | "completed" | "failed" | "cancelled";
+  createdAt: number;
+  updatedAt: number;
+  controller: AbortController;
+  contextUsage: Record<string, unknown> | null;
+  pending: DesktopLocalAiPendingCompletion | null;
+  result: Record<string, unknown> | null;
+  error: { status: number; code: string; message: string } | null;
+};
+
+const DESKTOP_LOCAL_AI_RUN_LIMIT = 20;
+const DESKTOP_LOCAL_AI_RUN_RETENTION_MS = 10 * 60_000;
+const DESKTOP_LOCAL_AI_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 
 export type AiContextCompactionEvent = {
   contextUsage: Record<string, unknown>;
@@ -2520,6 +2598,7 @@ export class AiManager {
     }>;
     timer: ReturnType<typeof setTimeout> | null;
   }>();
+  private readonly desktopLocalAiRuns = new Map<string, DesktopLocalAiRunRecord>();
   private readonly vertexTokenCache = new GoogleVertexTokenCache();
   private readonly connectivityTestGate: AiConnectivityTestGate;
   private readonly allowPrivateAiEndpoints: boolean;
@@ -3375,6 +3454,12 @@ export class AiManager {
 
   dispose(): void {
     logger.info("ai.manager.disposing", { scheduledWorks: this.autoRunTimers.size, activeTasks: this.taskControllers.size });
+    for (const run of this.desktopLocalAiRuns.values()) {
+      run.pending?.dispose();
+      run.pending?.reject(new Error("AI manager disposed"));
+      run.controller.abort(new Error("AI manager disposed"));
+    }
+    this.desktopLocalAiRuns.clear();
     if (this.autoRunStartupTimer) clearTimeout(this.autoRunStartupTimer);
     this.autoRunStartupTimer = null;
     for (const timer of this.autoRunTimers.values()) clearTimeout(timer);
@@ -5181,7 +5266,7 @@ export class AiManager {
       now(),
       currentRequestActor()?.userId ?? null
     );
-    if (input.taskType === "continue") await this.runSuggestionGuard(suggestionId);
+    if (input.taskType === "continue") await this.runSuggestionGuardWithRuntime(suggestionId, undefined, effectiveInput.runtime);
     return {
       ...this.getSuggestion(suggestionId),
       outputTokens: generated.outputTokens,
@@ -5355,6 +5440,14 @@ export class AiManager {
   }
 
   async runSuggestionGuard(suggestionId: string, candidateContent?: string): Promise<Record<string, unknown>> {
+    return this.runSuggestionGuardWithRuntime(suggestionId, candidateContent);
+  }
+
+  private async runSuggestionGuardWithRuntime(
+    suggestionId: string,
+    candidateContent?: string,
+    runtime?: DesktopLocalAiGenerateRuntime
+  ): Promise<Record<string, unknown>> {
     const suggestion = this.getSuggestion(suggestionId);
     if (suggestion.taskType !== "continue" || !suggestion.chapterId) {
       throw new AppError(409, "GUARD_NOT_APPLICABLE", "只有续写建议可以运行一致性守卫");
@@ -5385,7 +5478,8 @@ export class AiManager {
           "续写候选：",
           content
         ].join("\n\n"),
-        extraSystemPrompt: "你是续写一致性守卫。必须逐项对照人物状态、地点、时间、世界观硬约束、章节大纲和未回收伏笔。"
+        extraSystemPrompt: "你是续写一致性守卫。必须逐项对照人物状态、地点、时间、世界观硬约束、章节大纲和未回收伏笔。",
+        ...(runtime ? { runtime } : {})
       });
       const issues = parseGuardIssues(generated.content);
       return this.store.createContinuationGuard({
@@ -5498,44 +5592,15 @@ export class AiManager {
 
   listCalls(workId: string): Record<string, unknown>[] {
     this.store.getWork(workId);
-    return this.store.db.all("SELECT * FROM ai_calls WHERE work_id = ? ORDER BY created_at DESC LIMIT 200", workId).map((row) => ({
-      id: stringValue(row, "id"),
-      workId: stringValue(row, "work_id"),
-      taskId: row.task_id === null ? null : stringValue(row, "task_id"),
-      taskType: stringValue(row, "task_type"),
-      provider: this.getProvider(stringValue(row, "provider_id")),
-      model: this.getModel(stringValue(row, "model_id")),
-      contextScope: json(stringValue(row, "context_scope_json"), {}),
-      parameters: json(stringValue(row, "parameters_json"), {}),
-      status: stringValue(row, "status"),
-      failure: row.failure === null ? null : stringValue(row, "failure"),
-      inputChars: numberValue(row, "input_chars"),
-      outputChars: numberValue(row, "output_chars"),
-      createdAt: stringValue(row, "created_at"),
-      completedAt: row.completed_at === null ? null : stringValue(row, "completed_at")
-    }));
+    return this.store.db.all("SELECT * FROM ai_calls WHERE work_id = ? ORDER BY created_at DESC LIMIT 200", workId)
+      .map((row) => this.mapCall(row));
   }
 
   listCallsPage(workId: string, pagination: Pagination): PaginatedResult<Record<string, unknown>> {
     this.store.getWork(workId);
     const page = paginationSql(pagination);
     const rows = this.store.db.all(`SELECT * FROM ai_calls WHERE work_id = ? ORDER BY created_at DESC${page.sql}`, workId, ...page.params);
-    return paginated(rows.map((row) => ({
-      id: stringValue(row, "id"),
-      workId: stringValue(row, "work_id"),
-      taskId: row.task_id === null ? null : stringValue(row, "task_id"),
-      taskType: stringValue(row, "task_type"),
-      provider: this.getProvider(stringValue(row, "provider_id")),
-      model: this.getModel(stringValue(row, "model_id")),
-      contextScope: json(stringValue(row, "context_scope_json"), {}),
-      parameters: json(stringValue(row, "parameters_json"), {}),
-      status: stringValue(row, "status"),
-      failure: row.failure === null ? null : stringValue(row, "failure"),
-      inputChars: numberValue(row, "input_chars"),
-      outputChars: numberValue(row, "output_chars"),
-      createdAt: stringValue(row, "created_at"),
-      completedAt: row.completed_at === null ? null : stringValue(row, "completed_at")
-    })), pagination);
+    return paginated(rows.map((row) => this.mapCall(row)), pagination);
   }
 
   getTaskTrace(taskId: string): Record<string, unknown> {
@@ -5794,6 +5859,13 @@ export class AiManager {
 
   getContextUsage(input: Pick<GenerateInput, "workId" | "taskType" | "modelId" | "scope" | "instruction" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">): Record<string, unknown> {
     const { model } = this.resolveModel(input.workId, input.taskType, input.modelId);
+    return this.contextUsageForModel(input, model);
+  }
+
+  private contextUsageForModel(
+    input: Pick<GenerateInput, "workId" | "taskType" | "modelId" | "scope" | "instruction" | "conversationId" | "excludeConversationMessageId" | "agentToolIds">,
+    model: ModelRow
+  ): Record<string, unknown> {
     const budget = this.contextBudget(input, model);
     const conversation = budget.conversation as AiConversationContext | null;
     const contextPlan = this.buildContextPlan(input, model, budget);
@@ -5854,72 +5926,250 @@ export class AiManager {
     };
   }
 
-  prepareDesktopLocalAiCompletion(input: DesktopLocalAiPreparationInput): DesktopLocalAiPreparationResult {
-    const model: ModelRow = {
-      id: "desktop-local-model",
-      provider_id: "desktop-local-provider",
-      display_name: "Desktop Local AI",
-      model_id: "desktop-local-model",
-      enabled: 1,
-      context_window: input.contextWindow,
-      preset_json: JSON.stringify({ max_tokens: input.maxOutputTokens })
+  async startDesktopLocalAiRun(
+    input: DesktopLocalAiRunInput,
+    actorScope: string,
+    actor: RequestActor | null,
+    permissions: WorkModulePermissions
+  ): Promise<Record<string, unknown>> {
+    this.pruneDesktopLocalAiRuns();
+    if (this.desktopLocalAiRuns.size >= DESKTOP_LOCAL_AI_RUN_LIMIT) {
+      throw new AppError(429, "DESKTOP_LOCAL_AI_RUN_LIMIT", "当前正在处理的 Desktop 本地 AI 请求过多，请稍后再试");
+    }
+    const { provider, model } = this.desktopLocalAiRuntimeRows(input.runtimeModel);
+    const imageAttachments = await this.prepareChatImageAttachmentsForModel(
+      input.workId,
+      model,
+      provider,
+      input.imageAttachmentIds ?? [],
+      permissions
+    );
+    const runId = id("desktop-local-ai-run");
+    const timestamp = Date.now();
+    const run: DesktopLocalAiRunRecord = {
+      id: runId,
+      workId: input.workId,
+      actorScope,
+      actor,
+      status: "running",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      controller: new AbortController(),
+      contextUsage: null,
+      pending: null,
+      result: null,
+      error: null
     };
-    const scope = input.taskType === "continue"
-      ? this.enrichContinuationScope(input.workId, input.scope, input.instruction)
-      : input.scope;
-    const preparedInput: GenerateInput = {
+    const runtime: DesktopLocalAiGenerateRuntime = {
+      provider,
+      model,
+      localModelId: input.runtimeModel.id,
+      completionTransport: (request) => this.awaitDesktopLocalAiCompletion(run, request)
+    };
+    this.desktopLocalAiRuns.set(runId, run);
+    const updateContextUsage = (contextUsage: Record<string, unknown>): void => {
+      run.contextUsage = contextUsage;
+      run.updatedAt = Date.now();
+    };
+    void Promise.resolve().then(() => runWithRequestActor(actor, () => this.createSuggestion({
       workId: input.workId,
       taskType: input.taskType,
       instruction: input.instruction,
-      scope,
-      agentToolIds: [],
-      disableTools: true,
+      scope: input.scope,
+      modelId: input.runtimeModel.id,
+      signal: run.controller.signal,
+      runtime,
+      onPrepared: updateContextUsage,
+      onContextCompacted: (event) => updateContextUsage(event.contextUsage),
       ...(input.conversationId ? { conversationId: input.conversationId } : {}),
-      ...(input.excludeConversationMessageId ? { excludeConversationMessageId: input.excludeConversationMessageId } : {})
-    };
-    const conversation = preparedInput.conversationId
-      ? this.store.getAiConversationContext(
-        preparedInput.conversationId,
-        preparedInput.workId,
-        preparedInput.excludeConversationMessageId
-      )
-      : null;
-    const budget = this.contextBudget(preparedInput, model, conversation);
-    const context = this.buildContext(preparedInput, model, budget);
-    const completionMessages = this.buildMessages(preparedInput, context, conversation);
-    const systemMessage = completionMessages[0];
-    if (systemMessage?.role !== "system" || typeof systemMessage.content !== "string") {
-      throw new AppError(500, "LOCAL_AI_CONTEXT_INVALID", "无法为 Desktop 本地 AI 构建系统提示词");
-    }
-    const messages = completionMessages.slice(1).map((message) => {
-      if ((message.role !== "user" && message.role !== "assistant") || typeof message.content !== "string") {
-        throw new AppError(409, "LOCAL_AI_CONTENT_UNSUPPORTED", "当前上下文包含本地 AI 暂不支持的消息内容");
-      }
-      return { role: message.role, content: message.content };
+      ...(input.excludeConversationMessageId ? { excludeConversationMessageId: input.excludeConversationMessageId } : {}),
+      ...(imageAttachments.length > 0 ? { imageAttachments } : {}),
+      ...(input.sceneDirection ? { sceneDirection: input.sceneDirection } : {})
+    }))).then((result) => {
+      if (run.status === "cancelled") return;
+      run.status = "completed";
+      run.result = result;
+      run.contextUsage = result.contextUsage && typeof result.contextUsage === "object" && !Array.isArray(result.contextUsage)
+        ? result.contextUsage as Record<string, unknown>
+        : run.contextUsage;
+      run.updatedAt = Date.now();
+    }).catch((error) => {
+      if (run.status === "cancelled") return;
+      const appError = error instanceof AppError ? error : null;
+      run.status = "failed";
+      run.error = {
+        status: appError?.status ?? 502,
+        code: appError?.code ?? "AI_CALL_FAILED",
+        message: appError?.message ?? "AI 调用失败"
+      };
+      run.updatedAt = Date.now();
     });
-    const contextWindow = Math.max(32_768, Math.min(2_000_000, Number(input.contextWindow) || 128_000));
-    const inputTokens = estimateCompletionMessageTokens(completionMessages);
-    const systemPromptTokens = estimateAiTokens(systemMessage.content);
-    const remainingTokens = Math.max(0, contextWindow - inputTokens);
+    return this.desktopLocalAiRunStatus(runId, input.workId, actorScope);
+  }
+
+  desktopLocalAiRunStatus(runId: string, workId: string, actorScope: string): Record<string, unknown> {
+    this.pruneDesktopLocalAiRuns();
+    const run = this.desktopLocalAiRun(runId, workId, actorScope);
     return {
-      remoteSystemPrompt: systemMessage.content,
-      messages,
-      contextUsage: {
-        modelId: "desktop-local-model",
-        contextWindow,
-        inputTokens,
-        remainingTokens,
-        usagePercent: Math.min(100, Math.round(inputTokens / contextWindow * 100)),
-        maxOutputTokens: input.maxOutputTokens,
-        tokenDistribution: {
-          systemPromptTokens,
-          functionTokens: 0,
-          skillsTokens: 0,
-          contextTokens: Math.max(0, inputTokens - systemPromptTokens),
-          leftTokens: remainingTokens
-        }
+      id: run.id,
+      status: run.status,
+      ...(run.contextUsage ? { contextUsage: run.contextUsage } : {}),
+      ...(run.pending ? { completion: run.pending.request } : {}),
+      ...(run.result ? { result: run.result } : {}),
+      ...(run.error ? { error: run.error } : {})
+    };
+  }
+
+  submitDesktopLocalAiCompletion(
+    runId: string,
+    workId: string,
+    actorScope: string,
+    input: DesktopLocalAiCompletionResponseInput
+  ): Record<string, unknown> {
+    const run = this.desktopLocalAiRun(runId, workId, actorScope);
+    const pending = run.pending;
+    if (!pending || run.status !== "awaiting-completion") {
+      throw new AppError(409, "DESKTOP_LOCAL_AI_NOT_AWAITING", "当前 Desktop 本地 AI 请求不等待模型响应");
+    }
+    if (pending.request.requestId !== input.requestId) {
+      throw new AppError(409, "DESKTOP_LOCAL_AI_REQUEST_MISMATCH", "Desktop 本地 AI 响应与当前请求不匹配");
+    }
+    if (Buffer.byteLength(input.body, "utf8") > DESKTOP_LOCAL_AI_RESPONSE_MAX_BYTES) {
+      throw new AppError(413, "DESKTOP_LOCAL_AI_RESPONSE_TOO_LARGE", "Desktop 本地 AI 响应过大");
+    }
+    run.pending = null;
+    run.status = "running";
+    run.updatedAt = Date.now();
+    pending.dispose();
+    pending.resolve({
+      status: input.status,
+      body: input.body,
+      retryAfter: input.retryAfter ?? null
+    });
+    return this.desktopLocalAiRunStatus(runId, workId, actorScope);
+  }
+
+  cancelDesktopLocalAiRun(runId: string, workId: string, actorScope: string): Record<string, unknown> {
+    const run = this.desktopLocalAiRun(runId, workId, actorScope);
+    if (run.status === "completed" || run.status === "failed" || run.status === "cancelled") {
+      return this.desktopLocalAiRunStatus(runId, workId, actorScope);
+    }
+    run.status = "cancelled";
+    run.updatedAt = Date.now();
+    run.pending?.dispose();
+    run.pending?.reject(new Error("Desktop local AI run cancelled"));
+    run.pending = null;
+    run.controller.abort(new Error("Desktop local AI run cancelled"));
+    return this.desktopLocalAiRunStatus(runId, workId, actorScope);
+  }
+
+  private desktopLocalAiRuntimeRows(input: DesktopLocalAiRuntimeModelInput): { provider: ProviderRow; model: ModelRow } {
+    const timestamp = now();
+    return {
+      provider: {
+        id: input.providerId,
+        work_id: PLATFORM_AI_WORK_ID,
+        name: input.providerName,
+        base_url: "",
+        protocol: input.protocol,
+        encrypted_key: "",
+        key_iv: "",
+        key_tag: "",
+        key_hint: "",
+        status: "enabled",
+        connection_status: "success",
+        max_tokens_parameter: input.maxTokensParameter,
+        thinking_type: input.thinkingType,
+        concurrency_limit: input.concurrencyLimit,
+        rpm_limit: input.rpmLimit,
+        analysis_timeout_seconds: input.analysisTimeoutSeconds,
+        daily_token_quota: null,
+        monthly_token_quota: null,
+        default_model_id: input.id,
+        note: input.note,
+        last_error: null,
+        last_success_at: timestamp,
+        created_at: timestamp,
+        updated_at: timestamp,
+        desktop_local: 1
+      },
+      model: {
+        id: input.id,
+        provider_id: input.providerId,
+        display_name: input.displayName,
+        model_id: input.modelId,
+        enabled: 1,
+        purposes_json: JSON.stringify(input.purposes),
+        context_note: input.contextNote,
+        context_window: input.contextWindow,
+        output_note: input.outputNote,
+        preset_json: JSON.stringify(input.preset),
+        thinking_enabled: input.thinkingEnabled ? 1 : 0,
+        thinking_effort: input.thinkingEffort,
+        multimodal_enabled: input.multimodalEnabled ? 1 : 0,
+        note: input.note,
+        created_at: timestamp,
+        updated_at: timestamp,
+        desktop_local: 1
       }
     };
+  }
+
+  private desktopLocalAiRun(runId: string, workId: string, actorScope: string): DesktopLocalAiRunRecord {
+    const run = this.desktopLocalAiRuns.get(runId);
+    if (!run || run.workId !== workId || run.actorScope !== actorScope) throw notFound("Desktop 本地 AI 请求");
+    return run;
+  }
+
+  private awaitDesktopLocalAiCompletion(
+    run: DesktopLocalAiRunRecord,
+    request: DesktopLocalAiCompletionTransportRequest
+  ): Promise<DesktopLocalAiCompletionTransportResponse> {
+    if (run.controller.signal.aborted) return Promise.reject(new Error("Desktop local AI run cancelled"));
+    if (run.pending) return Promise.reject(new Error("Desktop local AI run already has a pending completion"));
+    return new Promise<DesktopLocalAiCompletionTransportResponse>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (run.pending?.request.requestId !== request.requestId) return;
+        run.pending = null;
+        run.status = "running";
+        run.updatedAt = Date.now();
+        run.controller.signal.removeEventListener("abort", onAbort);
+        reject(new Error(`AI 请求超时（${Math.round(request.timeoutMs / 1_000)} 秒）`));
+      }, request.timeoutMs);
+      const onAbort = (): void => {
+        if (run.pending?.request.requestId !== request.requestId) return;
+        run.pending = null;
+        clearTimeout(timeout);
+        reject(new Error("Desktop local AI run cancelled"));
+      };
+      const dispose = (): void => {
+        clearTimeout(timeout);
+        run.controller.signal.removeEventListener("abort", onAbort);
+      };
+      run.controller.signal.addEventListener("abort", onAbort, { once: true });
+      run.pending = {
+        request,
+        resolve: (response) => {
+          dispose();
+          resolve(response);
+        },
+        reject: (error) => {
+          dispose();
+          reject(error);
+        },
+        dispose
+      };
+      run.status = "awaiting-completion";
+      run.updatedAt = Date.now();
+    });
+  }
+
+  private pruneDesktopLocalAiRuns(): void {
+    const cutoff = Date.now() - DESKTOP_LOCAL_AI_RUN_RETENTION_MS;
+    for (const [runId, run] of this.desktopLocalAiRuns) {
+      if (run.updatedAt >= cutoff || run.status === "running" || run.status === "awaiting-completion") continue;
+      this.desktopLocalAiRuns.delete(runId);
+    }
   }
 
   private completionContextUsage(
@@ -5929,7 +6179,7 @@ export class AiManager {
     tools: Record<string, unknown>[],
     reportedUsage?: unknown
   ): Record<string, unknown> {
-    const baseUsage = this.getContextUsage(input);
+    const baseUsage = this.contextUsageForModel(input, model);
     const contextWindow = numberValue(model, "context_window") || DEFAULT_CONTEXT_WINDOW;
     const serializedMessageTokens = estimateCompletionMessageTokens(messages);
     const systemPromptTokens = messages
@@ -6082,10 +6332,20 @@ export class AiManager {
     attachmentIds: string[],
     permissions: WorkModulePermissions
   ): Promise<ChatImageAttachment[]> {
+    const { model, provider } = this.resolveModel(workId, "chat", modelId);
+    return this.prepareChatImageAttachmentsForModel(workId, model, provider, attachmentIds, permissions);
+  }
+
+  private async prepareChatImageAttachmentsForModel(
+    workId: string,
+    model: ModelRow,
+    provider: ProviderRow,
+    attachmentIds: string[],
+    permissions: WorkModulePermissions
+  ): Promise<ChatImageAttachment[]> {
     const ids = [...new Set(attachmentIds.map((attachmentId) => String(attachmentId).trim()).filter(Boolean))];
     if (ids.length === 0) return [];
     if (ids.length > 4) throw new AppError(400, "AI_CHAT_IMAGE_LIMIT", "一次最多添加 4 张图片附件");
-    const { model, provider } = this.resolveModel(workId, "chat", modelId);
     if (!boolValue(model, "multimodal_enabled")) {
       throw new AppError(400, "MODEL_NOT_MULTIMODAL", "当前选择的模型不是多模态模型，无法处理图片附件");
     }
@@ -6131,12 +6391,12 @@ export class AiManager {
 
   private async prepareConversationImageAttachments(
     workId: string,
-    modelId: string,
+    model: ModelRow,
+    provider: ProviderRow,
     conversation: AiConversationContext | null
   ): Promise<ReadonlyMap<string, ChatImageAttachment[]>> {
     const preparedByMessage = new Map<string, ChatImageAttachment[]>();
     if (!conversation) return preparedByMessage;
-    const { model, provider } = this.resolveModel(workId, "chat", modelId);
     if (!boolValue(model, "multimodal_enabled") || !supportsMultimodalProviderProtocol(provider)) {
       return preparedByMessage;
     }
@@ -6149,7 +6409,7 @@ export class AiManager {
       if (ids.length === 0) continue;
       preparedByMessage.set(
         message.id,
-        await this.prepareChatImageAttachments(workId, modelId, ids, permissions)
+        await this.prepareChatImageAttachmentsForModel(workId, model, provider, ids, permissions)
       );
     }
     return preparedByMessage;
@@ -7933,14 +8193,15 @@ export class AiManager {
     messages: CompletionMessage[],
     parameters: Record<string, unknown>,
     tools: Record<string, unknown>[] = [],
-    additionalUsedTokens = 0
+    additionalUsedTokens = 0,
+    includeProviderQuota = true
   ): Record<string, unknown> {
     const workStatus = this.getWorkTokenQuotaStatus(workId);
-    const providerStatus = this.getProviderTokenQuotaStatus(stringValue(provider, "id"));
+    const providerStatus = includeProviderQuota ? this.getProviderTokenQuotaStatus(stringValue(provider, "id")) : null;
     const dailyTokenQuota = workStatus.dailyTokenQuota === null ? null : Number(workStatus.dailyTokenQuota);
     const monthlyTokenQuota = workStatus.monthlyTokenQuota === null ? null : Number(workStatus.monthlyTokenQuota);
-    const providerDailyTokenQuota = providerStatus.dailyTokenQuota === null ? null : Number(providerStatus.dailyTokenQuota);
-    const providerMonthlyTokenQuota = providerStatus.monthlyTokenQuota === null ? null : Number(providerStatus.monthlyTokenQuota);
+    const providerDailyTokenQuota = providerStatus?.dailyTokenQuota === null || !providerStatus ? null : Number(providerStatus.dailyTokenQuota);
+    const providerMonthlyTokenQuota = providerStatus?.monthlyTokenQuota === null || !providerStatus ? null : Number(providerStatus.monthlyTokenQuota);
     if (dailyTokenQuota === null && monthlyTokenQuota === null && providerDailyTokenQuota === null && providerMonthlyTokenQuota === null) return parameters;
     const additionalTokens = Math.max(0, additionalUsedTokens);
     const estimatedInputTokens = estimateCompletionMessageTokens(messages)
@@ -7974,30 +8235,34 @@ export class AiManager {
         resetsAt: String(workStatus.monthlyResetsAt),
         startedAt: String(workStatus.monthStartedAt),
         timezone: String(workStatus.timezone)
-      },
-      {
-        scope: "provider",
-        period: "daily" as const,
-        quota: providerDailyTokenQuota,
-        usedTokens: Number(providerStatus.usedTokens) + additionalTokens,
-        resetsAt: String(providerStatus.resetsAt),
-        startedAt: String(providerStatus.dayStartedAt),
-        timezone: String(providerStatus.timezone),
-        providerId: stringValue(provider, "id"),
-        providerName: stringValue(provider, "name")
-      },
-      {
-        scope: "provider",
-        period: "monthly" as const,
-        quota: providerMonthlyTokenQuota,
-        usedTokens: Number(providerStatus.monthlyUsedTokens) + additionalTokens,
-        resetsAt: String(providerStatus.monthlyResetsAt),
-        startedAt: String(providerStatus.monthStartedAt),
-        timezone: String(providerStatus.timezone),
-        providerId: stringValue(provider, "id"),
-        providerName: stringValue(provider, "name")
       }
     ];
+    if (providerStatus) {
+      quotas.push(
+        {
+          scope: "provider",
+          period: "daily",
+          quota: providerDailyTokenQuota,
+          usedTokens: Number(providerStatus.usedTokens) + additionalTokens,
+          resetsAt: String(providerStatus.resetsAt),
+          startedAt: String(providerStatus.dayStartedAt),
+          timezone: String(providerStatus.timezone),
+          providerId: stringValue(provider, "id"),
+          providerName: stringValue(provider, "name")
+        },
+        {
+          scope: "provider",
+          period: "monthly",
+          quota: providerMonthlyTokenQuota,
+          usedTokens: Number(providerStatus.monthlyUsedTokens) + additionalTokens,
+          resetsAt: String(providerStatus.monthlyResetsAt),
+          startedAt: String(providerStatus.monthStartedAt),
+          timezone: String(providerStatus.timezone),
+          providerId: stringValue(provider, "id"),
+          providerName: stringValue(provider, "name")
+        }
+      );
+    }
     for (const item of quotas) {
       if (item.quota === null) continue;
       const availableTokens = Math.max(0, item.quota - item.usedTokens);
@@ -8062,10 +8327,11 @@ export class AiManager {
       ? this.store.getAiConversationContext(input.conversationId, input.workId, input.excludeConversationMessageId)
       : null;
     const generationRoleplayCharacterId = this.roleplayCharacterIdFromConversation(input.workId, conversation);
-    const { model, provider } = this.resolveModel(input.workId, input.taskType, input.modelId);
+    const { model, provider } = input.runtime ?? this.resolveModel(input.workId, input.taskType, input.modelId);
     const conversationImageAttachments = await this.prepareConversationImageAttachments(
       input.workId,
-      String(model.id),
+      model,
+      provider,
       conversation
     );
     const preset = safeJsonObject(stringValue(model, "preset_json"));
@@ -8109,11 +8375,29 @@ export class AiManager {
         modelId: stringValue(model, "id")
       });
     }
-    parameters = this.constrainParametersForTokenQuota(input.workId, provider, messages, parameters, tools);
+    parameters = this.constrainParametersForTokenQuota(
+      input.workId,
+      provider,
+      messages,
+      parameters,
+      tools,
+      0,
+      input.runtime === undefined
+    );
+    input.onPrepared?.(this.completionContextUsage(effectiveInput, model, messages, tools));
     const completionMessages: CompletionMessage[] = [...messages];
     const callId = id("call");
     const timestamp = now();
     const traceRounds: AiCallTraceRound[] = [];
+    const storedParameters = input.runtime
+      ? {
+          ...parameters,
+          __desktopLocalAi: {
+            provider: this.mapProvider(provider),
+            model: this.mapModel(model)
+          }
+        }
+      : parameters;
     this.store.db.transaction(() => {
       this.store.db.run(
         `INSERT INTO ai_calls (id, work_id, task_id, task_type, provider_id, model_id, context_scope_json, parameters_json,
@@ -8125,7 +8409,7 @@ export class AiManager {
         stringValue(provider, "id"),
         stringValue(model, "id"),
         JSON.stringify(input.scope),
-        JSON.stringify(parameters),
+        JSON.stringify(storedParameters),
         context.length + input.instruction.length,
         timestamp,
         currentRequestActor()?.userId ?? null
@@ -8190,9 +8474,14 @@ export class AiManager {
       return "mixed";
     };
     try {
-      const { accessToken, credentialSecret } = await this.resolveProviderAccessToken(provider);
-      activeSecrets = [credentialSecret, accessToken];
-      const endpoint = providerCompletionEndpoint(stringValue(provider, "base_url"), protocol);
+      let accessToken = "";
+      let endpoint = "";
+      if (!input.runtime) {
+        const credential = await this.resolveProviderAccessToken(provider);
+        accessToken = credential.accessToken;
+        activeSecrets = [credential.credentialSecret, credential.accessToken];
+        endpoint = providerCompletionEndpoint(stringValue(provider, "base_url"), protocol);
+      }
       const timeoutMs = isLongRunningAiAnalysisTaskType(input.taskType)
         ? providerAnalysisTimeoutSeconds(provider) * 1_000
         : AI_INTERACTIVE_TIMEOUT_MS;
@@ -8222,7 +8511,7 @@ export class AiManager {
         const requestParameters = options.parameters ?? parameters;
         const purpose = options.purpose ?? "generation";
         const requestTools = toolChoice === "auto" ? tools : [];
-        const streamResponse = Boolean(onDelta) && purpose === "generation";
+        const streamResponse = !input.runtime && Boolean(onDelta) && purpose === "generation";
         const processRound = streamResponse ? streamingGenerationRound + 1 : 0;
         if (streamResponse) streamingGenerationRound = processRound;
         const roundParameters = this.constrainParametersForTokenQuota(
@@ -8231,7 +8520,8 @@ export class AiManager {
           requestMessages,
           this.constrainParametersForContext(model, requestMessages, requestParameters, requestTools),
           requestTools,
-          trackedInputTokens + trackedOutputTokens
+          trackedInputTokens + trackedOutputTokens,
+          input.runtime === undefined
         );
         const traceRound: AiCallTraceRound = {
           round: traceRounds.length + 1,
@@ -8247,6 +8537,16 @@ export class AiManager {
           attempts: [],
           toolExecutions: []
         };
+        const completionRequestBody = buildCompletionRequestBody({
+          protocol,
+          model: stringValue(model, "model_id"),
+          messages: requestMessages,
+          parameters: roundParameters,
+          maxTokensParameter: providerMaxTokensParameter(provider),
+          tools: requestTools,
+          toolChoice,
+          ...(streamResponse ? { stream: true } : {})
+        });
         traceRounds.push(traceRound);
         saveTrace();
         let streamedThinkingStep: {
@@ -8274,6 +8574,30 @@ export class AiManager {
           let streamedRoundContent = "";
           try {
             const candidate = await this.scheduleProviderRequest(provider, input.signal, async () => {
+              if (input.runtime) {
+                const response = await input.runtime.completionTransport({
+                  requestId: id("desktop-local-ai-completion"),
+                  localModelId: input.runtime.localModelId,
+                  taskType: input.taskType,
+                  purpose,
+                  body: completionRequestBody,
+                  timeoutMs
+                });
+                if (response.status < 200 || response.status >= 300) {
+                  return {
+                    ok: false as const,
+                    status: response.status,
+                    body: response.body,
+                    retryAfter: response.retryAfter
+                  };
+                }
+                try {
+                  const payload = parseCompletionPayload(protocol, JSON.parse(response.body));
+                  return { ok: true as const, status: response.status, payload, delivery: "json" as const };
+                } catch {
+                  throw new Error(`${providerProtocolLabelText(protocol)} returned invalid JSON: ${response.body.slice(0, 500)}`);
+                }
+              }
               const controller = new AbortController();
               const forwardAbort = (): void => controller.abort(input.signal?.reason);
               if (input.signal?.aborted) forwardAbort();
@@ -8290,16 +8614,7 @@ export class AiManager {
                 const response = await this.outboundFetch(endpoint, {
                   method: "POST",
                   headers: providerRequestHeaders(protocol, accessToken, streamResponse ? "text/event-stream" : "application/json"),
-                  body: JSON.stringify(buildCompletionRequestBody({
-                    protocol,
-                    model: stringValue(model, "model_id"),
-                    messages: requestMessages,
-                    parameters: roundParameters,
-                    maxTokensParameter: providerMaxTokensParameter(provider),
-                    tools: requestTools,
-                    toolChoice,
-                    ...(streamResponse ? { stream: true } : {})
-                  })),
+                  body: JSON.stringify(completionRequestBody),
                   signal: controller.signal
                 });
                 responseReceived = true;
@@ -13102,18 +13417,21 @@ export class AiManager {
   }
 
   private mapProvider(row: Row): Record<string, unknown> {
+    const desktopLocal = boolValue(row, "desktop_local");
     let apiKeyHint = stringValue(row, "key_hint");
-    try {
-      const secret = this.decryptKey(row);
-      apiKeyHint = providerCredentialHint(providerProtocol(row), secret);
-    } catch {
-      // 凭据无法解密时保留数据库中的旧掩码，避免影响供应商列表展示。
+    if (!desktopLocal) {
+      try {
+        const secret = this.decryptKey(row);
+        apiKeyHint = providerCredentialHint(providerProtocol(row), secret);
+      } catch {
+        // 凭据无法解密时保留数据库中的旧掩码，避免影响供应商列表展示。
+      }
     }
     return {
       id: stringValue(row, "id"),
-      scope: "platform",
+      scope: desktopLocal ? "local" : "platform",
       name: stringValue(row, "name"),
-      baseUrl: stringValue(row, "base_url"),
+      baseUrl: desktopLocal ? "" : stringValue(row, "base_url"),
       protocol: providerProtocol(row),
       maxTokensParameter: providerMaxTokensParameter(row),
       thinkingType: providerThinkingType(row),
@@ -13135,8 +13453,10 @@ export class AiManager {
   }
 
   private mapModel(row: Row): Record<string, unknown> {
+    const desktopLocal = boolValue(row, "desktop_local");
     return {
       id: stringValue(row, "id"),
+      ...(desktopLocal ? { scope: "local" } : {}),
       providerId: stringValue(row, "provider_id"),
       displayName: stringValue(row, "display_name"),
       modelId: stringValue(row, "model_id"),
@@ -13148,7 +13468,7 @@ export class AiManager {
       thinkingEnabled: boolValue(row, "thinking_enabled"),
       thinkingEffort: stringValue(row, "thinking_effort") || "default",
       multimodalEnabled: boolValue(row, "multimodal_enabled"),
-      imageToolDefault: String(this.store.getPlatformAiSettings().imageToolModelId ?? "") === stringValue(row, "id"),
+      imageToolDefault: !desktopLocal && String(this.store.getPlatformAiSettings().imageToolModelId ?? "") === stringValue(row, "id"),
       enabled: boolValue(row, "enabled"),
       note: stringValue(row, "note"),
       createdAt: stringValue(row, "created_at"),
@@ -13156,8 +13476,55 @@ export class AiManager {
     };
   }
 
+  private aiCallTarget(row: Row): { provider: Record<string, unknown>; model: Record<string, unknown> } {
+    const parameters = safeJsonObject(stringValue(row, "parameters_json"));
+    const desktopLocal = parameters.__desktopLocalAi;
+    if (desktopLocal && typeof desktopLocal === "object" && !Array.isArray(desktopLocal)) {
+      const snapshot = desktopLocal as Record<string, unknown>;
+      if (
+        snapshot.provider && typeof snapshot.provider === "object" && !Array.isArray(snapshot.provider)
+        && snapshot.model && typeof snapshot.model === "object" && !Array.isArray(snapshot.model)
+      ) {
+        return {
+          provider: structuredClone(snapshot.provider as Record<string, unknown>),
+          model: structuredClone(snapshot.model as Record<string, unknown>)
+        };
+      }
+    }
+    return {
+      provider: this.getProvider(stringValue(row, "provider_id")),
+      model: this.getModel(stringValue(row, "model_id"))
+    };
+  }
+
+  private publicAiCallParameters(row: Row): Record<string, unknown> {
+    const { __desktopLocalAi: _desktopLocalAi, ...parameters } = safeJsonObject(stringValue(row, "parameters_json"));
+    return parameters;
+  }
+
+  private mapCall(row: Row): Record<string, unknown> {
+    const target = this.aiCallTarget(row);
+    return {
+      id: stringValue(row, "id"),
+      workId: stringValue(row, "work_id"),
+      taskId: row.task_id === null ? null : stringValue(row, "task_id"),
+      taskType: stringValue(row, "task_type"),
+      provider: target.provider,
+      model: target.model,
+      contextScope: json(stringValue(row, "context_scope_json"), {}),
+      parameters: this.publicAiCallParameters(row),
+      status: stringValue(row, "status"),
+      failure: row.failure === null ? null : stringValue(row, "failure"),
+      inputChars: numberValue(row, "input_chars"),
+      outputChars: numberValue(row, "output_chars"),
+      createdAt: stringValue(row, "created_at"),
+      completedAt: row.completed_at === null ? null : stringValue(row, "completed_at")
+    };
+  }
+
   private mapSuggestion(row: Row): Record<string, unknown> {
-    const call = this.store.db.get("SELECT provider_id, model_id FROM ai_calls WHERE id = ?", stringValue(row, "call_id"));
+    const call = this.store.db.get("SELECT provider_id, model_id, parameters_json FROM ai_calls WHERE id = ?", stringValue(row, "call_id"));
+    const target = call ? this.aiCallTarget(call) : null;
     const guard = this.store.getLatestContinuationGuard(stringValue(row, "id"));
     return {
       id: stringValue(row, "id"),
@@ -13173,8 +13540,8 @@ export class AiManager {
       status: stringValue(row, "status"),
       outputTokens: estimateAiTokens(stringValue(row, "content")),
       guard,
-      provider: call ? this.getProvider(stringValue(call, "provider_id")) : null,
-      model: call ? this.getModel(stringValue(call, "model_id")) : null,
+      provider: target?.provider ?? null,
+      model: target?.model ?? null,
       createdAt: stringValue(row, "created_at"),
       decidedAt: row.decided_at === null ? null : stringValue(row, "decided_at")
     };

--- a/src/app.ts
+++ b/src/app.ts
@@ -724,19 +724,53 @@ const contextSchema = z.object({
   includeSettingInfo: z.boolean().optional()
 });
 
-const desktopLocalAiPreparationSchema = z.object({
+const desktopLocalAiRuntimeModelSchema = z.object({
+  id: identifier,
+  providerId: identifier,
+  providerName: nonEmpty.max(200),
+  protocol: z.literal("openai-chat-completions"),
+  maxTokensParameter: z.enum(MAX_TOKENS_PARAMETERS),
+  thinkingType: z.enum(["enabled", "adaptive"]),
+  concurrencyLimit: z.number().int().min(1).max(100),
+  rpmLimit: z.number().int().min(1).max(10_000),
+  analysisTimeoutSeconds: z.number().int().min(MIN_AI_ANALYSIS_TIMEOUT_SECONDS).max(MAX_AI_ANALYSIS_TIMEOUT_SECONDS),
+  displayName: nonEmpty.max(200),
+  modelId: nonEmpty.max(300),
+  purposes: z.array(z.enum(TASK_TYPES)).min(1).max(TASK_TYPES.length),
+  contextNote: z.string().max(10_000),
+  contextWindow: z.number().int().min(32_768).max(2_000_000),
+  outputNote: z.string().max(10_000),
+  preset: z.object({
+    temperature: z.number().min(0).max(2),
+    max_tokens: z.number().int().min(1).max(2_000_000)
+  }).strict(),
+  thinkingEnabled: z.boolean(),
+  thinkingEffort: z.enum(["default", "auto", "low", "medium", "high", "xhigh", "max"]),
+  multimodalEnabled: z.boolean(),
+  note: z.string().max(10_000)
+}).strict().refine((input) => input.preset.max_tokens < input.contextWindow, {
+  path: ["preset", "max_tokens"],
+  message: "本地 AI 最大输出令牌数必须小于上下文窗口"
+});
+
+const desktopLocalAiRunSchema = z.object({
   taskType: z.enum(["chat", "continue", "polish"]),
   instruction: nonEmpty.max(100_000),
   scope: contextSchema,
-  contextWindow: z.number().int().min(32_768).max(2_000_000),
-  maxOutputTokens: z.number().int().min(1).max(2_000_000),
+  runtimeModel: desktopLocalAiRuntimeModelSchema,
   conversationId: identifier.optional(),
   currentMessageId: identifier.optional(),
-  citations: aiCitationsSchema.optional()
-}).strict().refine((input) => input.maxOutputTokens < input.contextWindow, {
-  path: ["maxOutputTokens"],
-  message: "本地 AI 最大输出令牌数必须小于上下文窗口"
-});
+  citations: aiCitationsSchema.optional(),
+  imageAttachmentIds: z.array(identifier).max(4).optional(),
+  sceneDirection: z.string().max(20_000).optional()
+}).strict();
+
+const desktopLocalAiCompletionResponseSchema = z.object({
+  requestId: identifier,
+  status: z.number().int().min(100).max(599),
+  body: z.string().max(4 * 1024 * 1024),
+  retryAfter: z.string().max(500).optional()
+}).strict();
 
 /** 创建任务 API 的分析类型校验：仅允许可新建类型，历史类型在运行层保留防御性拒绝。 */
 export const creatableAnalysisTaskTypeSchema = z.enum(CREATABLE_ANALYSIS_TASK_TYPES);
@@ -2106,7 +2140,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
   });
   app.get("/api/works/:workId/chapter-annotations", (request, response) => {
     const pagination = parsePagination(request.query);
-    const permissions = requestPermissions(request, request.params.workId);
+    const permissions = requestPermissions(request, String(request.params.workId));
     data(response, pagination
       ? store.listWorkChapterAnnotationsPage(request.params.workId, pagination, readableChapterAnnotationKinds(permissions))
       : store.listWorkChapterAnnotations(request.params.workId, readableChapterAnnotationKinds(permissions)));
@@ -3260,12 +3294,20 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       ? mapRecords(ai.listSuggestionsPage(request.params.workId, pagination, status), (suggestion) => redactSuggestion(suggestion, permissions))
       : ai.listSuggestions(request.params.workId, status).map((suggestion) => redactSuggestion(suggestion, permissions)));
   });
-  app.post("/api/works/:workId/desktop-local-ai/prepare", (request, response) => {
-    const input = parse(desktopLocalAiPreparationSchema, request.body);
-    const permissions = requestPermissions(request, request.params.workId);
+  const desktopLocalAiActorScope = (request: Request): string => {
+    const actor = currentRequestActor();
+    return request.authUser?.userId ? `user:${request.authUser.userId}` : actor?.userId ? `user:${actor.userId}` : "auth-disabled";
+  };
+  const assertDesktopLocalAiPermission = (request: Request): WorkModulePermissions => {
+    const permissions = requestPermissions(request, String(request.params.workId));
     if (!canWriteWorkModule(permissions, "ai-chat")) {
       throw new AppError(403, "WORK_MODULE_WRITE_DENIED", "你没有使用创作助手的权限");
     }
+    return permissions;
+  };
+  app.post("/api/works/:workId/desktop-local-ai/runs", async (request, response) => {
+    const input = parse(desktopLocalAiRunSchema, request.body);
+    const permissions = assertDesktopLocalAiPermission(request);
     const citations = input.citations ?? [];
     for (const citation of citations) {
       if (store.getChapter(citation.chapterId).workId !== request.params.workId) {
@@ -3279,16 +3321,33 @@ export function createRuntime(options: RuntimeOptions): Runtime {
         throw new AppError(400, "CONVERSATION_WORK_MISMATCH", "AI 对话不属于当前作品");
       }
     }
-    data(response, ai.prepareDesktopLocalAiCompletion({
+    data(response, await ai.startDesktopLocalAiRun({
       workId: request.params.workId,
       taskType: input.taskType,
       instruction: instructionWithCitations(input.instruction, citations),
       scope: input.scope as ContextScope,
-      contextWindow: input.contextWindow,
-      maxOutputTokens: input.maxOutputTokens,
+      runtimeModel: input.runtimeModel,
       ...(input.conversationId ? { conversationId: input.conversationId } : {}),
-      ...(input.currentMessageId ? { excludeConversationMessageId: input.currentMessageId } : {})
-    }));
+      ...(input.currentMessageId ? { excludeConversationMessageId: input.currentMessageId } : {}),
+      ...(input.imageAttachmentIds?.length ? { imageAttachmentIds: input.imageAttachmentIds } : {}),
+      ...(input.sceneDirection ? { sceneDirection: input.sceneDirection } : {})
+    }, desktopLocalAiActorScope(request), currentRequestActor(), permissions), 202);
+  });
+  app.get("/api/works/:workId/desktop-local-ai/runs/:runId", (request, response) => {
+    assertDesktopLocalAiPermission(request);
+    const runId = parse(identifier, request.params.runId);
+    data(response, ai.desktopLocalAiRunStatus(runId, request.params.workId, desktopLocalAiActorScope(request)));
+  });
+  app.post("/api/works/:workId/desktop-local-ai/runs/:runId/responses", (request, response) => {
+    assertDesktopLocalAiPermission(request);
+    const runId = parse(identifier, request.params.runId);
+    const input = parse(desktopLocalAiCompletionResponseSchema, request.body);
+    data(response, ai.submitDesktopLocalAiCompletion(runId, request.params.workId, desktopLocalAiActorScope(request), input));
+  });
+  app.delete("/api/works/:workId/desktop-local-ai/runs/:runId", (request, response) => {
+    assertDesktopLocalAiPermission(request);
+    const runId = parse(identifier, request.params.runId);
+    data(response, ai.cancelDesktopLocalAiRun(runId, request.params.workId, desktopLocalAiActorScope(request)));
   });
   app.post("/api/works/:workId/suggestions", async (request, response) => {
     const input = parse(z.object({

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -91,12 +91,13 @@ describe("AI 供应商、模型与建议 API", () => {
     runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", contextWindow, modelId);
   }
 
-  it("为 Desktop 本地模型准备 Server Prompt 和作品上下文但不调用远端供应商", async () => {
+  it("让 Desktop 本地模型复用 Server Agent 工具循环且不调用远端供应商", async () => {
     await request(runtime.app).patch("/api/platform/ai/settings").send({
       systemPrompt: "平台远端 Prompt"
     }).expect(200);
     await request(runtime.app).patch(`/api/works/${workId}/ai-settings`).send({
-      systemPrompt: "作品远端 Prompt"
+      systemPrompt: "作品远端 Prompt",
+      agentTools: ["story_index"]
     }).expect(200);
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
     const conversationId = String(conversation.body.data.id);
@@ -113,32 +114,119 @@ describe("AI 供应商、模型与建议 API", () => {
       content: "请结合跃迁限制继续讨论"
     }).expect(201);
 
-    const prepared = await request(runtime.app).post(`/api/works/${workId}/desktop-local-ai/prepare`).send({
+    const started = await request(runtime.app).post(`/api/works/${workId}/desktop-local-ai/runs`).send({
       taskType: "chat",
       instruction: "请结合跃迁限制继续讨论",
       scope: { type: "chapter", chapterId },
-      contextWindow: 128_000,
-      maxOutputTokens: 4_096,
+      runtimeModel: {
+        id: "desktop-local-model",
+        providerId: "desktop-local-provider",
+        providerName: "local/LM Studio",
+        protocol: "openai-chat-completions",
+        maxTokensParameter: "max_tokens",
+        thinkingType: "enabled",
+        concurrencyLimit: 3,
+        rpmLimit: 30,
+        analysisTimeoutSeconds: 300,
+        displayName: "本地模型",
+        modelId: "local-model",
+        purposes: ["chat", "continue", "polish"],
+        contextNote: "",
+        contextWindow: 128_000,
+        outputNote: "",
+        preset: { temperature: 0.4, max_tokens: 4_096 },
+        thinkingEnabled: false,
+        thinkingEffort: "default",
+        multimodalEnabled: false,
+        note: ""
+      },
       conversationId,
       currentMessageId: current.body.data.id
-    }).expect(200);
+    }).expect(202);
+
+    const runId = String(started.body.data.id);
+    const waitForStatus = async (expected: string): Promise<Record<string, unknown>> => {
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const polled = await request(runtime.app).get(`/api/works/${workId}/desktop-local-ai/runs/${runId}`).expect(200);
+        if (polled.body.data.status === expected) return polled.body.data as Record<string, unknown>;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      throw new Error(`Desktop local AI run did not reach ${expected}`);
+    };
+
+    const firstRound = await waitForStatus("awaiting-completion");
+    const firstCompletion = firstRound.completion as { requestId: string; body: Record<string, unknown> };
+    const firstBody = firstCompletion.body as {
+      model: string;
+      messages: Array<{ role: string; content: unknown }>;
+      tools: Array<{ function?: { name?: string } }>;
+      tool_choice: string;
+    };
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(prepared.body.data.remoteSystemPrompt).toContain("<platform_system_prompt>");
-    expect(prepared.body.data.remoteSystemPrompt).toContain("平台远端 Prompt");
-    expect(prepared.body.data.remoteSystemPrompt).toContain("<work_system_prompt>");
-    expect(prepared.body.data.remoteSystemPrompt).toContain("作品远端 Prompt");
-    expect(prepared.body.data.remoteSystemPrompt).not.toContain("desktop_local_ai_prompt");
-    expect(prepared.body.data.messages).toEqual(expect.arrayContaining([
-      { role: "user", content: "上一轮问题" },
-      { role: "assistant", content: "上一轮回答" }
-    ]));
-    expect(JSON.stringify(prepared.body.data.messages)).toContain("跃迁后必须冷却十二小时");
-    expect(JSON.stringify(prepared.body.data.messages)).toContain("<author_instruction>");
-    expect(prepared.body.data.contextUsage).toMatchObject({
+    expect(firstBody.model).toBe("local-model");
+    expect(firstBody.tool_choice).toBe("auto");
+    expect(firstBody.tools.some((tool) => tool.function?.name === "story_index")).toBe(true);
+    expect(JSON.stringify(firstBody.messages[0]?.content)).toContain("<platform_system_prompt>");
+    expect(JSON.stringify(firstBody.messages[0]?.content)).toContain("平台远端 Prompt");
+    expect(JSON.stringify(firstBody.messages[0]?.content)).toContain("<work_system_prompt>");
+    expect(JSON.stringify(firstBody.messages[0]?.content)).toContain("作品远端 Prompt");
+    expect(JSON.stringify(firstBody.messages)).toContain("上一轮问题");
+    expect(JSON.stringify(firstBody.messages)).toContain("上一轮回答");
+    expect(JSON.stringify(firstBody.messages)).toContain("跃迁后必须冷却十二小时");
+    expect(JSON.stringify(firstBody.messages)).toContain("<author_instruction>");
+    expect(firstRound.contextUsage).toMatchObject({
       modelId: "desktop-local-model",
       contextWindow: 128_000
     });
+    expect(Number(((firstRound.contextUsage as { tokenDistribution: { functionTokens: number } }).tokenDistribution.functionTokens))).toBeGreaterThan(0);
+
+    await request(runtime.app)
+      .post(`/api/works/${workId}/desktop-local-ai/runs/${runId}/responses`)
+      .send({
+        requestId: firstCompletion.requestId,
+        status: 200,
+        body: JSON.stringify({
+          choices: [{
+            finish_reason: "tool_calls",
+            message: {
+              content: null,
+              tool_calls: [{
+                id: "call-story-index",
+                type: "function",
+                function: { name: "story_index", arguments: "{}" }
+              }]
+            }
+          }]
+        })
+      })
+      .expect(200);
+
+    const secondRound = await waitForStatus("awaiting-completion");
+    const secondCompletion = secondRound.completion as { requestId: string; body: Record<string, unknown> };
+    expect(secondCompletion.requestId).not.toBe(firstCompletion.requestId);
+    expect(JSON.stringify(secondCompletion.body)).toContain('"role":"tool"');
+    expect(JSON.stringify(secondCompletion.body)).toContain("AI 测试作品");
+    expect((secondCompletion.body.tools as unknown[]).length).toBeGreaterThan(0);
+
+    await request(runtime.app)
+      .post(`/api/works/${workId}/desktop-local-ai/runs/${runId}/responses`)
+      .send({
+        requestId: secondCompletion.requestId,
+        status: 200,
+        body: JSON.stringify({ choices: [{ finish_reason: "stop", message: { content: "已查询作品目录，跃迁冷却限制仍然有效。" } }] })
+      })
+      .expect(200);
+
+    const completed = await waitForStatus("completed");
+    expect(completed.result).toMatchObject({
+      content: "已查询作品目录，跃迁冷却限制仍然有效。",
+      provider: { scope: "local", name: "local/LM Studio" },
+      model: { id: "desktop-local-model", scope: "local" },
+      toolCalls: [expect.objectContaining({ name: "story_index", status: "completed" })]
+    });
+    expect(Number((((completed.result as { contextUsage: { tokenDistribution: { functionTokens: number } } }).contextUsage.tokenDistribution.functionTokens)))).toBeGreaterThan(0);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,11 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: false,
-    pool: "forks",
+    pool: "threads",
     maxWorkers: 8,
     fileParallelism: true,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     include: ["tests/**/*.test.ts"],
     exclude: ["dist/**", "node_modules/**"],
     coverage: {


### PR DESCRIPTION
## 变更\n\n- 删除 Desktop 本地模型禁用 tools 的准备旁路\n- 由 Server 生成完整模型请求，Desktop 只在本机调用模型并回传响应\n- 复用现有 Agent 工具执行、权限校验、上下文压缩、建议守卫与 Token 分布\n- 本地 API Key 和 Base URL 仍只保存在 Desktop，不传给 Server\n- Vitest 使用 8 个线程，并将单测与钩子超时调整为 30 秒\n\n## 验证\n\n- npm run typecheck\n- tests/integration/ai-api.test.ts：90/90\n- npm test：232 files、1190 tests 全部通过\n- npm run build\n- 真实 Desktop 本地工作区：story_index 工具两轮调用成功，function Token 为 2213