### PR TITLE
MUXUE-111: clarify AI tool pagination

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -56,6 +56,7 @@ import {
   shouldRejectAgentToolCalls,
   shouldRejectGlobalToolCalls,
   structuralToolResultRecords,
+  type AgentToolResultPagination,
   withAgentToolCallQuotaNotice
 } from "./ai-tool-results.js";
 import { AiConnectivityTestGate, hashAiConnectivityConfiguration, type AiConnectivityTestClaim } from "./ai-connectivity-test.js";
@@ -1474,9 +1475,54 @@ const TOOL_CONTEXT_COMPACT_MAX_TOKENS = 1_024;
 const TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS = MIN_OUTPUT_RESERVE_TOKENS;
 const IMAGE_TOOL_MAX_BYTES = 30 * 1024 * 1024;
 const IMAGE_TOOL_MAX_OUTPUT_TOKENS = 8_192;
-// 工具轮次的可用结果预算会变化；固定分片上限，确保数值 cursor 始终指向同一条结构记录。
-const AGENT_TOOL_STABLE_RECORD_MAX_CHARS = 500;
-const agentToolCursor = z.number().int().min(0).max(100_000).default(0);
+const LEGACY_AGENT_TOOL_CURSOR_MAX = 100_000;
+const AGENT_TOOL_CURSOR_INDEX_BASE = 1_000_000;
+const AGENT_TOOL_RECORD_MIN_CHARS = 128;
+const AGENT_TOOL_RECORD_MAX_CHARS = 6_000;
+const AGENT_TOOL_CURSOR_MAX = AGENT_TOOL_RECORD_MAX_CHARS * AGENT_TOOL_CURSOR_INDEX_BASE + AGENT_TOOL_CURSOR_INDEX_BASE - 1;
+const agentToolCursor = z.number().int().min(0).max(AGENT_TOOL_CURSOR_MAX).refine((value) => {
+  if (value <= LEGACY_AGENT_TOOL_CURSOR_MAX) return true;
+  const recordChars = Math.floor(value / AGENT_TOOL_CURSOR_INDEX_BASE);
+  return recordChars >= AGENT_TOOL_RECORD_MIN_CHARS && recordChars <= AGENT_TOOL_RECORD_MAX_CHARS;
+}, "Invalid result cursor.").default(0);
+
+type AgentToolCursorState = {
+  suppliedCursor: number;
+  recordIndex: number;
+  recordMaximumChars: number;
+};
+
+function resolveAgentToolCursor(cursor: number, defaultRecordMaximumChars: number): AgentToolCursorState {
+  if (cursor <= LEGACY_AGENT_TOOL_CURSOR_MAX) {
+    return { suppliedCursor: cursor, recordIndex: cursor, recordMaximumChars: defaultRecordMaximumChars };
+  }
+  return {
+    suppliedCursor: cursor,
+    recordIndex: cursor % AGENT_TOOL_CURSOR_INDEX_BASE,
+    recordMaximumChars: Math.floor(cursor / AGENT_TOOL_CURSOR_INDEX_BASE)
+  };
+}
+
+function encodeAgentToolCursor(recordMaximumChars: number, recordIndex: number): number {
+  if (recordIndex >= AGENT_TOOL_CURSOR_INDEX_BASE) throw new Error("Agent tool result cursor exceeded its record index limit.");
+  return recordMaximumChars * AGENT_TOOL_CURSOR_INDEX_BASE + recordIndex;
+}
+
+function paginateAgentToolResultRecords(
+  records: Record<string, unknown>[],
+  cursor: AgentToolCursorState,
+  buildResult: (page: Record<string, unknown>[], pagination: AgentToolResultPagination) => Record<string, unknown>,
+  maximumChars: number
+): Record<string, unknown> {
+  return paginateToolResultRecords(records, cursor.recordIndex, (page, pagination) => buildResult(page, {
+    cursor: cursor.suppliedCursor,
+    nextCursor: pagination.nextCursor === null
+      ? null
+      : encodeAgentToolCursor(cursor.recordMaximumChars, pagination.nextCursor),
+    maxChars: pagination.maxChars
+  }), maximumChars);
+}
+
 const storyIndexArguments = z.object({
   chapterOffset: z.number().int().min(0).max(10_000).optional(),
   // 兼容旧版工具调用；新工具定义只向模型暴露语义明确的 chapterOffset。
@@ -1565,9 +1611,16 @@ const askUserQuestionArguments = z.object({
 const agentToolCursorParameter = {
   type: "integer",
   minimum: 0,
-  maximum: 100_000,
+  maximum: AGENT_TOOL_CURSOR_MAX,
   default: 0,
-  description: "结果分片游标；取 pagination.nextCursor 并保持查询参数不变。"
+  description: "不透明的结果分片游标；原样传入 pagination.nextCursor 并保持查询参数不变。"
+};
+const roleplayMemoryCursorParameter = {
+  type: "integer",
+  minimum: 0,
+  maximum: LEGACY_AGENT_TOOL_CURSOR_MAX,
+  default: 0,
+  description: "记忆列表续页游标；取 pagination.nextCursor。"
 };
 
 function storyOrderingGuide(timelineAvailable: boolean): Record<string, unknown> {
@@ -1727,7 +1780,7 @@ const AGENT_TOOL_DEFINITIONS: Record<AgentToolId, Record<string, unknown>> = {
         properties: {
           query: { type: "string", maxLength: 200, default: "" },
           categories: { type: "array", items: { type: "string", enum: ["event", "state", "relationship", "commitment", "knowledge", "scene"] }, maxItems: 6, default: [] },
-          cursor: agentToolCursorParameter
+          cursor: roleplayMemoryCursorParameter
         },
         additionalProperties: false
       }
@@ -8497,7 +8550,10 @@ export class AiManager {
     const name = toolCall.function.name;
     const calledAt = now();
     const conversationId = chatContext?.conversationId ?? null;
-    const maximumRecordChars = AGENT_TOOL_STABLE_RECORD_MAX_CHARS;
+    const defaultRecordMaximumChars = Math.max(
+      AGENT_TOOL_RECORD_MIN_CHARS,
+      Math.min(AGENT_TOOL_RECORD_MAX_CHARS, maximumResultChars - 500)
+    );
     let rawArguments: unknown = toolCall.function.arguments;
     if (typeof rawArguments === "string") {
       try {
@@ -8620,6 +8676,11 @@ export class AiManager {
       };
     }
     const args = parsed.data;
+    const suppliedCursor = typeof args === "object" && args !== null && "cursor" in args && typeof args.cursor === "number"
+      ? args.cursor
+      : 0;
+    const paginationCursor = resolveAgentToolCursor(suppliedCursor, defaultRecordMaximumChars);
+    const maximumRecordChars = paginationCursor.recordMaximumChars;
     const scopedChapterIds = scope && (scope.type === "chapter" || scope.type === "volume" || scope.type === "book")
       ? new Set(this.getScopeChapters(workId, scope).map((chapter) => String(chapter.id)))
       : null;
@@ -8718,7 +8779,7 @@ export class AiManager {
       }
       const sourceRecords = hasRequestedCharacters ? relationshipRecords : [...relatedCharacters.values()];
       const records = structuralToolResultRecords(sourceRecords, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: {
           identity: { name: character.name, gender: character.gender, code: character.code },
@@ -8791,7 +8852,7 @@ export class AiManager {
         }
       }
       const records = structuralToolResultRecords(sourceRecords, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: {
           identity: { name: character.name, gender: character.gender, code: character.code },
@@ -8913,7 +8974,7 @@ export class AiManager {
         }
       }
       const records = structuralToolResultRecords(memoryRecords, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: {
           identity: { name: character.name, gender: character.gender, code: character.code },
@@ -9089,7 +9150,7 @@ export class AiManager {
         }
       }
       const records = structuralToolResultRecords(memoryRecords, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: {
           identity: { name: character.name, gender: character.gender, code: character.code },
@@ -9143,7 +9204,7 @@ export class AiManager {
             rule: "directoryOrder 非剧情顺序；相同 storyOrder 或 timeSort 不强行定序。"
           }
         : storyOrderingGuide(timelineAvailable);
-      const result = paginateToolResultRecords([...latestChapterRecords, ...workRecords, ...chapterRecords], cursor, (page, pagination) => {
+      const result = paginateAgentToolResultRecords([...latestChapterRecords, ...workRecords, ...chapterRecords], paginationCursor, (page, pagination) => {
         const pageWork = page.flatMap((record) => {
           if (record._toolResultSection !== "work") return [];
           const { _toolResultSection: _section, ...value } = record;
@@ -9225,7 +9286,7 @@ export class AiManager {
         }
       });
       const records = structuralToolResultRecords(chapters, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: { storyOrdering: storyOrderingGuide(timelineAvailable), chapters: page },
         pagination
@@ -9275,9 +9336,9 @@ export class AiManager {
             rule: "directoryOrder 非剧情顺序；相同 storyOrder 或 timeSort 表示并行、同时或未知。"
           }
         : storyOrderingGuide(timelineAvailable);
-      const result = paginateToolResultRecords(
+      const result = paginateAgentToolResultRecords(
         [...latestStructureRecords, ...latestTimelineRecords, ...matchRecords],
-        cursor,
+        paginationCursor,
         (page, pagination) => {
           const section = (name: string): Record<string, unknown>[] => page.flatMap((record) => {
             if (record._toolResultSection !== name) return [];
@@ -9358,7 +9419,7 @@ export class AiManager {
             rule: "orderEligible=false 不参与时间比较；directoryOrder 非剧情顺序。"
           }
         : storyOrderingGuide(canReadWorkModule(permissions, "timeline"));
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: {
           query,
@@ -9398,7 +9459,7 @@ export class AiManager {
         });
         const matches = Array.isArray(search.results) ? search.results as Record<string, unknown>[] : [];
         const records = structuralToolResultRecords(matches, maximumRecordChars);
-        const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+        const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
           ok: search.status === "ready" || search.status === "degraded",
           data: {
             query,
@@ -9457,7 +9518,7 @@ export class AiManager {
         }
       });
       const records = structuralToolResultRecords(sections, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: { sections: page },
         pagination
@@ -9482,7 +9543,7 @@ export class AiManager {
         };
       });
       const records = structuralToolResultRecords(matches, maximumRecordChars);
-      const result = paginateToolResultRecords(records, cursor, (page, pagination) => ({
+      const result = paginateAgentToolResultRecords(records, paginationCursor, (page, pagination) => ({
         ok: true,
         data: {
           meaning: "这些内容是作者记录的未确认临时想法，可能采用，也可能永远不会写入正文或正式设定；不得视为故事事实。",

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1476,10 +1476,20 @@ const IMAGE_TOOL_MAX_BYTES = 30 * 1024 * 1024;
 const IMAGE_TOOL_MAX_OUTPUT_TOKENS = 8_192;
 const agentToolCursor = z.number().int().min(0).max(100_000).default(0);
 const storyIndexArguments = z.object({
-  offset: z.number().int().min(0).max(10_000).default(0),
+  chapterOffset: z.number().int().min(0).max(10_000).optional(),
+  // 兼容旧版工具调用；新工具定义只向模型暴露语义明确的 chapterOffset。
+  offset: z.number().int().min(0).max(10_000).optional(),
   limit: z.number().int().min(1).max(50).default(20),
   cursor: agentToolCursor
-}).strict();
+}).strict().superRefine((value, context) => {
+  if (value.chapterOffset !== undefined && value.offset !== undefined) {
+    context.addIssue({ code: "custom", message: "chapterOffset and legacy offset cannot be used together." });
+  }
+}).transform(({ chapterOffset, offset, limit, cursor }) => ({
+  chapterOffset: chapterOffset ?? offset ?? 0,
+  limit,
+  cursor
+}));
 const readChaptersArguments = z.object({
   chapterIds: z.array(z.string().min(1).max(200)).min(1).max(3),
   include: z.enum(["summary", "content", "both"]).default("both"),
@@ -1555,7 +1565,7 @@ const agentToolCursorParameter = {
   minimum: 0,
   maximum: 100_000,
   default: 0,
-  description: "续页游标，取 pagination.nextCursor。"
+  description: "结果分片游标；取 pagination.nextCursor 并保持查询参数不变。"
 };
 
 function storyOrderingGuide(timelineAvailable: boolean): Record<string, unknown> {
@@ -1581,8 +1591,22 @@ const AGENT_TOOL_DEFINITIONS: Record<AgentToolId, Record<string, unknown>> = {
     type: "function",
     function: {
       name: "story_index",
-      description: "读取当前作品的基本信息，并按分卷剧情顺序分页列出卷章、章节概要和完整顺序元数据。latestChaptersByStructure 始终独立返回结构上最新的正文章节，不受当前章节分页影响；nextOffset 非空时表示还有后续章节页。有时间线读取权限时还返回已确认且可排序的关联事件。回答作品简介、最新剧情、情节先后、整体结构或定位章节时优先使用；不会返回正文。",
-      parameters: { type: "object", properties: { offset: { type: "integer", minimum: 0 }, limit: { type: "integer", minimum: 1, maximum: 50 }, cursor: agentToolCursorParameter }, additionalProperties: false }
+      description: "读取当前作品的基本信息，并按分卷剧情顺序分页列出卷章、章节概要和完整顺序元数据。latestChaptersByStructure 始终独立返回结构上最新的正文章节，不受当前章节分页影响；nextChapterOffset 非空时表示还有后续章节页。有时间线读取权限时还返回已确认且可排序的关联事件。回答作品简介、最新剧情、情节先后、整体结构或定位章节时优先使用；不会返回正文。",
+      parameters: {
+        type: "object",
+        properties: {
+          chapterOffset: {
+            type: "integer",
+            minimum: 0,
+            maximum: 10_000,
+            default: 0,
+            description: "章节页起点；换页时取 data.nextChapterOffset 并将 cursor 置 0。"
+          },
+          limit: { type: "integer", minimum: 1, maximum: 50, default: 20, description: "每个章节页最多读取的章节数。" },
+          cursor: agentToolCursorParameter
+        },
+        additionalProperties: false
+      }
     }
   },
   read_chapters: {
@@ -7631,7 +7655,7 @@ export class AiManager {
           ...directImageToolGuidance,
           ...(enabledToolIds.includes("calculate_time") ? ["涉及两个日期之间的天数差时，使用 calculate_time；不要凭记忆估算日期。"] : []),
           "当作者询问当前作品、项目、章节、情节、人物、关系、世界观或设定，而预加载上下文为空或不足时，必须先调用工具主动查询；不得直接声称没有上下文，也不得先要求作者补充本系统已经能够查询的信息。",
-          "整体介绍、作品基本信息、目录、最新剧情、情节先后或章节定位优先调用 story_index，并严格按返回的 storyOrdering 与 storyOrder 判断顺序；story_index.latestChaptersByStructure 是不受当前分页影响的结构最新章节，若要遍历完整目录则在 nextOffset 非空时用该值作为 offset 继续调用。按关键字定位正文段落时调用 grep；以 grep.latestOccurrences.byStructure 判断关键词的结构最后出现位置，以 grep.latestOccurrences.byTimelineTrack 中同一 trackId 的最大 timeSort 判断倒叙时间，不能跨轨道比较。已知章节 ID 且需要原文事实或精确措辞时调用 read_chapters；查找设定、人物、组织、时间线、关系、大纲或伏笔时调用 search_story_entities（可传入短实体名、拼音或关键词，勿用自然语言整句）；需要用自然语言整句跨正文和设定库查找原文时，才显式调用 semantic_search_story，并保留其 semantic 来源标记；人物匹配结果包含 sectionId 且需要背景故事、能力或经历原文时调用 read_character_sections；作者询问尚未定稿的想法、备选方向或明确提到想法时调用 search_drafts。想法可能永远不会进入正文或设定，必须明确标注为未确认想法，不得把它当作故事事实。工具结果上限 10000 字符；pagination.nextCursor 非空时，以其作为 cursor 并保持其他参数不变续读，不得假定后续不存在。",
+          "整体介绍、作品基本信息、目录、最新剧情、情节先后或章节定位优先调用 story_index，并严格按返回的 storyOrdering 与 storyOrder 判断顺序；story_index.latestChaptersByStructure 是不受当前分页影响的结构最新章节。遍历目录时，pagination.nextCursor 非空则保持 chapterOffset/limit 续读；否则用 nextChapterOffset 换页并将 cursor 置 0。按关键字定位正文段落时调用 grep；以 grep.latestOccurrences.byStructure 判断关键词的结构最后出现位置，以 grep.latestOccurrences.byTimelineTrack 中同一 trackId 的最大 timeSort 判断倒叙时间，不能跨轨道比较。已知章节 ID 且需要原文事实或精确措辞时调用 read_chapters；查找设定、人物、组织、时间线、关系、大纲或伏笔时调用 search_story_entities（可传入短实体名、拼音或关键词，勿用自然语言整句）；需要用自然语言整句跨正文和设定库查找原文时，才显式调用 semantic_search_story，并保留其 semantic 来源标记；人物匹配结果包含 sectionId 且需要背景故事、能力或经历原文时调用 read_character_sections；作者询问尚未定稿的想法、备选方向或明确提到想法时调用 search_drafts。想法可能永远不会进入正文或设定，必须明确标注为未确认想法，不得把它当作故事事实。工具结果上限 10000 字符；pagination.nextCursor 非空时，以其作为 cursor 并保持其他参数不变续读，不得假定后续不存在。",
           "根据问题选择最少且必要的工具。工具结果仍不足时才说明未知，并明确已经查询过什么；不要重复无效调用。"
         ].join("\n")
       : "";
@@ -9087,10 +9111,10 @@ export class AiManager {
       };
     }
     if (name === "story_index") {
-      const { offset, limit, cursor } = args as z.infer<typeof storyIndexArguments>;
+      const { chapterOffset, limit, cursor } = args as z.infer<typeof storyIndexArguments>;
       const work = this.store.getWork(workId);
       const timelineAvailable = canReadWorkModule(permissions, "timeline");
-      const chapterPage = this.store.getStoryIndexChapterPage(workId, offset, limit, {
+      const chapterPage = this.store.getStoryIndexChapterPage(workId, chapterOffset, limit, {
         excludeAuthorNotes: true,
         includeTimeline: timelineAvailable
       });
@@ -9133,7 +9157,14 @@ export class AiManager {
           const { _toolResultSection: _section, ...value } = record;
           return [value];
         });
-        const nextOffset = pagination.nextCursor === null && offset + limit < chapterPage.totalChapters ? offset + limit : null;
+        const nextChapterOffset = pagination.nextCursor === null && chapterOffset + limit < chapterPage.totalChapters
+          ? chapterOffset + limit
+          : null;
+        const continuationRule = pagination.nextCursor !== null
+          ? "当前章节页的结果仍有后续分片；使用 pagination.nextCursor 作为 cursor，并保持 chapterOffset 与 limit 不变。"
+          : nextChapterOffset !== null
+            ? "当前章节页的结果已读完；使用 nextChapterOffset 作为下一次 chapterOffset，并把 cursor 重置为 0。"
+            : "章节目录已全部读完。";
         return {
           ok: true,
           data: {
@@ -9142,14 +9173,16 @@ export class AiManager {
             storyOrdering: indexStoryOrdering,
             latestChaptersByStructure: pageLatestChapters,
             totalChapters: chapterPage.totalChapters,
-            offset,
+            chapterOffset,
             chapters: pageChapters,
-            nextOffset,
-            nextOffsetRule: compactOrdering
-              ? (nextOffset === null ? "end" : "use nextOffset")
-              : nextOffset === null
-                ? "当前章节页已到末尾。"
-                : "章节目录仍有后续；如需遍历完整目录，使用 nextOffset 作为下一次 story_index 的 offset。"
+            nextChapterOffset,
+            continuationRule: compactOrdering
+              ? (pagination.nextCursor !== null
+                  ? "use pagination.nextCursor with same chapterOffset/limit"
+                  : nextChapterOffset !== null
+                    ? "use nextChapterOffset and reset cursor"
+                    : "end")
+              : continuationRule
           },
           pagination
         };
@@ -9158,7 +9191,7 @@ export class AiManager {
         id: toolCall.id,
         name,
         calledAt,
-        arguments: { offset, limit, ...(cursor > 0 ? { cursor } : {}) },
+        arguments: { chapterOffset, limit, ...(cursor > 0 ? { cursor } : {}) },
         status: "completed",
         result
       };

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1474,6 +1474,8 @@ const TOOL_CONTEXT_COMPACT_MAX_TOKENS = 1_024;
 const TOOL_CONTEXT_RESPONSE_RESERVE_TOKENS = MIN_OUTPUT_RESERVE_TOKENS;
 const IMAGE_TOOL_MAX_BYTES = 30 * 1024 * 1024;
 const IMAGE_TOOL_MAX_OUTPUT_TOKENS = 8_192;
+// 工具轮次的可用结果预算会变化；固定分片上限，确保数值 cursor 始终指向同一条结构记录。
+const AGENT_TOOL_STABLE_RECORD_MAX_CHARS = 500;
 const agentToolCursor = z.number().int().min(0).max(100_000).default(0);
 const storyIndexArguments = z.object({
   chapterOffset: z.number().int().min(0).max(10_000).optional(),
@@ -8495,7 +8497,7 @@ export class AiManager {
     const name = toolCall.function.name;
     const calledAt = now();
     const conversationId = chatContext?.conversationId ?? null;
-    const maximumRecordChars = Math.max(128, Math.min(6_000, maximumResultChars - 500));
+    const maximumRecordChars = AGENT_TOOL_STABLE_RECORD_MAX_CHARS;
     let rawArguments: unknown = toolCall.function.arguments;
     if (typeof rawArguments === "string") {
       try {

--- a/tests/e2e/browser-ai-fixture.ts
+++ b/tests/e2e/browser-ai-fixture.ts
@@ -103,7 +103,7 @@ const mockAi = createServer(async (request, response) => {
   if (latestUserMessage.includes("浏览器工具测试")) {
     if (toolMessages.length === 0) {
       sendToolCalls(response, [
-        { id: "browser-index", name: "story_index", arguments: { offset: 0, limit: 1 } },
+        { id: "browser-index", name: "story_index", arguments: { chapterOffset: 0, limit: 1 } },
         { id: "browser-read", name: "read_chapters", arguments: { chapterIds: [chapterId], include: "both" } },
         { id: "browser-query", name: "search_story_entities", arguments: { query: "跃迁", categories: ["setting"] } }
       ]);
@@ -134,7 +134,7 @@ const mockAi = createServer(async (request, response) => {
   if (latestUserMessage.includes("浏览器思考步骤测试")) {
     if (toolMessages.length === 0) {
       sendToolCalls(response, [
-        { id: "browser-thinking-index", name: "story_index", arguments: { offset: 0, limit: 1 } }
+        { id: "browser-thinking-index", name: "story_index", arguments: { chapterOffset: 0, limit: 1 } }
       ], { content: "我先读取作品目录。", reasoningContent: "需要先确认作品结构和章节范围。" });
       return;
     }
@@ -158,7 +158,7 @@ const mockAi = createServer(async (request, response) => {
       sendToolCalls(response, Array.from({ length: 8 }, (_, index) => ({
         id: `browser-scroll-${index}`,
         name: "story_index",
-        arguments: { offset: index, limit: 1 }
+        arguments: { chapterOffset: index, limit: 1 }
       })));
       return;
     }
@@ -236,7 +236,7 @@ const mockAi = createServer(async (request, response) => {
       sendToolCalls(response, [{ id: "browser-compact-read", name: "read_chapters", arguments: { chapterIds: [chapterId], include: "content" } }]);
       return;
     }
-    sendToolCalls(response, [{ id: "browser-compact-index", name: "story_index", arguments: { offset: 0, limit: 1 } }]);
+    sendToolCalls(response, [{ id: "browser-compact-index", name: "story_index", arguments: { chapterOffset: 0, limit: 1 } }]);
     return;
   }
   if (latestUserMessage.includes("浏览器压缩后测试")) {

--- a/tests/e2e/real-ai-agent-tools.ts
+++ b/tests/e2e/real-ai-agent-tools.ts
@@ -20,6 +20,7 @@ let characterSectionId = "";
 let matrixVerified = false;
 let matrixInitialResultsVerified = false;
 let matrixExpectedCursor: number | null = null;
+let matrixContinuationCalls = 0;
 const matrixBothChapterRecords: JsonObject[] = [];
 let failureFeedbackVerified = false;
 let multiTurnVerified = false;
@@ -96,7 +97,7 @@ const mockAi = createServer(async (incoming, outgoing) => {
           { id: "chapter-both", name: "read_chapters", arguments: { chapterIds, include: "both" } },
           { id: "chapter-errors", name: "read_chapters", arguments: { chapterIds: [chapterIds[0], "missing-chapter", otherWorkChapterId] } },
           { id: "knowledge-default", name: "search_story_entities", arguments: { query: "跃迁" } },
-          { id: "knowledge-all", name: "search_story_entities", arguments: { query: "跃迁", categories: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"] } },
+          { id: "knowledge-all", name: "search_story_entities", arguments: { query: "跃迁", categories: ["setting", "character", "race", "organization", "timeline", "relationship", "outline", "foreshadow"], includePhonetic: true } },
           { id: "character-section", name: "read_character_sections", arguments: { sectionIds: [characterSectionId], include: "both" } }
         ]);
         return;
@@ -115,7 +116,7 @@ const mockAi = createServer(async (incoming, outgoing) => {
         assert.equal(object(errorChapters[1]?.error).message, "The requested chapter was not found.");
         assert.equal(object(errorChapters[2]?.error).message, "The requested chapter belongs to a different work.");
         assert.deepEqual(object(results.get("knowledge-default")).ok, true);
-        assert.equal(object(object(results.get("knowledge-default")).data).matchMode, "hybrid_exact_phonetic");
+        assert.equal(object(object(results.get("knowledge-default")).data).matchMode, "hybrid_exact");
         const defaultMatches = array(object(object(results.get("knowledge-default")).data).matches).map(object);
         assert.equal(defaultMatches.some((item) => String(item.type) === "setting" && String(item.title).includes("跃迁")), true);
         assert.equal(array(object(object(results.get("knowledge-all")).data).matches).length >= 1, true);
@@ -134,6 +135,7 @@ const mockAi = createServer(async (incoming, outgoing) => {
       if (typeof nextCursor === "number") {
         assert.ok(nextCursor > (matrixExpectedCursor ?? 0));
         matrixExpectedCursor = nextCursor;
+        matrixContinuationCalls += 1;
         toolCalls(outgoing, [{
           id: `chapter-both-cursor-${nextCursor}`,
           name: "read_chapters",
@@ -264,7 +266,7 @@ try {
   const work = await api<JsonObject>("POST", "/works", { title: "AI 工具 E2E" });
   const workId = String(work.id);
   const volume = await api<JsonObject>("POST", `/works/${workId}/volumes`, { title: "第一卷" });
-  for (const [index, content] of ["林舟启动跃迁。", "飞船进入冷却阶段。", "北港记录了返回信标。"].entries()) {
+  for (const [index, content] of ["林舟启动跃迁。", "飞船进入冷却阶段。", "北港记录了返回信标。".repeat(400)].entries()) {
     const chapter = await api<JsonObject>("POST", `/works/${workId}/chapters`, {
       volumeId: String(volume.id),
       title: `第${index + 1}章`,
@@ -308,11 +310,12 @@ try {
   const matrix = await api<JsonObject>("POST", `/works/${workId}/suggestions`, {
     taskType: "chat",
     instruction: "E2E_TOOL_MATRIX",
-    scope: { type: "chapter", chapterId: chapterIds[0] },
+    scope: { type: "none" },
     modelId
   });
   assert.equal(matrix.content, "模型已读取并正确处理全部九组工具结果。");
-  assert.equal(array(matrix.toolCalls).length, 9);
+  assert.ok(matrixContinuationCalls > 0);
+  assert.equal(array(matrix.toolCalls).length, 9 + matrixContinuationCalls);
   assert.equal(matrixVerified, true);
   checked("tool-arguments", "all optional/default/boundary parameter combinations reached the model as structured results");
 

--- a/tests/e2e/real-ai-agent-tools.ts
+++ b/tests/e2e/real-ai-agent-tools.ts
@@ -18,6 +18,9 @@ let chapterIds: string[] = [];
 let otherWorkChapterId = "";
 let characterSectionId = "";
 let matrixVerified = false;
+let matrixInitialResultsVerified = false;
+let matrixExpectedCursor: number | null = null;
+const matrixBothChapterRecords: JsonObject[] = [];
 let failureFeedbackVerified = false;
 let multiTurnVerified = false;
 let compactRequestVerified = false;
@@ -87,7 +90,7 @@ const mockAi = createServer(async (incoming, outgoing) => {
         assert.deepEqual(body.tools?.map((tool) => tool.function?.name), ["story_index", "read_chapters", "grep", "search_story_entities", "read_character_sections", "search_drafts"]);
         toolCalls(outgoing, [
           { id: "index-default", name: "story_index", arguments: {} },
-          { id: "index-boundary", name: "story_index", arguments: JSON.stringify({ offset: 1, limit: 50 }) },
+          { id: "index-boundary", name: "story_index", arguments: JSON.stringify({ chapterOffset: 1, limit: 50 }) },
           { id: "chapter-summary", name: "read_chapters", arguments: { chapterIds: [chapterIds[0]], include: "summary" } },
           { id: "chapter-content", name: "read_chapters", arguments: { chapterIds: chapterIds.slice(0, 2), include: "content" } },
           { id: "chapter-both", name: "read_chapters", arguments: { chapterIds, include: "both" } },
@@ -98,30 +101,52 @@ const mockAi = createServer(async (incoming, outgoing) => {
         ]);
         return;
       }
-      assert.equal(results.size, 9);
-      assert.deepEqual(object(object(results.get("index-default")).data).offset, 0);
-      assert.equal(array(object(object(results.get("index-boundary")).data).chapters).length, 2);
-      const summaryChapter = object(array(object(object(results.get("chapter-summary")).data).chapters)[0]);
-      assert.ok("summary" in summaryChapter);
-      assert.ok(!("content" in summaryChapter));
-      const contentChapter = object(array(object(object(results.get("chapter-content")).data).chapters)[0]);
-      assert.ok("content" in contentChapter);
-      assert.ok(!("summary" in contentChapter));
-      const bothChapters = array(object(object(results.get("chapter-both")).data).chapters).map(object);
-      assert.equal(bothChapters.length, 3);
-      assert.ok(bothChapters.every((chapter) => "summary" in chapter && "content" in chapter));
-      const errorChapters = array(object(object(results.get("chapter-errors")).data).chapters).map(object);
-      assert.equal(object(errorChapters[1]?.error).message, "The requested chapter was not found.");
-      assert.equal(object(errorChapters[2]?.error).message, "The requested chapter belongs to a different work.");
-      assert.deepEqual(object(results.get("knowledge-default")).ok, true);
-      assert.equal(object(object(results.get("knowledge-default")).data).matchMode, "hybrid_exact_phonetic");
-      const defaultMatches = array(object(object(results.get("knowledge-default")).data).matches).map(object);
-      assert.equal(defaultMatches.some((item) => String(item.type) === "setting" && String(item.title).includes("跃迁")), true);
-      assert.equal(array(object(object(results.get("knowledge-all")).data).matches).length >= 1, true);
-      assert.equal(object(object(results.get("knowledge-all")).data).matchMode, "hybrid_exact_phonetic");
-      const characterSection = object(array(object(object(results.get("character-section")).data).sections)[0]);
-      assert.equal(characterSection.characterName, "哥斯拉");
-      assert.match(String(characterSection.contentMarkdown), /守护地球生态/u);
+      if (!matrixInitialResultsVerified) {
+        assert.equal(results.size, 9);
+        assert.deepEqual(object(object(results.get("index-default")).data).chapterOffset, 0);
+        assert.equal(array(object(object(results.get("index-boundary")).data).chapters).length, 2);
+        const summaryChapter = object(array(object(object(results.get("chapter-summary")).data).chapters)[0]);
+        assert.ok("summary" in summaryChapter);
+        assert.ok(!("content" in summaryChapter));
+        const contentChapter = object(array(object(object(results.get("chapter-content")).data).chapters)[0]);
+        assert.ok("content" in contentChapter);
+        assert.ok(!("summary" in contentChapter));
+        const errorChapters = array(object(object(results.get("chapter-errors")).data).chapters).map(object);
+        assert.equal(object(errorChapters[1]?.error).message, "The requested chapter was not found.");
+        assert.equal(object(errorChapters[2]?.error).message, "The requested chapter belongs to a different work.");
+        assert.deepEqual(object(results.get("knowledge-default")).ok, true);
+        assert.equal(object(object(results.get("knowledge-default")).data).matchMode, "hybrid_exact_phonetic");
+        const defaultMatches = array(object(object(results.get("knowledge-default")).data).matches).map(object);
+        assert.equal(defaultMatches.some((item) => String(item.type) === "setting" && String(item.title).includes("跃迁")), true);
+        assert.equal(array(object(object(results.get("knowledge-all")).data).matches).length >= 1, true);
+        assert.equal(object(object(results.get("knowledge-all")).data).matchMode, "hybrid_exact_phonetic");
+        const characterSection = object(array(object(object(results.get("character-section")).data).sections)[0]);
+        assert.equal(characterSection.characterName, "哥斯拉");
+        assert.match(String(characterSection.contentMarkdown), /守护地球生态/u);
+        matrixInitialResultsVerified = true;
+      }
+      const bothResultId = matrixExpectedCursor === null ? "chapter-both" : `chapter-both-cursor-${matrixExpectedCursor}`;
+      const bothResult = object(results.get(bothResultId));
+      matrixBothChapterRecords.push(...array(object(bothResult.data).chapters).map(object));
+      const pagination = object(bothResult.pagination);
+      assert.equal(pagination.cursor, matrixExpectedCursor ?? 0);
+      const nextCursor = pagination.nextCursor;
+      if (typeof nextCursor === "number") {
+        assert.ok(nextCursor > (matrixExpectedCursor ?? 0));
+        matrixExpectedCursor = nextCursor;
+        toolCalls(outgoing, [{
+          id: `chapter-both-cursor-${nextCursor}`,
+          name: "read_chapters",
+          arguments: { chapterIds, include: "both", cursor: nextCursor }
+        }]);
+        return;
+      }
+      assert.equal(nextCursor, null);
+      for (const chapterId of chapterIds) {
+        const chapterRecords = matrixBothChapterRecords.filter((chapter) => chapter.chapterId === chapterId);
+        assert.ok(chapterRecords.some((chapter) => "summary" in chapter));
+        assert.ok(chapterRecords.some((chapter) => "content" in chapter));
+      }
       matrixVerified = true;
       completion(outgoing, { content: "模型已读取并正确处理全部九组工具结果。" });
       return;

--- a/tests/integration/ai-api.test.ts
+++ b/tests/integration/ai-api.test.ts
@@ -1576,7 +1576,7 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(completionCount).toBe(2);
   });
 
-  it("story_index 首页独立返回第二十一章作为结构最新章节并明确 nextOffset", async () => {
+  it("story_index 首页独立返回第二十一章作为结构最新章节并明确 nextChapterOffset", async () => {
     const volumeId = String(runtime.store.getChapter(chapterId).volumeId);
     const addedChapters = Array.from({ length: 20 }, (_, index) => runtime.store.createChapter(workId, {
       volumeId,
@@ -1591,10 +1591,22 @@ describe("AI 供应商、模型与建议 API", () => {
     fetchMock.mockImplementation(async (input, init) => {
       if (String(input).endsWith("/models")) return new Response(JSON.stringify({ data: [{ id: "mock-novel-model" }] }), { status: 200 });
       completionCount += 1;
-      const body = JSON.parse(String(init?.body)) as { messages: Array<{ role: string; content?: string }> };
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content?: string }>;
+        tools?: Array<{
+          function?: {
+            name?: string;
+            parameters?: { properties?: Record<string, unknown> };
+          };
+        }>;
+      };
       if (completionCount === 1) {
         expect(body.messages[0]?.content).toContain("latestChaptersByStructure 是不受当前分页影响的结构最新章节");
-        expect(body.messages[0]?.content).toContain("nextOffset 非空时用该值作为 offset");
+        expect(body.messages[0]?.content).toContain("用 nextChapterOffset 换页并将 cursor 置 0");
+        const storyIndexProperties = body.tools?.find((tool) => tool.function?.name === "story_index")?.function?.parameters?.properties;
+        expect(storyIndexProperties).toHaveProperty("chapterOffset");
+        expect(storyIndexProperties).toHaveProperty("cursor");
+        expect(storyIndexProperties).not.toHaveProperty("offset");
         return new Response(JSON.stringify({ choices: [{ message: { content: null, tool_calls: [{
           id: "long-story-index",
           type: "function",
@@ -1617,8 +1629,8 @@ describe("AI 供应商、模型与建议 API", () => {
       ok: true,
       data: {
         totalChapters: 21,
-        offset: 0,
-        nextOffset: 20,
+        chapterOffset: 0,
+        nextChapterOffset: 20,
         latestChaptersByStructure: [{
           id: latestChapterId,
           title: "第21章",
@@ -1815,7 +1827,7 @@ describe("AI 供应商、模型与建议 API", () => {
 
     expect(response.body.data.content).toBe("已根据章节目录回答。");
     expect(response.body.data.toolCalls).toEqual([
-      expect.objectContaining({ id: "tool-call-1", name: "story_index", calledAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/u), status: "completed", arguments: { offset: 0, limit: 1 } })
+      expect.objectContaining({ id: "tool-call-1", name: "story_index", calledAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/u), status: "completed", arguments: { chapterOffset: 0, limit: 1 } })
     ]);
     expect(completionCount).toBe(2);
   });
@@ -2032,7 +2044,7 @@ describe("AI 供应商、模型与建议 API", () => {
     });
     const calls = [
       { id: "index-default", name: "story_index", arguments: {} },
-      { id: "index-page", name: "story_index", arguments: { offset: 0, limit: 1 } },
+      { id: "index-page", name: "story_index", arguments: { chapterOffset: 0, limit: 1 } },
       { id: "chapter-summary", name: "read_chapters", arguments: { chapterIds: [chapterId], include: "summary" } },
       { id: "chapter-content", name: "read_chapters", arguments: { chapterIds: [chapterId], include: "content" } },
       { id: "chapter-both", name: "read_chapters", arguments: { chapterIds: [chapterId], include: "both" } },
@@ -2057,7 +2069,7 @@ describe("AI 供应商、模型与建议 API", () => {
       expect(results.get("index-default")).toMatchObject({
         ok: true,
         data: {
-          offset: 0,
+          chapterOffset: 0,
           totalChapters: 1,
           storyOrdering: expect.any(Object),
           latestChaptersByStructure: [{ id: chapterId, storyOrder: { chapter: { isLatestByStructure: true } } }]
@@ -4462,9 +4474,9 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(deltas).toEqual(["我先读取目录。", "已读取", "目录。"]);
     expect(generated.content).toBe("已读取目录。");
     expect(generated.toolCalls).toEqual([
-      expect.objectContaining({ id: "stream-tool", name: "story_index", arguments: { offset: 0, limit: 1 }, status: "completed" })
+      expect.objectContaining({ id: "stream-tool", name: "story_index", arguments: { chapterOffset: 0, limit: 1 }, status: "completed" })
     ]);
-    expect(toolEvents).toEqual([{ arguments: { offset: 0, limit: 1 } }]);
+    expect(toolEvents).toEqual([{ arguments: { chapterOffset: 0, limit: 1 } }]);
     expect(completionCount).toBe(2);
   });
 
@@ -4522,7 +4534,7 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(streamed.text.indexOf('"delta":"我先读取作品目录。"')).toBeLessThan(streamed.text.indexOf('"type":"intermediate","round":1,"content":"我先读取作品目录。"'));
     expect(streamed.text.indexOf('"type":"intermediate","round":1,"content":"我先读取作品目录。"')).toBeLessThan(streamed.text.indexOf("event: tool_call"));
     expect(streamed.text).toContain('"name":"story_index"');
-    expect(streamed.text).toContain('"arguments":{"offset":0,"limit":1}');
+    expect(streamed.text).toContain('"arguments":{"chapterOffset":0,"limit":1}');
     expect(streamed.text).toMatch(/"calledAt":"\d{4}-\d{2}-\d{2}T/u);
     expect(streamed.text).toContain('"result":{"ok":true');
     expect(streamed.text).toContain('event: delta\ndata: {"delta":"已读取"}');
@@ -4540,7 +4552,7 @@ describe("AI 供应商、模型与建议 API", () => {
     expect(generatedSuggestions.body.data[0].content).toBe("已读取目录。");
 
     const conversation = await request(runtime.app).post(`/api/works/${workId}/ai-conversations`).send({}).expect(201);
-    const toolCalls = [{ id: "stream-tool", name: "story_index", calledAt: "2026-07-17T12:34:56.000Z", arguments: { offset: 0, limit: 1 }, status: "completed", result: { ok: true, data: { totalChapters: 1 } } }];
+    const toolCalls = [{ id: "stream-tool", name: "story_index", calledAt: "2026-07-17T12:34:56.000Z", arguments: { chapterOffset: 0, limit: 1 }, status: "completed", result: { ok: true, data: { totalChapters: 1 } } }];
     const processSteps = [
       { id: "process-thinking", type: "thinking", round: 1, content: "需要读取目录。", createdAt: "2026-07-17T12:34:55.000Z" },
       { id: "process-compaction", type: "context_compaction", round: 1, sourceMessageCount: 2, sourceChars: 12000, summaryChars: 180, createdAt: "2026-07-17T12:34:55.500Z" },

--- a/tests/integration/anthropic-messages-api.test.ts
+++ b/tests/integration/anthropic-messages-api.test.ts
@@ -366,9 +366,9 @@ describe("Anthropic Messages 供应商", () => {
     expect(deltas).toEqual(["我先读取目录。", "已读取", "目录。"]);
     expect(generated.content).toBe("已读取目录。");
     expect(generated.toolCalls).toEqual([
-      expect.objectContaining({ id: "toolu_stream", name: "story_index", arguments: { offset: 0, limit: 1 }, status: "completed" })
+      expect.objectContaining({ id: "toolu_stream", name: "story_index", arguments: { chapterOffset: 0, limit: 1 }, status: "completed" })
     ]);
-    expect(toolEvents).toEqual([{ arguments: { offset: 0, limit: 1 } }]);
+    expect(toolEvents).toEqual([{ arguments: { chapterOffset: 0, limit: 1 } }]);
     expect(streamedCompletionCount).toBe(2);
   });
 

--- a/tests/integration/user-auth-api.test.ts
+++ b/tests/integration/user-auth-api.test.ts
@@ -3252,7 +3252,7 @@ describe("用户、作品权限与操作者追踪 API", () => {
       () => internalAi.executeAgentTool(workId, {
         id: "structure-only",
         type: "function",
-        function: { name: "story_index", arguments: JSON.stringify({ offset: 0, limit: 20, cursor: 0 }) }
+        function: { name: "story_index", arguments: JSON.stringify({ chapterOffset: 0, limit: 20, cursor: 0 }) }
       })
     );
     expect(structureOnly).toMatchObject({ status: "completed", result: { ok: true } });

--- a/tests/unit/store-story-index.test.ts
+++ b/tests/unit/store-story-index.test.ts
@@ -234,4 +234,84 @@ describe("story_index 目录读取", () => {
       pagination: { nextCursor: expect.any(Number), maxChars: 1_000 }
     });
   });
+
+  it("区分章节翻页与结果分片，并兼容旧 offset 输入", async () => {
+    runtime = createTestRuntime();
+    const work = runtime.store.createWork({ title: "双层分页目录" });
+    const volume = runtime.store.createVolume(String(work.id), { title: "第一卷" });
+    const chapters = ["第一章", "第二章"].map((title) => runtime!.store.createChapter(String(work.id), {
+      volumeId: String(volume.id),
+      title,
+      content: `${title}正文`
+    }));
+    type StoryIndexExecution = {
+      arguments: Record<string, unknown>;
+      result: {
+        data: {
+          chapterOffset: number;
+          chapters: Array<{ id?: unknown }>;
+          nextChapterOffset: number | null;
+          continuationRule: string;
+        };
+        pagination: { cursor: number; nextCursor: number | null; maxChars: number };
+      };
+    };
+    const internalAi = runtime.ai as unknown as {
+      executeAgentTool: (
+        workId: string,
+        toolCall: Record<string, unknown>,
+        maximumResultChars?: number
+      ) => Promise<StoryIndexExecution>;
+    };
+    const readPage = (chapterOffset: number, cursor = 0): Promise<StoryIndexExecution> => internalAi.executeAgentTool(String(work.id), {
+      id: `index-${chapterOffset}-${cursor}`,
+      type: "function",
+      function: { name: "story_index", arguments: { chapterOffset, limit: 1, ...(cursor > 0 ? { cursor } : {}) } }
+    }, 1_000);
+
+    const firstChapterIds: unknown[] = [];
+    let cursor = 0;
+    let finalFirstPage: StoryIndexExecution | null = null;
+    for (let pageCount = 0; pageCount < 10; pageCount += 1) {
+      const execution = await readPage(0, cursor);
+      expect(execution.arguments).toMatchObject({ chapterOffset: 0, limit: 1 });
+      expect(execution.result.data.chapterOffset).toBe(0);
+      firstChapterIds.push(...execution.result.data.chapters.map((chapter) => chapter.id));
+      const nextCursor = execution.result.pagination.nextCursor;
+      if (nextCursor === null) {
+        finalFirstPage = execution;
+        break;
+      }
+      expect(execution.result.data.nextChapterOffset).toBeNull();
+      expect(execution.result.data.continuationRule).toContain("pagination.nextCursor");
+      expect(nextCursor).toBeGreaterThan(cursor);
+      cursor = nextCursor;
+    }
+
+    expect(firstChapterIds).toEqual([chapters[0]?.id]);
+    expect(finalFirstPage?.result.data).toMatchObject({
+      nextChapterOffset: 1,
+      continuationRule: expect.stringContaining("reset cursor")
+    });
+
+    const secondChapterIds: unknown[] = [];
+    cursor = 0;
+    for (let pageCount = 0; pageCount < 10; pageCount += 1) {
+      const execution = await readPage(1, cursor);
+      secondChapterIds.push(...execution.result.data.chapters.map((chapter) => chapter.id));
+      const nextCursor = execution.result.pagination.nextCursor;
+      if (nextCursor === null) break;
+      expect(nextCursor).toBeGreaterThan(cursor);
+      cursor = nextCursor;
+    }
+    expect(secondChapterIds).toEqual([chapters[1]?.id]);
+
+    const legacyExecution = await internalAi.executeAgentTool(String(work.id), {
+      id: "legacy-index-offset",
+      type: "function",
+      function: { name: "story_index", arguments: { offset: 1, limit: 1 } }
+    });
+    expect(legacyExecution.arguments).toEqual({ chapterOffset: 1, limit: 1 });
+    expect(legacyExecution.result.data.chapterOffset).toBe(1);
+  });
 });

--- a/tests/unit/store-story-index.test.ts
+++ b/tests/unit/store-story-index.test.ts
@@ -284,6 +284,7 @@ describe("story_index 目录读取", () => {
       }
       expect(execution.result.data.nextChapterOffset).toBeNull();
       expect(execution.result.data.continuationRule).toContain("pagination.nextCursor");
+      expect(nextCursor).toBeGreaterThan(100_000);
       expect(nextCursor).toBeGreaterThan(cursor);
       cursor = nextCursor;
     }
@@ -301,6 +302,7 @@ describe("story_index 目录读取", () => {
       secondChapterIds.push(...execution.result.data.chapters.map((chapter) => chapter.id));
       const nextCursor = execution.result.pagination.nextCursor;
       if (nextCursor === null) break;
+      expect(nextCursor).toBeGreaterThan(100_000);
       expect(nextCursor).toBeGreaterThan(cursor);
       cursor = nextCursor;
     }

--- a/tests/unit/store-story-index.test.ts
+++ b/tests/unit/store-story-index.test.ts
@@ -263,17 +263,17 @@ describe("story_index 目录读取", () => {
         maximumResultChars?: number
       ) => Promise<StoryIndexExecution>;
     };
-    const readPage = (chapterOffset: number, cursor = 0): Promise<StoryIndexExecution> => internalAi.executeAgentTool(String(work.id), {
+    const readPage = (chapterOffset: number, cursor = 0, maximumResultChars = 1_000): Promise<StoryIndexExecution> => internalAi.executeAgentTool(String(work.id), {
       id: `index-${chapterOffset}-${cursor}`,
       type: "function",
       function: { name: "story_index", arguments: { chapterOffset, limit: 1, ...(cursor > 0 ? { cursor } : {}) } }
-    }, 1_000);
+    }, maximumResultChars);
 
     const firstChapterIds: unknown[] = [];
     let cursor = 0;
     let finalFirstPage: StoryIndexExecution | null = null;
     for (let pageCount = 0; pageCount < 10; pageCount += 1) {
-      const execution = await readPage(0, cursor);
+      const execution = await readPage(0, cursor, cursor === 0 ? 1_000 : 10_000);
       expect(execution.arguments).toMatchObject({ chapterOffset: 0, limit: 1 });
       expect(execution.result.data.chapterOffset).toBe(0);
       firstChapterIds.push(...execution.result.data.chapters.map((chapter) => chapter.id));
@@ -291,13 +291,13 @@ describe("story_index 目录读取", () => {
     expect(firstChapterIds).toEqual([chapters[0]?.id]);
     expect(finalFirstPage?.result.data).toMatchObject({
       nextChapterOffset: 1,
-      continuationRule: expect.stringContaining("reset cursor")
+      continuationRule: expect.stringContaining("把 cursor 重置为 0")
     });
 
     const secondChapterIds: unknown[] = [];
     cursor = 0;
     for (let pageCount = 0; pageCount < 10; pageCount += 1) {
-      const execution = await readPage(1, cursor);
+      const execution = await readPage(1, cursor, cursor === 0 ? 1_000 : 10_000);
       secondChapterIds.push(...execution.result.data.chapters.map((chapter) => chapter.id));
       const nextCursor = execution.result.pagination.nextCursor;
       if (nextCursor === null) break;


### PR DESCRIPTION
## Summary

- Rename the exposed story_index chapter paginator to chapterOffset/nextChapterOffset while accepting legacy offset input.
- Distinguish chapter paging from result-fragment cursor continuation and return an explicit continuation rule.
- Encode the structural fragment budget into opaque cursors so continuation remains stable when per-round result budgets change.
- Extend unit, integration, Anthropic, streaming, permission, and real AI tool E2E coverage.

## Verification

- npm run typecheck
- npm test: 266 files, 1370 tests passed
- npm run build
- npm run test:e2e:ai-tools

Closes MUXUE-111