### PR TITLE
MUXUE-98: chunk and consolidate timeline analysis

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -8353,13 +8353,17 @@ export class AiManager {
   }
 
   private generateTaggedJson(input: GenerateInput): Promise<GenerateResult> {
+    return this.generate(this.taggedJsonInput(input));
+  }
+
+  private taggedJsonInput(input: GenerateInput): GenerateInput {
     const userRequirement = "将最终 JSON 放在唯一一对 <json> 和 </json> 标签中；标签外不要输出任何内容，也不要使用 Markdown 代码块。";
     const systemRequirement = "结构化响应要求：最终 JSON 必须且只能放在唯一一对 <json> 和 </json> 标签中。";
-    return this.generate({
+    return {
       ...input,
       instruction: `${input.instruction}\n${userRequirement}`,
       extraSystemPrompt: [input.extraSystemPrompt, systemRequirement].filter(Boolean).join("\n")
-    });
+    };
   }
 
   async generate(input: GenerateInput, onDelta?: (delta: string) => void): Promise<GenerateResult> {
@@ -9857,6 +9861,7 @@ export class AiManager {
     modelId?: string,
     taskId?: string
   ): Promise<{ nodes: TimelineAggregationNode[]; callIds: string[]; batchCount: number }> {
+    const { model } = this.resolveModel(workId, "timeline-analysis", modelId);
     let nodes = candidates.map((candidate) => ({
       nodeId: candidate.candidateId,
       sourceCandidateIds: [candidate.candidateId],
@@ -9881,31 +9886,11 @@ export class AiManager {
           [right.name, right.timeLabel, right.location].join("|"),
           "zh-CN"
         ));
-      const batches = this.buildTimelineAggregationBatches(orderedNodes, candidates, includeEvidence);
+      const batches = this.buildTimelineAggregationBatches(workId, orderedNodes, candidates, includeEvidence, model, modelId, taskId);
       const aggregationResults = await this.processChunks(batches, Math.min(concurrency, 4), async (batch, batchIndex) => {
         if (taskId && this.store.getTask(taskId).status !== "running") return { nodes: batch, callId: null };
         const payload = batch.map((node) => this.timelineAggregationPayload(node, candidates, includeEvidence));
-        const generated = await this.generateTaggedJson({
-          workId,
-          taskId,
-          taskType: "timeline-analysis",
-          signal: this.taskSignal(taskId),
-          maxAttempts: 2,
-          scope: { type: "entities", suppressAutomaticContext: true },
-          ...(modelId ? { modelId } : {}),
-          parameters: { temperature: 0.1 },
-          instruction: [
-            "你是小说时间线候选归并器。请对下面的证据账本候选做保守归并，输出 JSON 数组。",
-            "每项字段：candidateIds、name、description、eventType、timeLabel、timeSort、location、impactScope。candidateIds 只能引用输入对象的 candidateId，不能引用 sourceCandidateIds，并且每个输入 candidateId 最多出现一次。",
-            "只有证据足以确认是同一个故事事件时才能把多个 ID 放入一组；名称相似、参与者相同或章节相邻本身都不够。证据不足时保持单项组，禁止省略候选。",
-            "timeSort 只能沿用组内已经存在且有明确时间依据的有限数字；不得按章节或叙述顺序新造排序值。倒叙和回忆以事件发生时间为准。",
-            includeEvidence
-              ? "本层包含经服务端核验的短引文。只可据此归并，不得补充新证据、章节或人物。"
-              : "本层只包含下层摘要和证据引用，不含正文。只可归并这些摘要，不得推断引用之外的新事实。",
-            `候选账本：${JSON.stringify(payload)}`
-          ].join("\n"),
-          extraSystemPrompt: "归并结果只定义本次任务内的候选分组。宁可保留两个候选，也不要误合并证据不足的事件。"
-        });
+        const generated = await this.generateTaggedJson(this.timelineAggregationInput(workId, payload, includeEvidence, modelId, taskId));
         const extracted = extractJson<unknown>(generated.content);
         if (!Array.isArray(extracted)) throw new AppError(502, "AI_INVALID_JSON", "时间线归并结果必须是数组");
         return {
@@ -9930,25 +9915,113 @@ export class AiManager {
   }
 
   private buildTimelineAggregationBatches(
+    workId: string,
     nodes: TimelineAggregationNode[],
     candidates: TimelineLedgerCandidate[],
-    includeEvidence: boolean
+    includeEvidence: boolean,
+    model: ModelRow,
+    modelId?: string,
+    taskId?: string
   ): TimelineAggregationNode[][] {
-    const batches: TimelineAggregationNode[][] = [];
+    const characterBoundedBatches: TimelineAggregationNode[][] = [];
     let batch: TimelineAggregationNode[] = [];
     let batchLength = 2;
     for (const node of nodes) {
       const itemLength = JSON.stringify(this.timelineAggregationPayload(node, candidates, includeEvidence)).length + 1;
       if (batch.length > 0 && batchLength + itemLength > TIMELINE_AGGREGATION_MAX_CHARS) {
-        batches.push(batch);
+        characterBoundedBatches.push(batch);
         batch = [];
         batchLength = 2;
       }
       batch.push(node);
       batchLength += itemLength;
     }
-    if (batch.length > 0) batches.push(batch);
-    return batches;
+    if (batch.length > 0) characterBoundedBatches.push(batch);
+
+    const fitToModelBudget = (candidateBatch: TimelineAggregationNode[]): TimelineAggregationNode[][] => {
+      const payload = candidateBatch.map((node) => this.timelineAggregationPayload(node, candidates, includeEvidence));
+      const usage = this.timelineAggregationInputUsage(
+        this.timelineAggregationInput(workId, payload, includeEvidence, modelId, taskId),
+        model
+      );
+      if (usage.inputTokens <= usage.maximumInputTokens) return [candidateBatch];
+      if (candidateBatch.length === 1) {
+        throw new AppError(413, "TIMELINE_AGGREGATION_CONTEXT_TOO_LARGE", "单个时间线候选连同归并提示已超过所选模型的安全上下文容量", {
+          candidateId: candidateBatch[0]?.nodeId,
+          inputTokens: usage.inputTokens,
+          maximumInputTokens: usage.maximumInputTokens,
+          contextWindow: usage.contextWindow,
+          outputReserveTokens: usage.outputReserveTokens
+        });
+      }
+      const middle = Math.ceil(candidateBatch.length / 2);
+      return [
+        ...fitToModelBudget(candidateBatch.slice(0, middle)),
+        ...fitToModelBudget(candidateBatch.slice(middle))
+      ];
+    };
+    return characterBoundedBatches.flatMap((candidateBatch) => fitToModelBudget(candidateBatch));
+  }
+
+  private timelineAggregationInput(
+    workId: string,
+    payload: Record<string, unknown>[],
+    includeEvidence: boolean,
+    modelId?: string,
+    taskId?: string
+  ): GenerateInput {
+    return {
+      workId,
+      taskId,
+      taskType: "timeline-analysis",
+      signal: this.taskSignal(taskId),
+      maxAttempts: 2,
+      scope: { type: "entities", suppressAutomaticContext: true },
+      ...(modelId ? { modelId } : {}),
+      parameters: { temperature: 0.1 },
+      agentToolIds: [],
+      disableTools: true,
+      instruction: [
+        "你是小说时间线候选归并器。请对下面的证据账本候选做保守归并，输出 JSON 数组。",
+        "每项字段：candidateIds、name、description、eventType、timeLabel、timeSort、location、impactScope。candidateIds 只能引用输入对象的 candidateId，不能引用 sourceCandidateIds，并且每个输入 candidateId 最多出现一次。",
+        "只有证据足以确认是同一个故事事件时才能把多个 ID 放入一组；名称相似、参与者相同或章节相邻本身都不够。证据不足时保持单项组，禁止省略候选。",
+        "timeSort 只能沿用组内已经存在且有明确时间依据的有限数字；不得按章节或叙述顺序新造排序值。倒叙和回忆以事件发生时间为准。",
+        includeEvidence
+          ? "本层包含经服务端核验的短引文。只可据此归并，不得补充新证据、章节或人物。"
+          : "本层只包含下层摘要和证据引用，不含正文。只可归并这些摘要，不得推断引用之外的新事实。",
+        `候选账本：${JSON.stringify(payload)}`
+      ].join("\n"),
+      extraSystemPrompt: "归并结果只定义本次任务内的候选分组。宁可保留两个候选，也不要误合并证据不足的事件。"
+    };
+  }
+
+  private timelineAggregationInputUsage(input: GenerateInput, model: ModelRow): {
+    inputTokens: number;
+    maximumInputTokens: number;
+    contextWindow: number;
+    outputReserveTokens: number;
+  } {
+    const taggedInput = this.taggedJsonInput(input);
+    const budget = this.contextBudget(taggedInput, model);
+    const conversation = budget.conversation as AiConversationContext | null;
+    const context = this.buildContext(taggedInput, model, budget);
+    const messages = this.buildMessages(taggedInput, context, conversation);
+    const tools = taggedInput.disableTools
+      ? []
+      : this.enabledAgentTools(
+        taggedInput.workId,
+        taggedInput.taskType,
+        taggedInput.agentToolIds,
+        taggedInput.conversationId,
+        this.roleplayCharacterIdFromConversation(taggedInput.workId, conversation)
+      );
+    return {
+      inputTokens: estimateCompletionMessageTokens(messages)
+        + (tools.length > 0 ? estimateAiTokens(JSON.stringify(tools)) : 0),
+      maximumInputTokens: Number(budget.availableInputTokens),
+      contextWindow: Number(budget.contextWindow),
+      outputReserveTokens: Number(budget.outputReserveTokens)
+    };
   }
 
   private timelineAggregationPayload(

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -617,6 +617,36 @@ type CharacterExtractionApplicationItem = {
   conflicts?: string[];
 };
 
+type TimelineEvidence = {
+  chapterId: string;
+  chapterTitle: string;
+  quote: string;
+};
+
+type TimelineCandidateFields = {
+  name: string;
+  description: string;
+  eventType: string;
+  timeLabel: string;
+  timeSort: number | null;
+  location: string;
+  impactScope: "personal" | "organization" | "regional" | "world" | "galaxy";
+};
+
+type TimelineLedgerCandidate = TimelineCandidateFields & {
+  candidateId: string;
+  chapterIds: string[];
+  participantIds: string[];
+  evidence: TimelineEvidence[];
+};
+
+type TimelineAggregationNode = TimelineCandidateFields & {
+  nodeId: string;
+  sourceCandidateIds: string[];
+  participantIds: string[];
+  evidenceRefs: string[];
+};
+
 const allowedParameters = new Set(["temperature", "top_p", "max_tokens", "presence_penalty", "frequency_penalty", "seed"]);
 const DEFAULT_MAX_TOKENS = 32_000;
 const MAX_MODEL_OUTPUT_TOKENS = 2_000_000;
@@ -629,6 +659,11 @@ const RELATIONSHIP_MAX_FUZZY_SCAN_CHARACTERS = 4_000_000;
 const RELATIONSHIP_MAX_FUZZY_MATCHES = 600;
 const RELATIONSHIP_MAX_SOURCE_MATCHES = 256;
 const RELATIONSHIP_PREFILTER_DISABLE_HINT = "请取消勾选“分析前按人物名称和拼音过滤来源”后重新预览";
+const TIMELINE_CHUNK_MAX_CHARS = 10_000;
+const TIMELINE_CHUNK_OVERLAP_CHARS = 600;
+const TIMELINE_AGGREGATION_MAX_CHARS = 55_000;
+const TIMELINE_MAX_CANDIDATES_PER_CHUNK = 200;
+const TIMELINE_MAX_EVIDENCE_PER_CANDIDATE = 24;
 
 type HybridChapterLineRangeFallbackChapter = {
   chapterVersion: number;
@@ -4554,7 +4589,12 @@ export class AiManager {
       instruction = `审核角色规范表，找出疑似重复角色并给出原文证据。角色规范表：\n${roster}`;
       agentToolIds = ["search_story_entities", "grep", "read_chapters"];
     } else if (taskType === "timeline-analysis") {
-      instruction = "抽取所选范围内的大事件候选，区分发生时间与叙述时间，并为每项提供原文证据。";
+      const chapters = this.getScopeChapters(workId, scope);
+      if (chapters.length === 0) throw new AppError(409, "CHAPTERS_REQUIRED", "时间轴分析范围内没有章节");
+      const chunks = this.buildTimelineChapterChunks(chapters);
+      const selection = [...chunks].sort((left, right) => right.text.length - left.text.length)[0]?.text ?? "";
+      previewScope = { type: "selection", selection };
+      instruction = "从本批正文抽取大事件证据账本，区分发生时间与叙述时间，并为每项提供可核验的原文证据。";
     } else if (taskType === "worldview-analysis") {
       instruction = "分析所选范围内已经出现的世界观，区分事实、传闻和未知项，并为结论提供原文证据。";
     } else if (taskType === "consistency-check") {
@@ -9604,38 +9644,419 @@ export class AiManager {
   }
 
   private async runTimelineAnalysis(workId: string, scope: ContextScope, modelId?: string, taskId?: string): Promise<Record<string, unknown>> {
-    const generated = await this.generateTaggedJson({
-      workId,
-      taskId,
-      taskType: "timeline-analysis",
-      signal: this.taskSignal(taskId),
-      instruction: "抽取大事件候选并输出 JSON 数组。每项字段：name、description、eventType、timeLabel、timeSort（无法确定为 null）、location、impactScope、chapterIds、participantIds、evidence。必须区分发生时间与叙述时间；不确定时使用‘时间待定’。",
-      scope,
-      ...(modelId ? { modelId } : {}),
-      extraSystemPrompt: "本任务要求严格输出可解析的 JSON。仅生成候选，不得声称已确认。"
+    const chapters = this.getScopeChapters(workId, scope);
+    if (chapters.length === 0) throw new AppError(409, "CHAPTERS_REQUIRED", "时间轴分析范围内没有章节");
+    const chunks = this.buildTimelineChapterChunks(chapters);
+    const concurrency = this.configuredConcurrency(workId, "timeline-analysis", modelId);
+    const chunkResults = await this.processChunks(chunks, concurrency, async (chunk) => {
+      if (taskId && this.store.getTask(taskId).status !== "running") return { candidates: [], callId: null };
+      const generated = await this.generateTaggedJson({
+        workId,
+        taskId,
+        taskType: "timeline-analysis",
+        signal: this.taskSignal(taskId),
+        maxAttempts: 2,
+        instruction: [
+          "从本批正文抽取时间线事件证据账本，输出 JSON 数组；没有合格事件时输出 []。",
+          "每项字段：name、description、eventType、timeLabel、timeSort、location、impactScope、participantReferences、evidence。",
+          "timeSort 只有在原文明示了可用于排序的故事发生时间时才能填写有限数字，否则必须为 null；不得用章节顺序或叙述顺序代替故事发生顺序。",
+          "impactScope 只能是 personal、organization、regional、world、galaxy。participantReferences 只填写原文中的人物姓名、无歧义别名或给定 ID，禁止创造人物 ID。",
+          "每条 evidence 必须包含 chapterId、chapterTitle、quote；quote 必须是对应章节中的连续短引文且不超过 120 字。",
+          "倒叙、回忆和转述按事件实际发生时间理解；证据不足的相似事件保持分开。相邻片段重复出现的同一事件仍应保留相同名称和时间描述，交由后续归并。"
+        ].join("\n"),
+        scope: { type: "selection", selection: chunk.text },
+        ...(modelId ? { modelId } : {}),
+        parameters: { temperature: 0.1 },
+        extraSystemPrompt: "你是严格的小说时间线证据抽取器。只记录给定正文中的事实，不得补写、推断缺失时间或声称候选已确认。"
+      });
+      const extracted = extractJson<unknown>(generated.content);
+      if (!Array.isArray(extracted)) throw new AppError(502, "AI_INVALID_JSON", "时间轴分片分析结果必须是数组");
+      return {
+        candidates: extracted
+          .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object" && !Array.isArray(item))
+          .slice(0, TIMELINE_MAX_CANDIDATES_PER_CHUNK),
+        callId: generated.callId
+      };
+    }, (completed) => {
+      if (taskId && this.store.getTask(taskId).status === "running") {
+        this.store.updateTask(taskId, { status: "running", progress: Math.min(65, 5 + Math.round(completed / chunks.length * 60)) });
+      }
     });
-    const events = extractJson<Array<Record<string, unknown>>>(generated.content);
-    if (!Array.isArray(events)) throw new AppError(502, "AI_INVALID_JSON", "时间轴分析结果必须是数组");
-    if (!this.taskCanCommit(taskId)) return { interrupted: true, callId: generated.callId };
-    const eventIds: string[] = [];
-    for (const event of events) {
-      if (typeof event.name !== "string" || !event.name.trim()) continue;
+    const rawCandidates = chunkResults.flatMap((result) => result.candidates);
+    const callIds = chunkResults.map((result) => result.callId).filter((callId): callId is string => typeof callId === "string");
+    const interruptedResult = (): Record<string, unknown> => ({
+      interrupted: true,
+      callId: callIds[0] ?? null,
+      callIds,
+      batchCount: chunks.length,
+      coveredChapterCount: chapters.length,
+      rawCandidateCount: rawCandidates.length
+    });
+    if (!this.taskCanCommit(taskId)) return interruptedResult();
+
+    const skipped: Array<{ index: number; name: string; reason: string }> = [];
+    const characterIds = new Set(this.store.listCharacters(workId).map((character) => String(character.id)));
+    const validated = rawCandidates.flatMap((candidate, index) => {
+      const normalized = this.normalizeTimelineLedgerCandidate(workId, chapters, characterIds, candidate, index);
+      if ("reason" in normalized) {
+        skipped.push({ index, name: normalized.name, reason: normalized.reason });
+        return [];
+      }
+      return [normalized.candidate];
+    });
+    const ledger = this.mergeExactTimelineCandidates(validated);
+    if (!this.taskCanCommit(taskId)) return { ...interruptedResult(), skipped };
+
+    const aggregation = await this.aggregateTimelineCandidates(workId, ledger, concurrency, modelId, taskId);
+    callIds.push(...aggregation.callIds);
+    if (!this.taskCanCommit(taskId)) return { ...interruptedResult(), skipped };
+    const finalCandidates = this.materializeTimelineCandidates(aggregation.nodes, ledger);
+    if (!this.taskCanCommit(taskId)) return { ...interruptedResult(), skipped };
+
+    const eventIds = this.store.db.transaction(() => finalCandidates.map((event) => {
       const created = this.store.createTimelineEvent(workId, {
         name: event.name,
-        description: typeof event.description === "string" ? event.description : "",
-        eventType: typeof event.eventType === "string" ? event.eventType : "other",
-        timeLabel: typeof event.timeLabel === "string" ? event.timeLabel : "时间待定",
-        timeSort: typeof event.timeSort === "number" ? event.timeSort : null,
-        chapterIds: Array.isArray(event.chapterIds) ? event.chapterIds.filter((value): value is string => typeof value === "string") : [],
-        participantIds: Array.isArray(event.participantIds) ? event.participantIds.filter((value): value is string => typeof value === "string") : [],
-        location: typeof event.location === "string" ? event.location : "",
-        impactScope: typeof event.impactScope === "string" ? event.impactScope : "personal",
-        evidence: Array.isArray(event.evidence) ? event.evidence : [],
+        description: event.description,
+        eventType: event.eventType,
+        timeLabel: event.timeLabel,
+        timeSort: event.timeSort,
+        chapterIds: event.chapterIds,
+        participantIds: event.participantIds,
+        location: event.location,
+        impactScope: event.impactScope,
+        evidence: event.evidence,
         status: "candidate"
-      }, "analysis", taskId ?? generated.callId);
-      eventIds.push(String(created.id));
+      }, "analysis", taskId ?? callIds[0] ?? null);
+      return String(created.id);
+    }));
+    return {
+      eventIds,
+      candidateCount: eventIds.length,
+      callId: callIds[0] ?? null,
+      callIds,
+      batchCount: chunks.length,
+      aggregationBatchCount: aggregation.batchCount,
+      coveredChapterCount: chapters.length,
+      rawCandidateCount: rawCandidates.length,
+      skipped
+    };
+  }
+
+  private normalizeTimelineLedgerCandidate(
+    workId: string,
+    chapters: Record<string, unknown>[],
+    characterIds: Set<string>,
+    raw: Record<string, unknown>,
+    index: number
+  ): { candidate: TimelineLedgerCandidate } | { name: string; reason: string } {
+    const name = typeof raw.name === "string" ? raw.name.normalize("NFKC").trim() : "";
+    if (!name) return { name: "未命名候选", reason: "事件名称为空" };
+    const description = typeof raw.description === "string" ? raw.description.trim() : "";
+    const eventType = typeof raw.eventType === "string" && raw.eventType.trim() ? raw.eventType.trim() : "other";
+    const rawTimeLabel = typeof raw.timeLabel === "string" && raw.timeLabel.trim() ? raw.timeLabel.trim() : "时间待定";
+    const location = typeof raw.location === "string" ? raw.location.trim() : "";
+    if (name.length > 300 || description.length > 100_000 || eventType.length > 100 || rawTimeLabel.length > 300 || location.length > 500) {
+      return { name: name.slice(0, 300), reason: "事件字段超过允许长度" };
     }
-    return { eventIds, candidateCount: eventIds.length, callId: generated.callId };
+    const evidenceInput = (Array.isArray(raw.evidence) ? raw.evidence : []).filter((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+      const quote = (item as Record<string, unknown>).quote;
+      return typeof quote === "string" && quote.trim().length > 0 && quote.trim().length <= 120;
+    });
+    const evidence = this.validateAnalysisEvidence(chapters, evidenceInput)
+      .map((item) => ({
+        chapterId: String(item.chapterId),
+        chapterTitle: String(item.chapterTitle),
+        quote: String(item.quote)
+      }))
+      .filter((item, evidenceIndex, items) => items.findIndex((candidate) => this.timelineEvidenceKey(candidate) === this.timelineEvidenceKey(item)) === evidenceIndex)
+      .slice(0, TIMELINE_MAX_EVIDENCE_PER_CANDIDATE);
+    if (evidence.length === 0) return { name, reason: "原文证据无效或不属于本次章节范围" };
+    const allowedImpactScopes = new Set<TimelineCandidateFields["impactScope"]>(["personal", "organization", "regional", "world", "galaxy"]);
+    if (raw.impactScope !== undefined && (typeof raw.impactScope !== "string" || !allowedImpactScopes.has(raw.impactScope as TimelineCandidateFields["impactScope"]))) {
+      return { name, reason: "影响范围枚举无效" };
+    }
+    const timeLabel = rawTimeLabel;
+    const timeSort = typeof raw.timeSort === "number" && Number.isFinite(raw.timeSort) && !/待定|未知|不明|unknown/iu.test(timeLabel)
+      ? raw.timeSort
+      : null;
+    const participantReferences = [raw.participantReferences, raw.participants, raw.participantIds]
+      .flatMap((value) => Array.isArray(value) ? value : [])
+      .filter((value): value is string => typeof value === "string" && Boolean(value.trim()))
+      .map((value) => value.normalize("NFKC").trim().slice(0, 300))
+      .slice(0, 60);
+    const participantIds = [...new Set(participantReferences.flatMap((reference) => {
+      if (characterIds.has(reference)) return [reference];
+      try {
+        const resolved = this.store.resolveCharacterReference(workId, reference);
+        return resolved && characterIds.has(resolved) ? [resolved] : [];
+      } catch {
+        return [];
+      }
+    }))];
+    return {
+      candidate: {
+        candidateId: `timeline-candidate-${index + 1}`,
+        name,
+        description,
+        eventType,
+        timeLabel,
+        timeSort,
+        location,
+        impactScope: typeof raw.impactScope === "string" ? raw.impactScope as TimelineCandidateFields["impactScope"] : "personal",
+        chapterIds: [...new Set(evidence.map((item) => item.chapterId))],
+        participantIds,
+        evidence
+      }
+    };
+  }
+
+  private timelineEvidenceKey(evidence: Pick<TimelineEvidence, "chapterId" | "quote">): string {
+    return `${evidence.chapterId}|${evidence.quote.normalize("NFKC").replace(/\s+/gu, "").trim()}`;
+  }
+
+  private mergeExactTimelineCandidates(candidates: TimelineLedgerCandidate[]): TimelineLedgerCandidate[] {
+    const buckets = new Map<string, TimelineLedgerCandidate[]>();
+    const merged: TimelineLedgerCandidate[] = [];
+    for (const candidate of candidates) {
+      const key = [candidate.name, candidate.timeLabel, candidate.location]
+        .map((value) => this.normalizeReference(value))
+        .join("|");
+      const bucket = buckets.get(key) ?? [];
+      const evidenceKeys = new Set(candidate.evidence.map((item) => this.timelineEvidenceKey(item)));
+      const duplicate = bucket.find((item) => item.evidence.some((evidence) => evidenceKeys.has(this.timelineEvidenceKey(evidence))));
+      if (!duplicate) {
+        const copy = {
+          ...candidate,
+          chapterIds: [...candidate.chapterIds],
+          participantIds: [...candidate.participantIds],
+          evidence: [...candidate.evidence]
+        };
+        bucket.push(copy);
+        buckets.set(key, bucket);
+        merged.push(copy);
+        continue;
+      }
+      if (candidate.description.length > duplicate.description.length) duplicate.description = candidate.description;
+      if (duplicate.eventType === "other" && candidate.eventType !== "other") duplicate.eventType = candidate.eventType;
+      if (duplicate.timeSort === null && candidate.timeSort !== null) duplicate.timeSort = candidate.timeSort;
+      duplicate.chapterIds = [...new Set([...duplicate.chapterIds, ...candidate.chapterIds])];
+      duplicate.participantIds = [...new Set([...duplicate.participantIds, ...candidate.participantIds])];
+      const seenEvidence = new Set(duplicate.evidence.map((item) => this.timelineEvidenceKey(item)));
+      for (const evidence of candidate.evidence) {
+        if (!seenEvidence.has(this.timelineEvidenceKey(evidence))) duplicate.evidence.push(evidence);
+      }
+    }
+    return merged;
+  }
+
+  private async aggregateTimelineCandidates(
+    workId: string,
+    candidates: TimelineLedgerCandidate[],
+    concurrency: number,
+    modelId?: string,
+    taskId?: string
+  ): Promise<{ nodes: TimelineAggregationNode[]; callIds: string[]; batchCount: number }> {
+    let nodes = candidates.map((candidate) => ({
+      nodeId: candidate.candidateId,
+      sourceCandidateIds: [candidate.candidateId],
+      name: candidate.name,
+      description: candidate.description,
+      eventType: candidate.eventType,
+      timeLabel: candidate.timeLabel,
+      timeSort: candidate.timeSort,
+      location: candidate.location,
+      impactScope: candidate.impactScope,
+      participantIds: [...candidate.participantIds],
+      evidenceRefs: candidate.evidence.map((_evidence, index) => `${candidate.candidateId}#evidence-${index + 1}`)
+    }));
+    if (nodes.length <= 1) return { nodes, callIds: [], batchCount: 0 };
+    const callIds: string[] = [];
+    let batchCount = 0;
+    for (let level = 0; level < 6 && nodes.length > 1; level += 1) {
+      const includeEvidence = level === 0;
+      const orderedNodes = level === 0
+        ? nodes
+        : [...nodes].sort((left, right) => [left.name, left.timeLabel, left.location].join("|").localeCompare(
+          [right.name, right.timeLabel, right.location].join("|"),
+          "zh-CN"
+        ));
+      const batches = this.buildTimelineAggregationBatches(orderedNodes, candidates, includeEvidence);
+      const aggregationResults = await this.processChunks(batches, Math.min(concurrency, 4), async (batch, batchIndex) => {
+        if (taskId && this.store.getTask(taskId).status !== "running") return { nodes: batch, callId: null };
+        const payload = batch.map((node) => this.timelineAggregationPayload(node, candidates, includeEvidence));
+        const generated = await this.generateTaggedJson({
+          workId,
+          taskId,
+          taskType: "timeline-analysis",
+          signal: this.taskSignal(taskId),
+          maxAttempts: 2,
+          scope: { type: "entities", suppressAutomaticContext: true },
+          ...(modelId ? { modelId } : {}),
+          parameters: { temperature: 0.1 },
+          instruction: [
+            "你是小说时间线候选归并器。请对下面的证据账本候选做保守归并，输出 JSON 数组。",
+            "每项字段：candidateIds、name、description、eventType、timeLabel、timeSort、location、impactScope。candidateIds 只能引用输入对象的 candidateId，不能引用 sourceCandidateIds，并且每个输入 candidateId 最多出现一次。",
+            "只有证据足以确认是同一个故事事件时才能把多个 ID 放入一组；名称相似、参与者相同或章节相邻本身都不够。证据不足时保持单项组，禁止省略候选。",
+            "timeSort 只能沿用组内已经存在且有明确时间依据的有限数字；不得按章节或叙述顺序新造排序值。倒叙和回忆以事件发生时间为准。",
+            includeEvidence
+              ? "本层包含经服务端核验的短引文。只可据此归并，不得补充新证据、章节或人物。"
+              : "本层只包含下层摘要和证据引用，不含正文。只可归并这些摘要，不得推断引用之外的新事实。",
+            `候选账本：${JSON.stringify(payload)}`
+          ].join("\n"),
+          extraSystemPrompt: "归并结果只定义本次任务内的候选分组。宁可保留两个候选，也不要误合并证据不足的事件。"
+        });
+        const extracted = extractJson<unknown>(generated.content);
+        if (!Array.isArray(extracted)) throw new AppError(502, "AI_INVALID_JSON", "时间线归并结果必须是数组");
+        return {
+          nodes: this.applyTimelineAggregation(batch, extracted, level, batchIndex),
+          callId: generated.callId
+        };
+      }, (completed) => {
+        if (taskId && this.store.getTask(taskId).status === "running") {
+          const targetProgress = Math.min(92, 65 + level * 8 + Math.round(completed / batches.length * 8));
+          const currentProgress = Number(this.store.getTask(taskId).progress ?? 0);
+          this.store.updateTask(taskId, { status: "running", progress: Math.max(currentProgress, targetProgress) });
+        }
+      });
+      batchCount += batches.length;
+      callIds.push(...aggregationResults.map((result) => result.callId).filter((callId): callId is string => typeof callId === "string"));
+      const nextNodes = aggregationResults.flatMap((result) => result.nodes);
+      nodes = nextNodes;
+      if (batches.length === 1) break;
+      if (level > 0 && nextNodes.length >= orderedNodes.length) break;
+    }
+    return { nodes, callIds, batchCount };
+  }
+
+  private buildTimelineAggregationBatches(
+    nodes: TimelineAggregationNode[],
+    candidates: TimelineLedgerCandidate[],
+    includeEvidence: boolean
+  ): TimelineAggregationNode[][] {
+    const batches: TimelineAggregationNode[][] = [];
+    let batch: TimelineAggregationNode[] = [];
+    let batchLength = 2;
+    for (const node of nodes) {
+      const itemLength = JSON.stringify(this.timelineAggregationPayload(node, candidates, includeEvidence)).length + 1;
+      if (batch.length > 0 && batchLength + itemLength > TIMELINE_AGGREGATION_MAX_CHARS) {
+        batches.push(batch);
+        batch = [];
+        batchLength = 2;
+      }
+      batch.push(node);
+      batchLength += itemLength;
+    }
+    if (batch.length > 0) batches.push(batch);
+    return batches;
+  }
+
+  private timelineAggregationPayload(
+    node: TimelineAggregationNode,
+    candidates: TimelineLedgerCandidate[],
+    includeEvidence: boolean
+  ): Record<string, unknown> {
+    const sourceCandidates = node.sourceCandidateIds.flatMap((candidateId) => {
+      const candidate = candidates.find((item) => item.candidateId === candidateId);
+      return candidate ? [candidate] : [];
+    });
+    return {
+      candidateId: node.nodeId,
+      sourceCandidateIds: node.sourceCandidateIds,
+      name: node.name,
+      description: node.description.slice(0, includeEvidence ? 2_000 : 600),
+      eventType: node.eventType,
+      timeLabel: node.timeLabel,
+      timeSort: node.timeSort,
+      location: node.location,
+      impactScope: node.impactScope,
+      participantIds: node.participantIds,
+      ...(includeEvidence ? {
+        evidence: sourceCandidates.flatMap((candidate) => candidate.evidence.map((evidence, index) => ({
+          evidenceRef: `${candidate.candidateId}#evidence-${index + 1}`,
+          chapterId: evidence.chapterId,
+          chapterTitle: evidence.chapterTitle,
+          quote: evidence.quote
+        })))
+      } : { evidenceRefs: node.evidenceRefs })
+    };
+  }
+
+  private applyTimelineAggregation(
+    nodes: TimelineAggregationNode[],
+    rawGroups: unknown[],
+    level: number,
+    batchIndex: number
+  ): TimelineAggregationNode[] {
+    const available = new Map(nodes.map((node) => [node.nodeId, node]));
+    const assigned = new Set<string>();
+    const result: TimelineAggregationNode[] = [];
+    rawGroups.forEach((rawGroup, groupIndex) => {
+      if (!rawGroup || typeof rawGroup !== "object" || Array.isArray(rawGroup)) return;
+      const group = rawGroup as Record<string, unknown>;
+      const candidateIds = [...new Set((Array.isArray(group.candidateIds) ? group.candidateIds : [])
+        .filter((candidateId): candidateId is string => typeof candidateId === "string" && available.has(candidateId) && !assigned.has(candidateId)))];
+      if (candidateIds.length === 0) return;
+      candidateIds.forEach((candidateId) => assigned.add(candidateId));
+      const members = candidateIds.map((candidateId) => available.get(candidateId)).filter((node): node is TimelineAggregationNode => Boolean(node));
+      const fallback = members[0] as TimelineAggregationNode;
+      const allowedImpactScopes = new Set<TimelineCandidateFields["impactScope"]>(["personal", "organization", "regional", "world", "galaxy"]);
+      const reportedTimeSort = typeof group.timeSort === "number" && Number.isFinite(group.timeSort)
+        ? group.timeSort
+        : null;
+      const timeSort = reportedTimeSort !== null && members.some((member) => member.timeSort === reportedTimeSort)
+        ? reportedTimeSort
+        : members.every((member) => member.timeSort === members[0]?.timeSort)
+          ? members[0]?.timeSort ?? null
+          : null;
+      result.push({
+        nodeId: `timeline-group-${level + 1}-${batchIndex + 1}-${groupIndex + 1}`,
+        sourceCandidateIds: [...new Set(members.flatMap((member) => member.sourceCandidateIds))],
+        name: typeof group.name === "string" && group.name.trim() ? group.name.normalize("NFKC").trim().slice(0, 300) : fallback.name,
+        description: typeof group.description === "string" ? group.description.trim().slice(0, 100_000) : fallback.description,
+        eventType: typeof group.eventType === "string" && group.eventType.trim() ? group.eventType.trim().slice(0, 100) : fallback.eventType,
+        timeLabel: typeof group.timeLabel === "string" && group.timeLabel.trim() ? group.timeLabel.trim().slice(0, 300) : fallback.timeLabel,
+        timeSort,
+        location: typeof group.location === "string" ? group.location.trim().slice(0, 500) : fallback.location,
+        impactScope: typeof group.impactScope === "string" && allowedImpactScopes.has(group.impactScope as TimelineCandidateFields["impactScope"])
+          ? group.impactScope as TimelineCandidateFields["impactScope"]
+          : fallback.impactScope,
+        participantIds: [...new Set(members.flatMap((member) => member.participantIds))],
+        evidenceRefs: [...new Set(members.flatMap((member) => member.evidenceRefs))]
+      });
+    });
+    for (const node of nodes) if (!assigned.has(node.nodeId)) result.push(node);
+    return result;
+  }
+
+  private materializeTimelineCandidates(
+    nodes: TimelineAggregationNode[],
+    ledger: TimelineLedgerCandidate[]
+  ): TimelineLedgerCandidate[] {
+    const byCandidateId = new Map(ledger.map((candidate) => [candidate.candidateId, candidate]));
+    const candidates = nodes.flatMap((node) => {
+      const sources = node.sourceCandidateIds.flatMap((candidateId) => {
+        const candidate = byCandidateId.get(candidateId);
+        return candidate ? [candidate] : [];
+      });
+      if (sources.length === 0) return [];
+      const evidence = sources.flatMap((source) => source.evidence)
+        .filter((item, index, items) => items.findIndex((candidate) => this.timelineEvidenceKey(candidate) === this.timelineEvidenceKey(item)) === index);
+      return [{
+        candidateId: node.nodeId,
+        name: node.name,
+        description: node.description,
+        eventType: node.eventType,
+        timeLabel: node.timeLabel,
+        timeSort: node.timeSort,
+        location: node.location,
+        impactScope: node.impactScope,
+        chapterIds: [...new Set(evidence.map((item) => item.chapterId))],
+        participantIds: [...new Set(sources.flatMap((source) => source.participantIds))],
+        evidence
+      }];
+    });
+    return this.mergeExactTimelineCandidates(candidates);
   }
 
   private async runWorldviewAnalysis(workId: string, scope: ContextScope, modelId?: string, taskId?: string): Promise<Record<string, unknown>> {
@@ -12763,6 +13184,46 @@ export class AiManager {
         text = `${header.replace("<CHAPTER ", `<CHAPTER part="${part}" `)}${content.slice(offset, offset + segmentSize)}${footer}`;
         chapterIds = [String(chapter.id)];
         flush();
+      }
+    }
+    flush();
+    return chunks;
+  }
+
+  private buildTimelineChapterChunks(chapters: Record<string, unknown>[]): Array<{ text: string; chapterIds: string[] }> {
+    const chunks: Array<{ text: string; chapterIds: string[] }> = [];
+    let text = "";
+    let chapterIds: string[] = [];
+    const flush = (): void => {
+      if (!text) return;
+      chunks.push({ text, chapterIds });
+      text = "";
+      chapterIds = [];
+    };
+    for (const chapter of chapters) {
+      const chapterId = String(chapter.id);
+      const title = String(chapter.title).replaceAll('"', "'");
+      const header = `\n<CHAPTER id="${chapterId}" title="${title}">\n`;
+      const footer = "\n</CHAPTER>\n";
+      const content = String(chapter.content);
+      const block = `${header}${content}${footer}`;
+      if (text && text.length + block.length > TIMELINE_CHUNK_MAX_CHARS) flush();
+      if (block.length <= TIMELINE_CHUNK_MAX_CHARS) {
+        text += block;
+        chapterIds.push(chapterId);
+        continue;
+      }
+      flush();
+      const segmentSize = Math.max(1_000, TIMELINE_CHUNK_MAX_CHARS - header.length - footer.length - 120);
+      let start = 0;
+      let part = 1;
+      while (start < content.length) {
+        const end = Math.min(content.length, start + segmentSize);
+        const partHeader = header.replace("<CHAPTER ", `<CHAPTER part="${part}" `);
+        chunks.push({ text: `${partHeader}${content.slice(start, end)}${footer}`, chapterIds: [chapterId] });
+        if (end >= content.length) break;
+        start = Math.max(start + 1, end - TIMELINE_CHUNK_OVERLAP_CHARS);
+        part += 1;
       }
     }
     flush();

--- a/src/store.ts
+++ b/src/store.ts
@@ -10742,8 +10742,20 @@ export class Store {
           return event.workId === workId ? [event] : [];
         } catch { return []; }
       });
-      summary = `提取并写入 ${events.length} 个时间轴事件候选。`;
-      metrics = [metric("写入事件", events.length), metric("已不存在", Math.max(0, ids.length - events.length))];
+      const hasChunkMetrics = typeof result.coveredChapterCount === "number" || typeof result.batchCount === "number";
+      summary = hasChunkMetrics
+        ? `覆盖 ${Number(result.coveredChapterCount ?? 0)} 章正文，识别 ${Number(result.rawCandidateCount ?? events.length)} 个原始候选，写入 ${events.length} 个时间轴事件候选。`
+        : `提取并写入 ${events.length} 个时间轴事件候选。`;
+      metrics = [
+        metric("写入事件", events.length),
+        ...(hasChunkMetrics ? [
+          metric("覆盖章节", result.coveredChapterCount),
+          metric("正文分片", result.batchCount),
+          metric("归并批次", result.aggregationBatchCount),
+          metric("原始候选", result.rawCandidateCount)
+        ] : []),
+        metric("已不存在", Math.max(0, ids.length - events.length))
+      ];
       storageTargets.unshift({ label: "时间轴候选", entity: "时间轴与事件", key: "timeline", count: events.length, note: "以候选状态写入，等待作者确认。" });
       sections = [section("事件候选", events, "没有形成可写入的时间轴事件。")];
     } else if (taskType === "worldview-analysis") {

--- a/tests/integration/analysis-task-model.test.ts
+++ b/tests/integration/analysis-task-model.test.ts
@@ -217,4 +217,42 @@ describe("AI 分析任务模型", () => {
     });
     expect(compactPreview).toMatchObject({ allowed: true, overThreshold: false });
   });
+
+  it("百万字符时间线任务只按最大正文分片预检", async () => {
+    runtime = createTestRuntime();
+    const work = runtime.store.createWork({ title: "百万字符时间线预检" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "百万字符长章",
+      content: "星".repeat(1_000_000)
+    });
+    const provider = runtime.ai.createProvider({
+      name: "时间线短上下文模型",
+      baseUrl: "https://timeline-context-preview.test/v1",
+      apiKey: "sk-timeline-context-preview-test",
+      status: "enabled"
+    });
+    runtime.database.run("UPDATE providers SET connection_status = 'success' WHERE id = ?", String(provider.id));
+    const model = runtime.ai.createModel(String(provider.id), {
+      displayName: "时间线短上下文模型",
+      modelId: "timeline-context-preview-model",
+      contextWindow: 32_768
+    });
+
+    const preview = runtime.ai.previewAnalysisTaskContext(workId, {
+      taskType: "timeline-analysis",
+      scope: { type: "book" },
+      modelId: String(model.id)
+    });
+
+    expect(preview).toMatchObject({ allowed: true, overThreshold: false });
+    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
+      taskType: "timeline-analysis",
+      scope: { type: "book" },
+      modelId: model.id
+    }).expect(201);
+    expect(task.body.data).toMatchObject({ status: "pending", taskType: "timeline-analysis" });
+  });
 });

--- a/tests/integration/timeline-analysis.test.ts
+++ b/tests/integration/timeline-analysis.test.ts
@@ -1,0 +1,376 @@
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Runtime } from "../../src/app.js";
+import { createTestRuntime } from "../helpers.js";
+
+async function configureModel(runtime: Runtime, workId: string): Promise<string> {
+  const provider = await request(runtime.app).post(`/api/works/${workId}/providers`).send({
+    name: "时间线测试模型",
+    baseUrl: "https://timeline-ai.test/v1",
+    apiKey: "sk-timeline-test",
+    status: "enabled",
+    concurrencyLimit: 4,
+    rpmLimit: 1000
+  }).expect(201);
+  runtime.database.run("UPDATE providers SET connection_status = 'success' WHERE id = ?", provider.body.data.id);
+  const model = await request(runtime.app).post(`/api/providers/${provider.body.data.id}/models`).send({
+    displayName: "时间线模型",
+    modelId: "timeline-model"
+  }).expect(201);
+  return model.body.data.id as string;
+}
+
+function completion(content: unknown): Response {
+  return new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify(content) } }] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+describe("时间线分片分析", () => {
+  let runtime: Runtime | null = null;
+
+  afterEach(async () => {
+    await runtime?.close();
+    runtime = null;
+  });
+
+  it("并发抽取分片、校验证据与人物归属，并保守归并跨章重复事件", async () => {
+    let firstChapterId = "";
+    let secondChapterId = "";
+    let foreignCharacterId = "";
+    const extractionPrompts: string[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ content?: string }> };
+      const prompt = body.messages?.map((message) => message.content ?? "").join("\n") ?? "";
+      if (prompt.includes("小说时间线候选归并器")) {
+        const candidateIds = [...new Set(prompt.match(/timeline-candidate-\d+/gu) ?? [])];
+        return completion([{
+          candidateIds,
+          name: "北港大停电",
+          description: "北港在同一场暴雨中断电。",
+          eventType: "灾害",
+          timeLabel: "时间待定",
+          timeSort: 999,
+          location: "北港",
+          impactScope: "regional"
+        }]);
+      }
+      extractionPrompts.push(prompt);
+      if (prompt.includes("第一章唯一标记")) {
+        return completion([{
+          name: "北港大停电",
+          description: "北港在暴雨中断电。",
+          eventType: "灾害",
+          timeLabel: "时间待定",
+          timeSort: 7,
+          location: "北港",
+          impactScope: "regional",
+          participantReferences: ["林舟", foreignCharacterId],
+          chapterIds: ["伪造章节"],
+          evidence: [{ chapterId: firstChapterId, chapterTitle: "伪造标题", quote: "北港在暴雨中突然断电。" }]
+        }, {
+          name: "不存在的加冕",
+          description: "模型伪造事件。",
+          eventType: "政治",
+          timeLabel: "第七日",
+          timeSort: 7,
+          location: "王城",
+          impactScope: "world",
+          participantReferences: [foreignCharacterId],
+          evidence: [{ chapterId: firstChapterId, chapterTitle: "第一章", quote: "正文中不存在的加冕引文" }]
+        }]);
+      }
+      return completion([{
+        name: "北港大停电",
+        description: "停电波及港区。",
+        eventType: "灾害",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港",
+        impactScope: "regional",
+        participantReferences: ["林舟"],
+        evidence: [{ chapterId: secondChapterId, chapterTitle: "第二章", quote: "港区仍未恢复供电。" }]
+      }]);
+    });
+    runtime = createTestRuntime(fetchMock);
+    const foreignWork = runtime.store.createWork({ title: "异作品" });
+    foreignCharacterId = String(runtime.store.createCharacter(String(foreignWork.id), { name: "异作品角色" }).id);
+    const work = runtime.store.createWork({ title: "北港纪事" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    const first = runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "第一章唯一标记",
+      content: `${"潮声拍岸。".repeat(1_300)}北港在暴雨中突然断电。林舟赶往灯塔。`
+    });
+    const second = runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "第二章唯一标记",
+      content: `${"雨水冲刷街道。".repeat(1_100)}港区仍未恢复供电。林舟检查备用电源。`
+    });
+    firstChapterId = String(first.id);
+    secondChapterId = String(second.id);
+    const currentCharacter = runtime.store.createCharacter(workId, { name: "林舟" });
+    const modelId = await configureModel(runtime, workId);
+    const task = await request(runtime.app).post(`/api/works/${workId}/tasks`).send({
+      taskType: "timeline-analysis",
+      scope: { type: "book" },
+      modelId
+    }).expect(201);
+
+    const completed = await request(runtime.app).post(`/api/tasks/${task.body.data.id}/run`).send({}).expect(200);
+
+    expect(completed.body.data).toMatchObject({ status: "review", progress: 100 });
+    expect(completed.body.data.result).toMatchObject({
+      candidateCount: 1,
+      rawCandidateCount: 3,
+      batchCount: 2,
+      aggregationBatchCount: 1,
+      coveredChapterCount: 2
+    });
+    expect(completed.body.data.result.callIds).toHaveLength(3);
+    expect(completed.body.data.result.skipped).toEqual([
+      expect.objectContaining({ name: "不存在的加冕", reason: "原文证据无效或不属于本次章节范围" })
+    ]);
+    expect(extractionPrompts).toHaveLength(2);
+    expect(extractionPrompts.every((prompt) => prompt.length < 30_000)).toBe(true);
+    expect(extractionPrompts.every((prompt) => !(prompt.includes("第一章唯一标记") && prompt.includes("第二章唯一标记")))).toBe(true);
+
+    const events = runtime.store.listTimelineEvents(workId);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      name: "北港大停电",
+      status: "candidate",
+      timeLabel: "时间待定",
+      timeSort: null,
+      chapterIds: [firstChapterId, secondChapterId],
+      participantIds: [currentCharacter.id]
+    });
+    expect(events[0]?.participantIds).not.toContain(foreignCharacterId);
+    expect(events[0]?.evidence).toEqual([
+      { chapterId: firstChapterId, chapterTitle: "第一章唯一标记", quote: "北港在暴雨中突然断电。" },
+      { chapterId: secondChapterId, chapterTitle: "第二章唯一标记", quote: "港区仍未恢复供电。" }
+    ]);
+  });
+
+  it("以重叠片段覆盖超长单章边界，并精确合并重复引文", async () => {
+    let chapterId = "";
+    const boundaryQuote = "灯塔熄灭后，林舟在黑暗中拉响警报。";
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ content?: string }> };
+      const prompt = body.messages?.map((message) => message.content ?? "").join("\n") ?? "";
+      return completion(prompt.includes(boundaryQuote) ? [{
+        name: "灯塔停摆",
+        description: "灯塔熄灭并触发警报。",
+        eventType: "事故",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港灯塔",
+        impactScope: "regional",
+        participantReferences: ["林舟"],
+        evidence: [{ chapterId, chapterTitle: "超长章", quote: boundaryQuote }]
+      }] : []);
+    });
+    runtime = createTestRuntime(fetchMock);
+    const work = runtime.store.createWork({ title: "边界测试" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    const chapter = runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "超长章",
+      content: `${"甲".repeat(9_400)}${boundaryQuote}${"乙".repeat(8_500)}`
+    });
+    chapterId = String(chapter.id);
+    runtime.store.createCharacter(workId, { name: "林舟" });
+    const modelId = await configureModel(runtime, workId);
+    const task = runtime.store.createTask(workId, { taskType: "timeline-analysis", scope: { type: "book" }, modelId });
+
+    const completed = await request(runtime.app).post(`/api/tasks/${task.id}/run`).send({}).expect(200);
+
+    expect(completed.body.data.result).toMatchObject({ candidateCount: 1, rawCandidateCount: 2, batchCount: 2, aggregationBatchCount: 0 });
+    expect(runtime.store.listTimelineEvents(workId)[0]?.evidence).toEqual([
+      { chapterId, chapterTitle: "超长章", quote: boundaryQuote }
+    ]);
+  });
+
+  it("任一正文分片双重失败时不写入候选、版本或审计记录", async () => {
+    let firstChapterId = "";
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ content?: string }> };
+      const prompt = body.messages?.map((message) => message.content ?? "").join("\n") ?? "";
+      if (prompt.includes("故障第二章")) return new Response("upstream failed", { status: 500 });
+      return completion([{
+        name: "北港启航",
+        description: "飞船离港。",
+        eventType: "启程",
+        timeLabel: "启航日",
+        timeSort: 1,
+        location: "北港",
+        impactScope: "personal",
+        evidence: [{ chapterId: firstChapterId, chapterTitle: "正常第一章", quote: "飞船驶离北港。" }]
+      }]);
+    });
+    runtime = createTestRuntime(fetchMock);
+    const work = runtime.store.createWork({ title: "失败回滚" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    const first = runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "正常第一章",
+      content: `${"潮声。".repeat(1_600)}飞船驶离北港。`
+    });
+    runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "故障第二章",
+      content: `${"暴雨。".repeat(1_600)}港区关闭。`
+    });
+    firstChapterId = String(first.id);
+    const modelId = await configureModel(runtime, workId);
+    const task = runtime.store.createTask(workId, { taskType: "timeline-analysis", scope: { type: "book" }, modelId });
+
+    const failed = await request(runtime.app).post(`/api/tasks/${task.id}/run`).send({}).expect(502);
+
+    expect(failed.body.error.code).toBe("AI_BATCH_FAILED");
+    expect(runtime.store.listTimelineEvents(workId)).toEqual([]);
+    expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'timeline-event'")?.count).toBe(0);
+    expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'timeline.created'")?.count).toBe(0);
+  });
+
+  it("来源章节在模型返回前变化时丢弃全部结果", async () => {
+    let chapterId = "";
+    let originalContent = "";
+    let changed = false;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      if (!changed) {
+        changed = true;
+        runtime?.store.saveChapter(chapterId, { content: `${originalContent}\n作者在分析期间修订正文。` });
+      }
+      return completion([{
+        name: "过期事件",
+        description: "不应落库。",
+        eventType: "other",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港",
+        impactScope: "personal",
+        evidence: [{ chapterId, chapterTitle: "第一章", quote: "林舟抵达北港。" }]
+      }]);
+    });
+    runtime = createTestRuntime(fetchMock);
+    const work = runtime.store.createWork({ title: "来源版本测试" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    originalContent = "林舟抵达北港。";
+    const chapter = runtime.store.createChapter(workId, { volumeId: String(volume.id), title: "第一章", content: originalContent });
+    chapterId = String(chapter.id);
+    const modelId = await configureModel(runtime, workId);
+    const task = runtime.store.createTask(workId, { taskType: "timeline-analysis", scope: { type: "book" }, modelId });
+
+    const expired = await request(runtime.app).post(`/api/tasks/${task.id}/run`).send({}).expect(200);
+
+    expect(expired.body.data.status).toBe("expired");
+    expect(runtime.store.listTimelineEvents(workId)).toEqual([]);
+  });
+
+  it("任务在分片请求期间取消时不写入任何候选", async () => {
+    let chapterId = "";
+    let taskId = "";
+    let cancelled = false;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      if (!cancelled) {
+        cancelled = true;
+        runtime?.ai.cancelTask(taskId);
+      }
+      return completion([{
+        name: "取消后的事件",
+        description: "不应落库。",
+        eventType: "other",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港",
+        impactScope: "personal",
+        evidence: [{ chapterId, chapterTitle: "第一章", quote: "林舟抵达北港。" }]
+      }]);
+    });
+    runtime = createTestRuntime(fetchMock);
+    const work = runtime.store.createWork({ title: "取消测试" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    const chapter = runtime.store.createChapter(workId, { volumeId: String(volume.id), title: "第一章", content: "林舟抵达北港。" });
+    chapterId = String(chapter.id);
+    const modelId = await configureModel(runtime, workId);
+    const task = runtime.store.createTask(workId, { taskType: "timeline-analysis", scope: { type: "book" }, modelId });
+    taskId = String(task.id);
+
+    const result = await request(runtime.app).post(`/api/tasks/${taskId}/run`).send({}).expect(200);
+
+    expect(result.body.data.status).toBe("cancelled");
+    expect(runtime.store.listTimelineEvents(workId)).toEqual([]);
+  });
+
+  it("最终批量写入任一候选失败时回滚同批事件、版本和审计", async () => {
+    let chapterId = "";
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ content?: string }> };
+      const prompt = body.messages?.map((message) => message.content ?? "").join("\n") ?? "";
+      if (prompt.includes("小说时间线候选归并器")) {
+        const candidateIds = [...new Set(prompt.match(/timeline-candidate-\d+/gu) ?? [])];
+        return completion(candidateIds.map((candidateId, index) => ({
+          candidateIds: [candidateId],
+          name: index === 0 ? "第一次警报" : "第二次警报",
+          description: "",
+          eventType: "事故",
+          timeLabel: "时间待定",
+          timeSort: null,
+          location: "北港",
+          impactScope: "personal"
+        })));
+      }
+      return completion([{
+        name: "第一次警报",
+        description: "第一次警报响起。",
+        eventType: "事故",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港",
+        impactScope: "personal",
+        evidence: [{ chapterId, chapterTitle: "第一章", quote: "第一次警报响起。" }]
+      }, {
+        name: "第二次警报",
+        description: "第二次警报响起。",
+        eventType: "事故",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港",
+        impactScope: "personal",
+        evidence: [{ chapterId, chapterTitle: "第一章", quote: "第二次警报响起。" }]
+      }]);
+    });
+    runtime = createTestRuntime(fetchMock);
+    const work = runtime.store.createWork({ title: "事务测试" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    const chapter = runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "第一章",
+      content: "第一次警报响起。守卫检查后，第二次警报响起。"
+    });
+    chapterId = String(chapter.id);
+    const modelId = await configureModel(runtime, workId);
+    const task = runtime.store.createTask(workId, { taskType: "timeline-analysis", scope: { type: "book" }, modelId });
+    const createTimelineEvent = runtime.store.createTimelineEvent.bind(runtime.store);
+    let writeCount = 0;
+    vi.spyOn(runtime.store, "createTimelineEvent").mockImplementation((...args) => {
+      writeCount += 1;
+      if (writeCount === 2) throw new Error("simulated timeline write failure");
+      return createTimelineEvent(...args);
+    });
+
+    await request(runtime.app).post(`/api/tasks/${task.id}/run`).send({}).expect(500);
+
+    expect(runtime.store.listTimelineEvents(workId)).toEqual([]);
+    expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM entity_versions WHERE entity_type = 'timeline-event'")?.count).toBe(0);
+    expect(runtime.database.get<{ count: number }>("SELECT COUNT(*) AS count FROM audit_logs WHERE action = 'timeline.created'")?.count).toBe(0);
+  });
+});

--- a/tests/integration/timeline-analysis.test.ts
+++ b/tests/integration/timeline-analysis.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { estimateAiTokens } from "../../src/ai.js";
 import type { Runtime } from "../../src/app.js";
 import { createTestRuntime } from "../helpers.js";
 
@@ -192,6 +193,71 @@ describe("时间线分片分析", () => {
     expect(runtime.store.listTimelineEvents(workId)[0]?.evidence).toEqual([
       { chapterId, chapterTitle: "超长章", quote: boundaryQuote }
     ]);
+  });
+
+  it("按 32K 模型输入预算拆分 50 个长描述归并候选", async () => {
+    let chapterId = "";
+    const quotes = Array.from({ length: 50 }, (_value, index) => `第${index + 1}号事件证据。`);
+    const aggregationInputTokens: number[] = [];
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { messages?: Array<{ role?: string; content?: string }> };
+      const messages = body.messages ?? [];
+      const prompt = messages.map((message) => message.content ?? "").join("\n");
+      if (prompt.includes("小说时间线候选归并器")) {
+        aggregationInputTokens.push(estimateAiTokens(JSON.stringify(messages.map((message) => ({
+          ...message,
+          content: message.content ?? ""
+        })))));
+        const candidateIds = [...prompt.matchAll(/"candidateId":"([^"]+)"/gu)].map((match) => String(match[1]));
+        return completion(candidateIds.map((candidateId, index) => ({
+          candidateIds: [candidateId],
+          name: `预算内候选${index + 1}`,
+          description: "",
+          eventType: "other",
+          timeLabel: "时间待定",
+          timeSort: null,
+          location: "北港",
+          impactScope: "personal"
+        })));
+      }
+      return completion(quotes.map((quote, index) => ({
+        name: `第${index + 1}号事件`,
+        description: "长".repeat(2_000),
+        eventType: "other",
+        timeLabel: "时间待定",
+        timeSort: null,
+        location: "北港",
+        impactScope: "personal",
+        evidence: [{ chapterId, chapterTitle: "候选压力章", quote }]
+      })));
+    });
+    runtime = createTestRuntime(fetchMock);
+    const work = runtime.store.createWork({ title: "归并预算压力测试" });
+    const workId = String(work.id);
+    const volume = runtime.store.createVolume(workId, { title: "第一卷" });
+    const chapter = runtime.store.createChapter(workId, {
+      volumeId: String(volume.id),
+      title: "候选压力章",
+      content: quotes.join("")
+    });
+    chapterId = String(chapter.id);
+    const modelId = await configureModel(runtime, workId);
+    runtime.database.run("UPDATE models SET context_window = ? WHERE id = ?", 32_768, modelId);
+    const task = runtime.store.createTask(workId, { taskType: "timeline-analysis", scope: { type: "book" }, modelId });
+
+    const completed = await request(runtime.app).post(`/api/tasks/${task.id}/run`).send({}).expect(200);
+
+    expect(completed.body.data).toMatchObject({ status: "review", progress: 100 });
+    expect(completed.body.data.result).toMatchObject({
+      candidateCount: 50,
+      rawCandidateCount: 50,
+      batchCount: 1,
+      coveredChapterCount: 1
+    });
+    expect(completed.body.data.result.aggregationBatchCount).toBeGreaterThan(1);
+    expect(aggregationInputTokens.length).toBe(completed.body.data.result.aggregationBatchCount);
+    expect(Math.max(...aggregationInputTokens)).toBeLessThanOrEqual(24_064);
+    expect(runtime.store.listTimelineEvents(workId)).toHaveLength(50);
   });
 
   it("任一正文分片双重失败时不写入候选、版本或审计记录", async () => {

--- a/tests/system/author-journey.test.ts
+++ b/tests/system/author-journey.test.ts
@@ -28,8 +28,9 @@ describe("作者完整创作流程", () => {
         let content = "舱门关闭，林舟望向逐渐远去的北港。";
         if (prompt.includes("检查下面的续写候选")) {
           content = "[]";
-        } else if (prompt.includes("抽取大事件候选")) {
-          content = JSON.stringify([{ name: "北港启航", description: "林舟驾驶飞船离开北港。", eventType: "离别", timeLabel: "启航日", timeSort: 1, location: "北港", impactScope: "personal", chapterIds: [], participantIds: [], evidence: [{ quote: "飞船驶离北港" }] }]);
+        } else if (prompt.includes("时间线事件证据账本")) {
+          const chapter = prompt.match(/<CHAPTER id="([^"]+)" title="([^"]+)">/u);
+          content = JSON.stringify([{ name: "北港启航", description: "林舟驾驶飞船离开北港。", eventType: "离别", timeLabel: "启航日", timeSort: 1, location: "北港", impactScope: "personal", participantReferences: ["林舟"], evidence: [{ chapterId: chapter?.[1], chapterTitle: chapter?.[2], quote: "逐渐远去的北港" }] }]);
         } else if (prompt.includes("小说人物关系抽取器")) {
           const chapters = [...prompt.matchAll(/<CHAPTER id="([^"]+)" title="([^"]+)">/gu)];
           content = JSON.stringify([{ fromCharacterId: "林舟", toCharacterId: "沈星", category: "social", subtype: "朋友", directed: false, currentStatus: "active", timeRange: { start: "第一卷" }, confidence: 0.82, evidence: chapters.map((match, index) => ({ chapterId: match[1], chapterTitle: match[2], quote: index === 0 ? "林舟想起沈星的警告" : "沈星仍保存着林舟的旧信", contextType: "current", supports: "两人保持长期联系" })) }]);


### PR DESCRIPTION
## Summary

- preview timeline tasks against the largest bounded source chunk instead of the full book
- extract timeline evidence concurrently, validate source evidence and character ownership, then consolidate candidates in bounded hierarchical batches
- commit all generated timeline candidates, versions, and audit records in one transaction
- expose chunk, aggregation, coverage, raw-candidate, and skip metrics in task results

## Verification

- `npm run check` (237 test files, 1206 tests; typecheck and build passed)
- focused timeline/model/readable-result/author-journey tests (21 tests)
- isolated SQLite `PRAGMA integrity_check` returned `ok`
- isolated SQLite `PRAGMA foreign_key_check` returned no rows

Closes MUXUE-98
