### PR TITLE
chore(release): bump version to 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.9.1";
+export const APP_VERSION = "0.9.2";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 将 `package.json`、根 `package-lock.json` 元数据和运行时 `APP_VERSION` 同步更新为 `0.9.2`

## CLI 审计

- 本版本没有新增或改变 CLI 所需的 API 路由、请求结构、响应结构、认证范围或导入导出格式
- 无需追加 CLI 命令或契约改动

## 验证

- `tests/unit/version.test.ts`：2 项通过
- `npm run check`：类型检查、236 个测试文件 / 1199 项测试、生产构建全部通过