### PR TITLE
chore(release): bump Server version to 0.9.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.9.7";
+export const APP_VERSION = "0.9.8";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 

--- a/tests/integration/ai-development-endpoint.test.ts
+++ b/tests/integration/ai-development-endpoint.test.ts
@@ -40,14 +40,15 @@ async function testProviderConnection(options: {
     developmentServer: options.developmentServer
   });
   runtimes.push(runtime);
+  const agent = request.agent(runtime.app);
 
-  const provider = await request(runtime.app).post("/api/platform/ai/providers").send({
+  const provider = await agent.post("/api/platform/ai/providers").send({
     name: "开发地址测试供应商",
     baseUrl: options.baseUrl,
     apiKey: "development-test-key",
     status: "enabled"
   }).expect(201);
-  const tested = await request(runtime.app).post(`/api/providers/${provider.body.data.id}/test`).send({}).expect(200);
+  const tested = await agent.post(`/api/providers/${provider.body.data.id}/test`).send({}).expect(200);
   return { result: tested.body.data as Record<string, unknown>, requestedUrls };
 }
 


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 与运行时 `APP_VERSION` 同步更新为 `0.9.8`
- 修复全量并发测试中 Supertest 临时监听器端口竞争，复用同一测试 agent

## 发布审计

- `develop` 无待合入 PR
- CLI 无需适配：本版本未新增 CLI 用户操作或导入导出契约

## 验证

- 版本一致性测试：2 项通过
- `npm run typecheck`
- `npm test`：265 个文件、1365 项通过
- `npm run build`
- `npm run test:e2e:cli`
- 隔离健康检查返回 `0.9.8`
- SQLite `integrity_check` / `foreign_key_check` 通过