### PR TITLE
fix(database): close connections after initialization errors

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -88,9 +88,11 @@ export class Database {
 
   constructor(readonly filename: string) {
     logger.info("database.opening", { databasePath: filename, inMemory: filename === ":memory:" });
+    let raw: DatabaseSync | null = null;
     try {
       if (filename !== ":memory:") mkdirSync(dirname(filename), { recursive: true });
-      this.raw = new DatabaseSync(filename);
+      raw = new DatabaseSync(filename);
+      this.raw = raw;
       this.raw.exec("PRAGMA foreign_keys = ON");
       this.raw.exec("PRAGMA busy_timeout = 5000");
       if (filename !== ":memory:") this.raw.exec("PRAGMA journal_mode = WAL");
@@ -104,6 +106,11 @@ export class Database {
       const migration = this.get<{ version: number }>("SELECT MAX(version) AS version FROM schema_migrations");
       logger.info("database.ready", { inMemory: filename === ":memory:", schemaVersion: Number(migration?.version ?? 0) });
     } catch (error) {
+      try {
+        raw?.close();
+      } catch (closeError) {
+        logger.warn("database.open_failure_close_failed", { databasePath: filename, error: sanitizeError(closeError) });
+      }
       logSqliteDiskIoError(filename, error);
       logger.error("database.open_failed", { databasePath: filename, error: sanitizeError(error) });
       throw error;

--- a/tests/unit/database-constructor.test.ts
+++ b/tests/unit/database-constructor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+const databaseSync = vi.hoisted(() => ({
+  close: vi.fn(),
+  exec: vi.fn()
+}));
+
+vi.mock("node:sqlite", () => ({
+  DatabaseSync: class {
+    close = databaseSync.close;
+    exec = databaseSync.exec;
+  }
+}));
+
+import { Database } from "../../src/database.js";
+
+describe("Database", () => {
+  it("初始化失败时关闭已打开的连接并保留原始错误", () => {
+    const initializationError = new Error("initialization failed");
+    const closeError = new Error("close failed");
+    databaseSync.exec.mockImplementation(() => {
+      throw initializationError;
+    });
+    databaseSync.close.mockImplementation(() => {
+      throw closeError;
+    });
+
+    expect(() => new Database(":memory:")).toThrow(initializationError);
+    expect(databaseSync.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 修复内容

关闭 `Database` 构造期间已打开但因初始化或迁移失败而未完成构造的 SQLite 连接，避免 Windows 清理临时数据库目录时出现 `EPERM`。

同时新增回归测试，验证关闭异常不会覆盖原始初始化错误。

Closes #638

## 验证

- `npx vitest run tests/unit/database-constructor.test.ts --no-file-parallelism`
- `npx vitest run tests/unit/database-migration.test.ts --no-file-parallelism`
- `npm run typecheck`
- `npm test`
- `npm run build`
- 隔离服务 `/api/health` 与 SQLite 只读完整性检查