### PR TITLE
MUXUE-99: allow closing analysis dialog without a model

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -567,7 +567,7 @@
       <form id="dynamic-form" method="dialog">
         <div class="dialog-header">
           <div><span id="dialog-eyebrow" class="eyebrow">新增</span><h2 id="dialog-title">创建记录</h2><input id="dialog-title-input" class="dialog-title-input hidden" type="text" autocomplete="off" aria-label="记录标题"><p id="dialog-meta" class="dialog-header-meta hidden"></p></div>
-          <div class="settings-dialog-header-actions"><div id="dialog-context-actions" class="dialog-context-actions"></div><button class="dialog-close" value="cancel" aria-label="关闭" type="submit">×</button></div>
+          <div class="settings-dialog-header-actions"><div id="dialog-context-actions" class="dialog-context-actions"></div><button class="dialog-close" value="cancel" aria-label="关闭" type="submit" formnovalidate>×</button></div>
         </div>
         <div id="dialog-fields" class="dialog-fields"></div>
         <div id="dialog-submit-status" class="dialog-submit-status hidden" role="status" aria-live="polite">
@@ -575,7 +575,7 @@
           <div class="dialog-submit-progress" role="progressbar" aria-label="提交处理中" aria-valuetext="正在等待服务器响应"><span></span></div>
         </div>
         <div class="dialog-actions">
-          <button class="ghost-button" value="cancel" type="submit">取消</button>
+          <button class="ghost-button" value="cancel" type="submit" formnovalidate>取消</button>
           <button id="dialog-submit" class="primary-button" value="default" type="submit">保存</button>
         </div>
       </form>

--- a/tests/system/analysis-scope-ui.test.ts
+++ b/tests/system/analysis-scope-ui.test.ts
@@ -18,6 +18,8 @@ describe("AI 分析范围交互", () => {
     expect(application).toContain('const settingsOnly = taskType === "relationship-analysis" && scopeType === "settings"');
     expect(application).toContain('function analysisTaskModelPurpose(taskType)');
     expect(application).toContain('name="modelId" required aria-describedby="analysis-task-model-help"');
+    expect(page).toContain('class="dialog-close" value="cancel" aria-label="关闭" type="submit" formnovalidate');
+    expect(page).toContain('class="ghost-button" value="cancel" type="submit" formnovalidate>取消</button>');
     expect(application).toContain('默认值来自“本书 AI 设置”，只修改当前任务，不会改变全书默认模型。');
     expect(application).toContain('const defaultId = defaultModelByTask.get(analysisTaskModelPurpose(taskTypeSelect.value)) ?? ""');
     expect(application).toContain('body: { taskType, scope, modelId }');


### PR DESCRIPTION
Closes MUXUE-99

## Summary

- let the shared form dialog close and cancel buttons bypass native form validation
- keep the AI analysis model required when creating a task
- cover both dialog dismissal controls with a system regression assertion

## Verification

- `npm test -- tests/system/analysis-scope-ui.test.ts`
- `npm run typecheck`
- `npm test -- --reporter=dot` (235 files, 1196 tests)
- `npm run build`
- browser checks at 1280×720 and 390×844
- isolated SQLite `integrity_check` and `foreign_key_check`
