### PR TITLE
fix(ai): keep long tool streams connected

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1145,6 +1145,7 @@ const grepArguments = z.object({
 const searchStoryEntitiesArguments = z.object({
   query: z.string().trim().min(1).max(MAXIMUM_WORK_SEARCH_QUERY_LENGTH),
   categories: z.array(z.enum(["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"])).max(8).default([]),
+  includePhonetic: z.boolean().default(false),
   limit: z.number().int().min(1).max(30).default(30),
   cursor: agentToolCursor
 }).strict();
@@ -1237,8 +1238,8 @@ const AGENT_TOOL_DEFINITIONS: Record<AgentToolId, Record<string, unknown>> = {
     type: "function",
     function: {
       name: "search_story_entities",
-      description: "按短关键词在结构化作品实体中进行元数据、精确全文和拼音混合检索：设定、人物（含 Markdown 档案章节）、种族、组织、时间线、关系、大纲和伏笔。人物结果包含权威 gender 字段：male 表示男/雄性，female 表示女/雌性，none 表示无性别，unknown 表示未知；gender=unknown 时禁止根据正文或常识自行推断。人物、种族、组织结果还分别包含权威布尔状态 isDead、isExtinct、isDissolved；只有值为 true 才能判定该角色已死亡、该种族已灭绝或该组织已解散，字段为 false 时必须视为仍存活、未灭绝或未解散，禁止根据正文情节自行改判。时间线事件结果返回 trackId、timeSort、chapterIds、chapterStoryOrders 与 orderEligible；只有 orderEligible=true 的事件才可参与同轨道时间比较。不是语义问答；请传入实体名、别名、标题、拼音或短关键词，不要传入自然语言整句。结果按综合相关度排序；人物结果含 sectionId 时可再调用 read_character_sections 精读。无匹配时改用更短关键词，或改用 story_index / grep。",
-      parameters: { type: "object", properties: { query: { type: "string", minLength: 1, maxLength: MAXIMUM_WORK_SEARCH_QUERY_LENGTH }, categories: { type: "array", items: { type: "string", enum: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"] }, maxItems: 8 }, limit: { type: "integer", minimum: 1, maximum: 30, default: 30 }, cursor: agentToolCursorParameter }, required: ["query"], additionalProperties: false }
+      description: "按短关键词在结构化作品实体中进行元数据与精确全文检索：设定、人物（含 Markdown 档案章节）、种族、组织、时间线、关系、大纲和伏笔。默认不查询拼音索引；只有中文实体可能存在同音字或错别字且精确检索无结果时，才设置 includePhonetic=true。拼音索引极其缓慢，必须谨慎使用。人物结果包含权威 gender 字段：male 表示男/雄性，female 表示女/雌性，none 表示无性别，unknown 表示未知；gender=unknown 时禁止根据正文或常识自行推断。人物、种族、组织结果还分别包含权威布尔状态 isDead、isExtinct、isDissolved；只有值为 true 才能判定该角色已死亡、该种族已灭绝或该组织已解散，字段为 false 时必须视为仍存活、未灭绝或未解散，禁止根据正文情节自行改判。时间线事件结果返回 trackId、timeSort、chapterIds、chapterStoryOrders 与 orderEligible；只有 orderEligible=true 的事件才可参与同轨道时间比较。不是语义问答；请传入实体名、别名、标题或短关键词，不要传入自然语言整句。结果按综合相关度排序；人物结果含 sectionId 时可再调用 read_character_sections 精读。无匹配时先改用更短关键词，再按需谨慎启用拼音索引，或改用 story_index / grep。",
+      parameters: { type: "object", properties: { query: { type: "string", minLength: 1, maxLength: MAXIMUM_WORK_SEARCH_QUERY_LENGTH }, categories: { type: "array", items: { type: "string", enum: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"] }, maxItems: 8 }, includePhonetic: { type: "boolean", default: false, description: "是否启用极其缓慢的拼音索引。默认关闭；仅在同音字或错别字检索确有必要时谨慎开启。" }, limit: { type: "integer", minimum: 1, maximum: 30, default: 30 }, cursor: agentToolCursorParameter }, required: ["query"], additionalProperties: false }
     }
   },
   read_character_sections: {
@@ -2815,6 +2816,7 @@ export class AiManager {
       limit?: number;
       allowedTypes?: readonly HybridSearchType[];
       conversationOwnerUserId?: string;
+      includePhonetic?: boolean;
     } = {}
   ): Promise<Record<string, unknown>[]> {
     this.store.getWork(workId);
@@ -2864,7 +2866,7 @@ export class AiManager {
         ? this.hybridAgentHistoryMatches(workId, normalizedQuery, channelLimit, options.conversationOwnerUserId)
         : [])
     ];
-    const phoneticCandidates = [
+    const phoneticCandidates = options.includePhonetic === false ? [] : [
       ...(requestedTypes.has("chapter")
         ? this.hybridChapterMatches(workId, normalizedQuery, "phonetic", channelLimit, chapterLineRangeFallbackState)
         : []),
@@ -7889,13 +7891,14 @@ export class AiManager {
       };
     }
     if (name === "search_story_entities") {
-      const { query, categories: categoryList, limit, cursor } = args as z.infer<typeof searchStoryEntitiesArguments>;
+      const { query, categories: categoryList, includePhonetic, limit, cursor } = args as z.infer<typeof searchStoryEntitiesArguments>;
       const readableCategories = this.readableAgentEntityCategories(permissions);
       const categories = new Set<AgentEntityCategory>(categoryList.filter((category): category is AgentEntityCategory => readableCategories.has(category)));
       const requestedCategories = categoryList.length > 0 ? categories : readableCategories;
       const combined = (await this.searchWork(workId, query, {
         limit: 100,
-        allowedTypes: agentEntitySearchTypes(requestedCategories)
+        allowedTypes: agentEntitySearchTypes(requestedCategories),
+        includePhonetic
       })).flatMap((item) => {
         const sourceType = String(item.type);
         const type = sourceType === "timeline-track" || sourceType === "timeline-event"
@@ -7928,7 +7931,7 @@ export class AiManager {
         ok: true,
         data: {
           query,
-          matchMode: "hybrid_exact_phonetic",
+          matchMode: includePhonetic ? "hybrid_exact_phonetic" : "hybrid_exact",
           ...(requestedCategories.has("timeline")
             ? { storyOrdering: entityStoryOrdering }
             : {}),
@@ -7943,7 +7946,7 @@ export class AiManager {
         id: toolCall.id,
         name,
         calledAt,
-        arguments: { query, categories: [...requestedCategories], limit, ...(cursor > 0 ? { cursor } : {}) },
+        arguments: { query, categories: [...requestedCategories], includePhonetic, limit, ...(cursor > 0 ? { cursor } : {}) },
         status: "completed",
         result
       };

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -782,6 +782,20 @@ const AGENT_ENTITY_CATEGORY_MODULES = {
   foreshadow: "outlines"
 } as const satisfies Record<string, WorkPermissionModule>;
 type AgentEntityCategory = keyof typeof AGENT_ENTITY_CATEGORY_MODULES;
+const AGENT_ENTITY_CATEGORY_SEARCH_TYPES = {
+  setting: ["setting"],
+  character: ["character"],
+  race: ["race"],
+  organization: ["organization"],
+  timeline: ["timeline-track", "timeline-event"],
+  relationship: ["relationship"],
+  outline: ["chapter-outline"],
+  foreshadow: ["foreshadow"]
+} as const satisfies Record<AgentEntityCategory, readonly HybridSearchType[]>;
+
+function agentEntitySearchTypes(categories: ReadonlySet<AgentEntityCategory>): HybridSearchType[] {
+  return [...new Set([...categories].flatMap((category) => AGENT_ENTITY_CATEGORY_SEARCH_TYPES[category]))];
+}
 
 type AiCallTraceAttempt = {
   attempt: number;
@@ -7879,7 +7893,10 @@ export class AiManager {
       const readableCategories = this.readableAgentEntityCategories(permissions);
       const categories = new Set<AgentEntityCategory>(categoryList.filter((category): category is AgentEntityCategory => readableCategories.has(category)));
       const requestedCategories = categoryList.length > 0 ? categories : readableCategories;
-      const combined = (await this.searchWork(workId, query, { limit: 100 })).flatMap((item) => {
+      const combined = (await this.searchWork(workId, query, {
+        limit: 100,
+        allowedTypes: agentEntitySearchTypes(requestedCategories)
+      })).flatMap((item) => {
         const sourceType = String(item.type);
         const type = sourceType === "timeline-track" || sourceType === "timeline-event"
           ? "timeline"

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -114,7 +114,9 @@ import {
   normalizeRelationshipSearchText,
   relationshipCharacterTokenText,
   relationshipCharacterTokens,
+  relationshipPinyinFtsQuery,
   relationshipPinyinSearchTokens,
+  relationshipPinyinSequenceMatches,
   relationshipPinyinTokenText,
   relationshipPinyinTokens
 } from "./relationship-search.js";
@@ -2951,9 +2953,11 @@ export class AiManager {
     fallbackState: HybridChapterLineRangeFallbackState
   ): HybridSearchCandidate[] {
     let rows: Row[];
+    let phoneticVerificationSyllables: string[] | null = null;
     if (matchKind === "phonetic") {
-      const tokens = relationshipPinyinSearchTokens(query);
-      if (tokens.length === 0) return [];
+      const pinyinQuery = relationshipPinyinFtsQuery(query);
+      if (!pinyinQuery) return [];
+      phoneticVerificationSyllables = pinyinQuery.verificationSyllables;
       rows = this.store.db.all(
         `SELECT paragraph.id AS paragraph_id, paragraph.chapter_id, paragraph.paragraph_order,
                 paragraph.content AS paragraph_content, line_range.chapter_version AS range_chapter_version,
@@ -2969,7 +2973,7 @@ export class AiManager {
          ORDER BY bm25(chapter_paragraph_pinyin_fts), volume.sort_order, chapter.sort_order, paragraph.paragraph_order
          LIMIT ?`,
         workId,
-        ftsPhrase(tokens),
+        pinyinQuery.expression,
         limit
       );
     } else if ([...query].length < 3) {
@@ -3009,6 +3013,12 @@ export class AiManager {
         `"${query.replaceAll('"', '""')}"`,
         limit
       );
+    }
+    if (phoneticVerificationSyllables) {
+      rows = rows.filter((row) => relationshipPinyinSequenceMatches(
+        String(row.paragraph_content ?? ""),
+        phoneticVerificationSyllables!
+      ));
     }
     const seen = new Set<string>();
     return rows.flatMap((row): HybridSearchCandidate[] => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -954,6 +954,8 @@ export type RuntimeOptions = {
   uploadLimits?: ImageUploadLimits;
   /** 交互式 AI 流的事件空闲超时；生产启动值由环境变量解析，测试可注入更短时长。 */
   aiStreamIdleTimeoutMs?: number;
+  /** 测试用：覆盖客户端 SSE 心跳间隔。 */
+  aiStreamHeartbeatIntervalMs?: number;
   /** AI 上游 HTTP 状态码重试配置；生产启动值由环境变量解析。 */
   aiRetryPolicy?: Partial<AiRetryPolicy>;
   /** 测试用：替换 AI HTTP 重试等待。 */
@@ -984,6 +986,7 @@ export type Runtime = {
 };
 
 export const RUNTIME_BACKUP_IDLE_TIMEOUT_MS = 9_000;
+export const AI_CLIENT_STREAM_HEARTBEAT_INTERVAL_MS = 15_000;
 
 function data(response: Response, value: unknown, status = 200): void {
   response.status(status).json({ data: value });
@@ -1361,6 +1364,10 @@ function redactVersionSnapshots(
 export function createRuntime(options: RuntimeOptions): Runtime {
   const uploadLimits = options.uploadLimits ?? DEFAULT_IMAGE_UPLOAD_LIMITS;
   const aiChatTabLimit = options.aiChatTabLimit ?? DEFAULT_AI_CHAT_TAB_LIMIT;
+  const requestedAiStreamHeartbeatIntervalMs = Number(options.aiStreamHeartbeatIntervalMs);
+  const aiStreamHeartbeatIntervalMs = Number.isFinite(requestedAiStreamHeartbeatIntervalMs)
+    ? Math.max(1, Math.trunc(requestedAiStreamHeartbeatIntervalMs))
+    : AI_CLIENT_STREAM_HEARTBEAT_INTERVAL_MS;
   logger.info("runtime.initializing", {
     databasePath: options.databasePath,
     serveUi: options.serveUi ?? true,
@@ -3456,15 +3463,28 @@ export function createRuntime(options: RuntimeOptions): Runtime {
     const modelId = resolveConversationModelId(request.params.workId, conversationId, input.modelId);
     const permissions = requestPermissions(request, request.params.workId);
     const controller = new AbortController();
-    response.on("close", () => {
-      if (!response.writableEnded) controller.abort(new Error("浏览器已中断流式请求"));
-    });
     let streamRequestId: string | null = null;
     let streamRequestFinished = false;
     let lastStreamLeaseTouchAt = Date.now();
+    let streamHeartbeatTimer: NodeJS.Timeout | null = null;
     let preparedContext: Record<string, unknown> | null = null;
     let preparedConversation: Record<string, unknown> | null = null;
     let preparedChatImageAttachments: Awaited<ReturnType<typeof ai.prepareChatImageAttachments>> = [];
+    const touchStreamLease = (): void => {
+      if (streamRequestId && Date.now() - lastStreamLeaseTouchAt >= 30_000) {
+        store.touchAiConversationStreamRequest(streamRequestId);
+        lastStreamLeaseTouchAt = Date.now();
+      }
+    };
+    const stopStreamHeartbeat = (): void => {
+      if (!streamHeartbeatTimer) return;
+      clearInterval(streamHeartbeatTimer);
+      streamHeartbeatTimer = null;
+    };
+    response.on("close", () => {
+      stopStreamHeartbeat();
+      if (!response.writableEnded) controller.abort(new Error("浏览器已中断流式请求"));
+    });
     const startStream = (): void => {
       if (response.headersSent) return;
       response.status(200);
@@ -3473,12 +3493,14 @@ export function createRuntime(options: RuntimeOptions): Runtime {
       response.setHeader("Connection", "keep-alive");
       response.setHeader("X-Accel-Buffering", "no");
       response.flushHeaders();
+      streamHeartbeatTimer = setInterval(() => {
+        touchStreamLease();
+        if (!response.writableEnded && !response.destroyed) response.write(": heartbeat\n\n");
+      }, aiStreamHeartbeatIntervalMs);
+      streamHeartbeatTimer.unref();
     };
     const sendEvent = (event: string, payload: unknown): void => {
-      if (streamRequestId && Date.now() - lastStreamLeaseTouchAt >= 30_000) {
-        store.touchAiConversationStreamRequest(streamRequestId);
-        lastStreamLeaseTouchAt = Date.now();
-      }
+      touchStreamLease();
       if (!response.writableEnded && !response.destroyed) response.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
     };
     try {
@@ -3654,6 +3676,7 @@ export function createRuntime(options: RuntimeOptions): Runtime {
         sendEvent("error", publicAiStreamError(error));
       }
     } finally {
+      stopStreamHeartbeat();
       if (streamRequestId && !streamRequestFinished && !stopping) {
         store.finishAiConversationStreamRequest(streamRequestId, "cancelled", "stream_closed");
         streamRequestFinished = true;

--- a/src/public/ai-stream-protocol.js
+++ b/src/public/ai-stream-protocol.js
@@ -1,3 +1,7 @@
+/**
+ * @param {string} code
+ * @param {string} message
+ */
 function streamTransportError(code, message) {
   const error = new Error(message);
   error.code = code;
@@ -5,6 +9,7 @@ function streamTransportError(code, message) {
   return error;
 }
 
+/** @param {boolean} completed */
 export function assertAiStreamCompleted(completed) {
   if (completed) return;
   throw streamTransportError(
@@ -13,6 +18,10 @@ export function assertAiStreamCompleted(completed) {
   );
 }
 
+/**
+ * @param {ReadableStream<Uint8Array>} body
+ * @param {(eventName: string, payload: unknown) => void | Promise<void>} onEvent
+ */
 export async function readAiEventStream(body, onEvent) {
   const reader = body.getReader();
   const decoder = new TextDecoder();

--- a/src/relationship-search.ts
+++ b/src/relationship-search.ts
@@ -1,6 +1,7 @@
 import { pinyin } from "pinyin-pro";
 
 export const RELATIONSHIP_SEARCH_POLICY_VERSION = 3;
+export const RELATIONSHIP_PINYIN_JOINED_TOKEN_MAX_SYLLABLES = 6;
 
 export function normalizeRelationshipSearchText(value: string): string {
   return value.normalize("NFKC").toLocaleLowerCase("zh-CN");
@@ -43,7 +44,10 @@ export function relationshipPinyinSearchTokens(value: string): string[] {
   return compact ? [safePinyinToken(compact)] : [];
 }
 
-export function relationshipPinyinJoinedTokens(value: string, maximumSyllables = 6): string[] {
+export function relationshipPinyinJoinedTokens(
+  value: string,
+  maximumSyllables = RELATIONSHIP_PINYIN_JOINED_TOKEN_MAX_SYLLABLES
+): string[] {
   const tokens = new Set<string>();
   for (const match of value.matchAll(/[\p{Script=Han}]{2,}/gu)) {
     const syllables = relationshipPinyinSyllables(match[0]);
@@ -66,6 +70,40 @@ export function relationshipPinyinTokenText(value: string): string {
 
 export function ftsPhrase(tokens: string[]): string {
   return `"${tokens.join(" ").replaceAll('"', '""')}"`;
+}
+
+export type RelationshipPinyinFtsQuery = {
+  expression: string;
+  verificationSyllables: string[] | null;
+};
+
+export function relationshipPinyinFtsQuery(value: string): RelationshipPinyinFtsQuery | null {
+  const normalized = normalizeRelationshipSearchText(value).trim();
+  const fallbackTokens = relationshipPinyinSearchTokens(normalized);
+  if (fallbackTokens.length === 0) return null;
+  if (!/^\p{Script=Han}{2,}$/u.test(normalized)) {
+    return { expression: ftsPhrase(fallbackTokens), verificationSyllables: null };
+  }
+  const syllables = relationshipPinyinSyllables(normalized);
+  const joinedTokens: string[] = [];
+  for (let start = 0; start < syllables.length; start += RELATIONSHIP_PINYIN_JOINED_TOKEN_MAX_SYLLABLES) {
+    joinedTokens.push(safePinyinToken(
+      syllables.slice(start, start + RELATIONSHIP_PINYIN_JOINED_TOKEN_MAX_SYLLABLES).join("")
+    ));
+  }
+  return {
+    expression: joinedTokens.map((token) => ftsPhrase([token])).join(" AND "),
+    verificationSyllables: joinedTokens.length > 1 ? syllables : null
+  };
+}
+
+export function relationshipPinyinSequenceMatches(value: string, expectedSyllables: readonly string[]): boolean {
+  if (expectedSyllables.length === 0) return false;
+  const sourceSyllables = relationshipPinyinSyllables(value);
+  for (let start = 0; start + expectedSyllables.length <= sourceSyllables.length; start += 1) {
+    if (expectedSyllables.every((syllable, index) => sourceSyllables[start + index] === syllable)) return true;
+  }
+  return false;
 }
 
 export function damerauLevenshteinDistance(left: readonly string[], right: readonly string[], maximum = Number.POSITIVE_INFINITY): number {

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1749,7 +1749,7 @@ describe("AI 供应商、模型与建议 API", () => {
         tools?: Array<{ function?: {
           name?: string;
           description?: string;
-          parameters?: { properties?: { query?: { maxLength?: number } } };
+          parameters?: { properties?: { query?: { maxLength?: number }; includePhonetic?: { type?: string; default?: boolean; description?: string } } };
         } }>;
       };
       if (completionCount === 1) {
@@ -1757,7 +1757,13 @@ describe("AI 供应商、模型与建议 API", () => {
         expect(searchTool?.function?.description).toContain("gender=unknown 时禁止");
         expect(searchTool?.function?.description).toContain("只有值为 true 才能判定");
         expect(searchTool?.function?.description).toContain("字段为 false 时必须视为仍存活、未灭绝或未解散");
+        expect(searchTool?.function?.description).toContain("拼音索引极其缓慢，必须谨慎使用");
         expect(searchTool?.function?.parameters?.properties?.query?.maxLength).toBe(100);
+        expect(searchTool?.function?.parameters?.properties?.includePhonetic).toMatchObject({
+          type: "boolean",
+          default: false,
+          description: expect.stringContaining("极其缓慢")
+        });
         return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [{
           id: "race-knowledge",
           type: "function",
@@ -1896,7 +1902,7 @@ describe("AI 供应商、模型与建议 API", () => {
       { id: "grep-default", name: "grep", arguments: { keyword: "林舟" } },
       { id: "grep-limit", name: "grep", arguments: { keyword: "林舟", limit: 1 } },
       { id: "knowledge-default", name: "search_story_entities", arguments: { query: "跃迁" } },
-      { id: "knowledge-categories", name: "search_story_entities", arguments: { query: "跃迁", categories: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"] } },
+      { id: "knowledge-categories", name: "search_story_entities", arguments: { query: "跃迁", categories: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"], includePhonetic: true } },
       { id: "character-section-summary", name: "read_character_sections", arguments: { sectionIds: [section.id], include: "summary" } },
       { id: "character-section-content", name: "read_character_sections", arguments: { sectionIds: [section.id], include: "content" } },
       { id: "character-section-both", name: "read_character_sections", arguments: { sectionIds: [section.id], include: "both" } }
@@ -1939,7 +1945,7 @@ describe("AI 供应商、模型与建议 API", () => {
         }
       });
       expect(results.get("grep-limit")).toMatchObject({ ok: true, data: { limit: 1, matches: [{ chapterId }] } });
-      expect(results.get("knowledge-default")).toMatchObject({ ok: true, data: { query: "跃迁", matchMode: "hybrid_exact_phonetic" } });
+      expect(results.get("knowledge-default")).toMatchObject({ ok: true, data: { query: "跃迁", matchMode: "hybrid_exact" } });
       expect(results.get("knowledge-categories")).toMatchObject({ ok: true, data: { matchMode: "hybrid_exact_phonetic", matches: expect.any(Array) } });
       expect(results.get("character-section-summary")).toMatchObject({ ok: true, data: { sections: [{ sectionId: section.id, characterName: "哥斯拉", gender: "male", summary: "哥斯拉在远古时期守护地球生态。" }] } });
       expect(results.get("character-section-summary")).not.toHaveProperty("data.sections.0.contentMarkdown");

--- a/tests/integration/ai-stream-idle-timeout.test.ts
+++ b/tests/integration/ai-stream-idle-timeout.test.ts
@@ -39,6 +39,7 @@ describe("交互式 AI 流事件空闲超时", () => {
       disableUserAuth: true,
       fetchImpl: fetchMock,
       serveUi: false,
+      aiStreamHeartbeatIntervalMs: 10,
       aiRetrySleep: async (delayMs) => { retryDelays.push(delayMs); }
     });
     const defaultSettings = await request(runtime.app).get("/api/platform/ai/settings").expect(200);
@@ -75,6 +76,32 @@ describe("交互式 AI 流事件空闲超时", () => {
     expect(response.body.error.code).toBe("VALIDATION_ERROR");
     const settings = await request(runtime.app).get("/api/platform/ai/settings").expect(200);
     expect(settings.body.data.streamIdleTimeoutSeconds).toBe(30);
+  });
+
+  it("上游流暂时静默时持续向客户端发送 SSE 心跳", async () => {
+    const encoder = new TextEncoder();
+    fetchMock.mockImplementation(async (_input, init) => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        const timer = setTimeout(() => {
+          controller.enqueue(encoder.encode(openAiDelta("心跳后完成", "stop")));
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        }, 75);
+        init?.signal?.addEventListener("abort", () => {
+          clearTimeout(timer);
+          controller.error(init.signal?.reason);
+        }, { once: true });
+      }
+    }), { status: 200, headers: { "Content-Type": "text/event-stream" } }));
+
+    const streamed = await request(runtime.app)
+      .post(`/api/works/${workId}/chat/stream`)
+      .send({ instruction: "等待心跳后完成", scope: { type: "none" }, modelId })
+      .expect(200);
+
+    expect(streamed.text).toContain(": heartbeat\n\n");
+    expect(streamed.text).toContain("event: complete");
+    expect(streamed.text).toContain("心跳后完成");
   });
 
   it("每 5 秒收到事件时持续超过 60 秒仍正常完成", async () => {

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -112,6 +112,29 @@ describe("作品混合检索", () => {
     expect(updated.body.data).toEqual([expect.objectContaining({ id: setting.id, type: "setting" })]);
   });
 
+  it("长中文拼音查询使用组合 token 并过滤分离片段", async () => {
+    runtime = createTestRuntime();
+    const matched = await seedChapter(runtime, "斯库拉湖泊污然事件已经发生。");
+    const workId = String(matched.work.id);
+    const separated = runtime.store.createChapter(workId, {
+      volumeId: String(matched.chapter.volumeId),
+      title: "分离片段",
+      content: "斯库拉湖泊污，染事件只是两个片段。"
+    });
+
+    const response = await request(runtime.app)
+      .get(`/api/works/${workId}/search`)
+      .query({ q: "斯库拉湖泊污染事件", type: "chapter", limit: 100 })
+      .expect(200);
+
+    expect(response.body.data).toEqual([
+      expect.objectContaining({ id: matched.chapter.id, matchKinds: expect.arrayContaining(["phonetic"]) })
+    ]);
+    expect(response.body.data).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: separated.id })
+    ]));
+  });
+
   it("实体工具只检索请求的设定库类型，不扫描正文与对话历史", async () => {
     runtime = createTestRuntime();
     const seeded = await seedChapter(runtime, "正文包含实体工具性能标记，但实体工具不应扫描正文。");

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -112,6 +112,42 @@ describe("作品混合检索", () => {
     expect(updated.body.data).toEqual([expect.objectContaining({ id: setting.id, type: "setting" })]);
   });
 
+  it("实体工具只检索请求的设定库类型，不扫描正文与对话历史", async () => {
+    runtime = createTestRuntime();
+    const seeded = await seedChapter(runtime, "正文包含实体工具性能标记，但实体工具不应扫描正文。");
+    const workId = String(seeded.work.id);
+    runtime.store.createSetting(workId, {
+      title: "实体工具性能标记",
+      category: "规则",
+      content: "只返回设定库结果。"
+    });
+    const search = vi.spyOn(runtime.store, "search");
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        candidateWorkId: string,
+        toolCall: Record<string, unknown>
+      ) => Promise<Record<string, unknown>>;
+    };
+
+    const execution = await internalAi.executeAgentTool(workId, {
+      id: "entity-only-search",
+      type: "function",
+      function: {
+        name: "search_story_entities",
+        arguments: JSON.stringify({ query: "实体工具性能标记", categories: ["setting", "timeline"] })
+      }
+    });
+
+    expect(execution.status).toBe("completed");
+    expect(search).toHaveBeenCalledWith(
+      workId,
+      "实体工具性能标记",
+      new Set(["setting", "timeline-track", "timeline-event"])
+    );
+    expect(search.mock.calls[0]?.[2]).not.toContain("chapter");
+    expect(search.mock.calls[0]?.[2]).not.toContain("agent-history");
+  });
+
   it("三条正文搜索路径复用版本化行号索引并对缺失索引执行有界自修复", async () => {
     runtime = createTestRuntime();
     const longPrefix = Array.from({ length: 2_000 }, (_, index) => `铺垫行 ${index + 1}`).join("\n");

--- a/tests/integration/hybrid-search.test.ts
+++ b/tests/integration/hybrid-search.test.ts
@@ -122,6 +122,7 @@ describe("作品混合检索", () => {
       content: "只返回设定库结果。"
     });
     const search = vi.spyOn(runtime.store, "search");
+    const searchWork = vi.spyOn(runtime.ai, "searchWork");
     const internalAi = runtime.ai as unknown as {
       executeAgentTool: (
         candidateWorkId: string,
@@ -146,6 +147,25 @@ describe("作品混合检索", () => {
     );
     expect(search.mock.calls[0]?.[2]).not.toContain("chapter");
     expect(search.mock.calls[0]?.[2]).not.toContain("agent-history");
+    expect(searchWork).toHaveBeenCalledWith(workId, "实体工具性能标记", {
+      limit: 100,
+      allowedTypes: ["setting", "timeline-track", "timeline-event"],
+      includePhonetic: false
+    });
+
+    await internalAi.executeAgentTool(workId, {
+      id: "entity-phonetic-search",
+      type: "function",
+      function: {
+        name: "search_story_entities",
+        arguments: JSON.stringify({ query: "实体工具性能标记", categories: ["setting"], includePhonetic: true })
+      }
+    });
+    expect(searchWork).toHaveBeenLastCalledWith(workId, "实体工具性能标记", {
+      limit: 100,
+      allowedTypes: ["setting"],
+      includePhonetic: true
+    });
   });
 
   it("三条正文搜索路径复用版本化行号索引并对缺失索引执行有界自修复", async () => {

--- a/tests/unit/ai-stream-protocol.test.ts
+++ b/tests/unit/ai-stream-protocol.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error 浏览器端模块没有单独的类型声明，测试仅调用纯函数导出。
+import { assertAiStreamCompleted, readAiEventStream } from "../../src/public/ai-stream-protocol.js";
+
+describe("AI 客户端流协议", () => {
+  it("忽略 SSE 心跳注释并继续消费业务事件", async () => {
+    const body = new Response([
+      ": heartbeat",
+      "",
+      "event: delta",
+      'data: {"delta":"继续生成"}',
+      "",
+      ": heartbeat",
+      "",
+      "event: complete",
+      "data: {}",
+      ""
+    ].join("\n")).body;
+    expect(body).not.toBeNull();
+    const events: Array<{ event: string; payload: unknown }> = [];
+
+    const result = await readAiEventStream(body!, async (event: string, payload: unknown) => {
+      events.push({ event, payload });
+    });
+
+    expect(events).toEqual([
+      { event: "delta", payload: { delta: "继续生成" } },
+      { event: "complete", payload: {} }
+    ]);
+    expect(() => assertAiStreamCompleted(result.completed)).not.toThrow();
+  });
+});

--- a/tests/unit/relationship-search.test.ts
+++ b/tests/unit/relationship-search.test.ts
@@ -7,7 +7,9 @@ import {
   isRelationshipPhoneticReference,
   relationshipCharacterTokens,
   relationshipPinyinJoinedTokens,
+  relationshipPinyinFtsQuery,
   relationshipPinyinSearchTokens,
+  relationshipPinyinSequenceMatches,
   relationshipPinyinSyllables,
   relationshipPinyinTokens
 } from "../../src/relationship-search.js";
@@ -20,6 +22,23 @@ describe("人物关系来源搜索", () => {
     expect(relationshipPinyinSearchTokens("北港")).toEqual(["pbei", "pgang"]);
     expect(relationshipPinyinSearchTokens("bei gang")).toEqual(["pbeigang"]);
     expect(relationshipPinyinJoinedTokens("抵达北港议会")).toContain("pbeigang");
+  });
+
+  it("使用组合拼音 token 压缩 FTS 查询并校验长短语顺序", () => {
+    expect(relationshipPinyinFtsQuery("回忆录")).toEqual({
+      expression: '"phuiyilu"',
+      verificationSyllables: null
+    });
+    expect(relationshipPinyinFtsQuery("斯库拉湖泊污染事件")).toEqual({
+      expression: '"psikulahubowu" AND "pranshijian"',
+      verificationSyllables: ["si", "ku", "la", "hu", "bo", "wu", "ran", "shi", "jian"]
+    });
+    expect(relationshipPinyinFtsQuery("bei gang")).toEqual({
+      expression: '"pbeigang"',
+      verificationSyllables: null
+    });
+    expect(relationshipPinyinSequenceMatches("斯库拉湖泊污然事件发生", ["si", "ku", "la", "hu", "bo", "wu", "ran", "shi", "jian"])).toBe(true);
+    expect(relationshipPinyinSequenceMatches("斯库拉湖泊污，染事件发生", ["si", "ku", "la", "hu", "bo", "wu", "ran", "shi", "jian"])).toBe(false);
   });
 
   it("仅允许中文姓名和中文别名参与拼音疑似匹配", () => {


### PR DESCRIPTION
## 变更\n\n- 为浏览器与 Desktop 的 AI SSE 增加 15 秒心跳，并同步续租流请求。\n- 将 search_story_entities 限定为请求的设定库类型，避免扫描正文与 Agent 历史。\n- search_story_entities 默认关闭拼音索引，新增 includePhonetic 参数显式开启，并在工具描述中提示高开销。\n- 全局章节拼音搜索复用组合 token，长短语增加结果顺序校验。\n\n## 生产性能验证\n\n- 回忆录：4783 ms 降至 415 ms。\n- 娜奇卡：3108 ms 降至 422 ms。\n- 长中文短语：52436 ms 降至 842 ms。\n- 三组查询命中数量与优化前一致，提升约 86% 至 98%。\n\n## 根因证据\n\n- OpenResty 默认 60 秒读取超时早于 Server 的 AI 流空闲超时。\n- 生产日志中 search_story_entities 单次阻塞约 144 秒，期间 health、presence、tasks 等接口同时 504。\n- 生产只读分阶段基准确认，主要耗时来自无关的 chapter_paragraph_pinyin_fts 查询。\n\n## 验证\n\n- npm run typecheck\n- npm test：237 个测试文件、1204 个用例通过\n- npm run build\n- 生产数据库只读 PRAGMA integrity_check 与 foreign_key_check\n- monarch OpenResty 配置检查、重载与健康检查