### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.8.8",
+      "version": "0.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.8.8";
+export const APP_VERSION = "0.9.0";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 顶层与根包版本、`src/version.ts` 同步升级到 `0.9.0`
- 为首个支持 Scriverse Desktop 的 Server 版本做发布准备

## CLI 审计

- Desktop 登录、离线同步、本地模型中继接口是桌面客户端专用协议，不新增通用 CLI 命令
- 供应商分析超时属于 CLI 明确禁止的 AI 供应商管理范围
- 现有作品、章节、设定库、搜索、认证和导出 CLI 契约未失效，无需 CLI 变更

## 验证

- `tests/unit/version.test.ts`
- `npm run typecheck`
- `npm run build`