### PR TITLE
chore(release): bump version to 0.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.9.4";
+export const APP_VERSION = "0.9.5";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 摘要
- 将 package.json、package-lock.json 和 src/version.ts 统一更新至 0.9.5

## 验证
- npm run typecheck
- npm test（253 个文件，1301 个测试）
- npm run build
- npm run test:e2e:cli
- npm run test:database-upgrade
- 隔离服务健康检查与 SQLite 完整性检查