### PR TITLE
chore(release): bump version to 0.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.9.6";
+export const APP_VERSION = "0.9.7";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 将 package.json、package-lock.json 和运行时 APP_VERSION 同步更新至 0.9.7。
- CLI 契约审计确认本次 develop 相对 main 的功能不需要新增或修复 CLI 入口。

## 验证

- 版本一致性测试通过。
- npm test：265 个测试文件、1361 项测试全部通过。
- npm run typecheck、npm run build、npm run test:database-upgrade 通过。
- 真实 CLI E2E 全部通过。
- 隔离健康检查返回 Server/Web 0.9.7，SQLite integrity_check 与 foreign_key_check 通过。