### PR TITLE
feat(cli): manage ai conversation titles and author questions

### DIFF
--- a/src/cli-core.ts
+++ b/src/cli-core.ts
@@ -5,6 +5,7 @@ import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { cliResourceDefinitions, cliResourceTypes, cliWorkDefinition, type CliResourceType } from "./cli-contract.js";
 import { HYBRID_SEARCH_TYPES } from "./hybrid-search.js";
+import { AI_USER_QUESTION_STATUSES } from "./ai-write-plans.js";
 import type { LocalServerOptions } from "./server-runtime.js";
 
 type OutputStream = { write(chunk: string): unknown };
@@ -525,10 +526,19 @@ function helpText(): string {
   scriverse annotation update <annotationId> --input <json-file|->
   scriverse annotation delete <annotationId> [--expected-version <number>]
 
+AI 对话与提问：
+  scriverse ai rename <conversationId> --title <text>
+  scriverse ai questions list <workId> [--status pending|answered|rejected|expired] [--conversation-id <id>] [--limit <number>]
+  scriverse ai questions get <workId> <questionId>
+  scriverse ai questions answer <workId> <questionId> --input <json-file|->
+  scriverse ai questions reject <workId> <questionId>
+
 AI 编辑辅助：
   scriverse schema list
   scriverse schema show <type>
   --field-file content=chapter.txt 可把长文本写入 JSON 字段
+  ai questions answer 的 --input 支持单项 {selectedOption, customAnswer} 或批量 {answers: [...最多 5 项]}
+  跨作品 IM 仅限网页或桌面交互式会话使用，不通过 CLI 开放
 
 全局选项：
   --config <path>  指定登录配置文件
@@ -549,9 +559,10 @@ function schemaList(): Record<string, unknown> {
       writing: ["progress", "goal"],
       chapter: ["move", "batch"],
       annotation: ["list", "list-work", "create", "update", "delete"],
-      manuscript: ["get"]
+      manuscript: ["get"],
+      ai: ["rename", "questions"]
     },
-    prohibited: ["用户管理", "作品成员管理", "系统管理", "AI 供应商与模型管理", "永久删除及作品、分卷、知识实体删除", "任意 HTTP 请求"],
+    prohibited: ["用户管理", "作品成员管理", "系统管理", "AI 供应商与模型管理", "永久删除及作品、分卷、知识实体删除", "任意 HTTP 请求", "跨作品 IM（仅限交互式会话）"],
     resources: cliResourceTypes.map((type) => ({
       type,
       description: cliResourceDefinitions[type].description,
@@ -709,7 +720,7 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
     throw new CliError("CLI_COMMAND_UNKNOWN", "未知 schema 命令");
   }
 
-  if (!["work", "manuscript", "search", "audit", "resource", "writing", "chapter", "annotation"].includes(group)) {
+  if (!["work", "manuscript", "search", "audit", "resource", "writing", "chapter", "annotation", "ai"].includes(group)) {
     throw new CliError("CLI_COMMAND_UNKNOWN", "未知命令；使用 --help 查看可用命令");
   }
   const config = requestConfig(parsed, path);
@@ -900,6 +911,83 @@ async function execute(parsed: ParsedArguments, dependencies: Required<CliDepend
       return;
     }
     throw new CliError("CLI_COMMAND_UNKNOWN", "未知 annotation 命令");
+  }
+
+  if (group === "ai") {
+    if (action === "rename") {
+      assertAllowedOptions(parsed, ["title"]);
+      const conversationId = requiredPosition(parsed.positionals, 2, "conversationId");
+      assertPositionCount(parsed.positionals, 3);
+      const title = option(parsed, "title")?.trim() ?? "";
+      if (!title) throw new CliError("CLI_TITLE_REQUIRED", "请使用 --title 提供新标题");
+      if (title.length > 200) throw new CliError("CLI_TITLE_INVALID", "标题不能超过 200 字");
+      emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/ai-conversations/${encoded(conversationId)}/title`, {
+        method: "PATCH",
+        body: { title }
+      }), compact);
+      return;
+    }
+    if (action === "questions") {
+      const subaction = requiredPosition(parsed.positionals, 2, "questions 子命令");
+      if (subaction === "list") {
+        assertAllowedOptions(parsed, ["status", "conversation-id", "limit"]);
+        const workId = requiredPosition(parsed.positionals, 3, "workId");
+        assertPositionCount(parsed.positionals, 4);
+        const status = option(parsed, "status")?.trim();
+        if (status && !AI_USER_QUESTION_STATUSES.includes(status as never)) {
+          throw new CliError("CLI_QUESTION_STATUS_INVALID", `status 必须是 ${AI_USER_QUESTION_STATUSES.join("、")} 之一`);
+        }
+        const conversationId = option(parsed, "conversation-id")?.trim();
+        if (conversationId !== undefined && !conversationId) {
+          throw new CliError("CLI_CONVERSATION_ID_INVALID", "--conversation-id 不能为空");
+        }
+        const rawLimit = option(parsed, "limit");
+        const limit = rawLimit === undefined ? undefined : Number(rawLimit);
+        if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 200)) {
+          throw new CliError("CLI_QUESTION_LIMIT_INVALID", "limit 必须是 1 到 200 之间的整数");
+        }
+        const parameters = new URLSearchParams();
+        if (conversationId) parameters.set("conversationId", conversationId);
+        if (status) parameters.set("status", status);
+        if (limit !== undefined) parameters.set("limit", String(limit));
+        const query = parameters.size > 0 ? `?${parameters}` : "";
+        emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/works/${encoded(workId)}/ai/questions${query}`), compact);
+        return;
+      }
+      if (subaction === "get") {
+        assertAllowedOptions(parsed, []);
+        const workId = requiredPosition(parsed.positionals, 3, "workId");
+        const questionId = requiredPosition(parsed.positionals, 4, "questionId");
+        assertPositionCount(parsed.positionals, 5);
+        emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/works/${encoded(workId)}/ai/questions/${encoded(questionId)}`), compact);
+        return;
+      }
+      if (subaction === "answer") {
+        assertAllowedOptions(parsed, ["input", "field-file"]);
+        const workId = requiredPosition(parsed.positionals, 3, "workId");
+        const questionId = requiredPosition(parsed.positionals, 4, "questionId");
+        assertPositionCount(parsed.positionals, 5);
+        const body = await editInput(parsed, dependencies, false);
+        emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/works/${encoded(workId)}/ai/questions/${encoded(questionId)}/answer`, {
+          method: "POST",
+          body
+        }), compact);
+        return;
+      }
+      if (subaction === "reject") {
+        assertAllowedOptions(parsed, []);
+        const workId = requiredPosition(parsed.positionals, 3, "workId");
+        const questionId = requiredPosition(parsed.positionals, 4, "questionId");
+        assertPositionCount(parsed.positionals, 5);
+        emitJson(dependencies.stdout, await apiRequest(dependencies.fetchImpl, config, `/api/works/${encoded(workId)}/ai/questions/${encoded(questionId)}/reject`, {
+          method: "POST",
+          body: {}
+        }), compact);
+        return;
+      }
+      throw new CliError("CLI_COMMAND_UNKNOWN", "未知 ai questions 子命令");
+    }
+    throw new CliError("CLI_COMMAND_UNKNOWN", "未知 ai 命令");
   }
 
   if (group === "resource") {

--- a/src/user-auth.ts
+++ b/src/user-auth.ts
@@ -1088,7 +1088,11 @@ const cliApiRules: Array<{ methods: string[]; path: RegExp }> = [
   { methods: ["GET"], path: /^\/api\/characters\/[^/]+\/versions$/u },
   { methods: ["POST"], path: /^\/api\/characters\/[^/]+\/restore$/u },
   { methods: ["GET"], path: /^\/api\/entity-versions\/[^/]+\/[^/]+$/u },
-  { methods: ["POST"], path: /^\/api\/entity-versions\/[^/]+\/[^/]+\/restore$/u }
+  { methods: ["POST"], path: /^\/api\/entity-versions\/[^/]+\/[^/]+\/restore$/u },
+  { methods: ["PATCH"], path: /^\/api\/ai-conversations\/[^/]+\/title$/u },
+  { methods: ["GET"], path: /^\/api\/works\/[^/]+\/ai\/questions$/u },
+  { methods: ["GET"], path: /^\/api\/works\/[^/]+\/ai\/questions\/[^/]+$/u },
+  { methods: ["POST"], path: /^\/api\/works\/[^/]+\/ai\/questions\/[^/]+\/(?:answer|reject)$/u }
 ];
 
 export function createCliApiScopeMiddleware(disabled = false): RequestHandler {

--- a/tests/e2e/real-cli.ts
+++ b/tests/e2e/real-cli.ts
@@ -287,6 +287,16 @@ async function run(): Promise<void> {
   assert.equal((cliJson(["work", "get", workId]) as Record<string, unknown>).id, workId);
   checked("work-commands", "work create, update, list and get passed with admin API key restricted to owned works");
 
+  const aiConversation = await sessionRequest(admin, `/api/works/${workId}/ai-conversations`, "POST", { title: "初始对话标题" }) as Record<string, unknown>;
+  const aiConversationId = String(aiConversation.id);
+  const renamedConversation = cliJson(["ai", "rename", aiConversationId, "--title", "CLI 重命名后的对话"]) as Record<string, unknown>;
+  assert.equal(renamedConversation.title, "CLI 重命名后的对话");
+  const conversationDetail = await sessionRequest(admin, `/api/ai-conversations/${aiConversationId}`) as Record<string, unknown>;
+  assert.equal(conversationDetail.title, "CLI 重命名后的对话");
+  const emptyQuestions = cliJson(["ai", "questions", "list", workId]) as { questions: unknown[] };
+  assert.equal(emptyQuestions.questions.length, 0);
+  checked("ai-commands", "ai rename and questions list passed against the real server");
+
   const volume = createResource("volume", workId, {
     title: "第一卷",
     kind: "main",
@@ -556,6 +566,7 @@ async function run(): Promise<void> {
   const writerWorks = cliJson(["work", "list"]) as Array<Record<string, unknown>>;
   assert.deepEqual(writerWorks.map((item) => item.id), [writerWork.id]);
   cliError(["work", "get", workId], "WORK_ACCESS_DENIED");
+  cliError(["ai", "rename", aiConversationId, "--title", "越权重命名"], "WORK_ACCESS_DENIED");
   await resetApiKey(writer);
   cliError(["auth", "status"], "API_KEY_INVALID");
   assert.deepEqual(cliJson(["auth", "logout"]), { authenticated: false, server: baseUrl, defaultServer: baseUrl, configPath });

--- a/tests/unit/cli-core.test.ts
+++ b/tests/unit/cli-core.test.ts
@@ -544,4 +544,74 @@ describe("Scriverse CLI 核心", () => {
     expect(await runCli(["users", "list"], { stdout: stdout.stream, stderr: unknownError.stream })).toBe(1);
     expect(JSON.parse(unknownError.text())).toMatchObject({ error: { code: "CLI_COMMAND_UNKNOWN" } });
   });
+
+  it("支持 AI 对话重命名与批量提问的查看、回答和拒绝命令", async () => {
+    const root = temporaryRoot();
+    const configPath = join(root, "cli.json");
+    writeFileSync(configPath, JSON.stringify({
+      version: 2,
+      defaultServer: "http://127.0.0.1:13210",
+      servers: {
+        "http://127.0.0.1:13210": {
+          apiKey: "scrv_test_key",
+          apiKeyPrefix: "scrv_test",
+          user: { userId: "user-1", username: "writer", displayName: "Writer", role: "user" }
+        }
+      }
+    }));
+    const calls: Array<{ url: string; method: string; body: unknown }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(input), method: init?.method ?? "GET", body: init?.body ? JSON.parse(String(init.body)) : null });
+      return new Response(JSON.stringify({ data: { ok: true } }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as typeof fetch;
+    const run = (args: string[]) => runCli([...args, "--config", configPath], { fetchImpl, stdout: outputCapture().stream, stderr: outputCapture().stream });
+    const answerPath = jsonFile(root, "question-answer.json", {
+      answers: [
+        { selectedOption: 1, customAnswer: "补充背景：星港在雨季封锁航道" },
+        { customAnswer: "沿用第三章的潮汐时间线" }
+      ]
+    });
+
+    expect(await run(["ai", "rename", "conversation-1", "--title", "  星港谈判线  "])).toBe(0);
+    expect(await run(["ai", "questions", "list", "work-1"])).toBe(0);
+    expect(await run(["ai", "questions", "list", "work-1", "--status", "pending", "--conversation-id", "conversation-1", "--limit", "12"])).toBe(0);
+    expect(await run(["ai", "questions", "get", "work-1", "question-1"])).toBe(0);
+    expect(await run(["ai", "questions", "answer", "work-1", "question-1", "--input", answerPath])).toBe(0);
+    expect(await run(["ai", "questions", "reject", "work-1", "question-1"])).toBe(0);
+    expect(calls).toEqual([
+      { url: "http://127.0.0.1:13210/api/ai-conversations/conversation-1/title", method: "PATCH", body: { title: "星港谈判线" } },
+      { url: "http://127.0.0.1:13210/api/works/work-1/ai/questions", method: "GET", body: null },
+      { url: "http://127.0.0.1:13210/api/works/work-1/ai/questions?conversationId=conversation-1&status=pending&limit=12", method: "GET", body: null },
+      { url: "http://127.0.0.1:13210/api/works/work-1/ai/questions/question-1", method: "GET", body: null },
+      {
+        url: "http://127.0.0.1:13210/api/works/work-1/ai/questions/question-1/answer",
+        method: "POST",
+        body: {
+          answers: [
+            { selectedOption: 1, customAnswer: "补充背景：星港在雨季封锁航道" },
+            { customAnswer: "沿用第三章的潮汐时间线" }
+          ]
+        }
+      },
+      { url: "http://127.0.0.1:13210/api/works/work-1/ai/questions/question-1/reject", method: "POST", body: {} }
+    ]);
+
+    const longTitle = outputCapture();
+    expect(await runCli(["ai", "rename", "conversation-1", "--title", "标".repeat(201), "--config", configPath], {
+      fetchImpl, stdout: longTitle.stream, stderr: longTitle.stream
+    })).toBe(1);
+    expect(JSON.parse(longTitle.text())).toMatchObject({ error: { code: "CLI_TITLE_INVALID" } });
+
+    const invalidStatus = outputCapture();
+    expect(await runCli(["ai", "questions", "list", "work-1", "--status", "closed", "--config", configPath], {
+      fetchImpl, stdout: invalidStatus.stream, stderr: invalidStatus.stream
+    })).toBe(1);
+    expect(JSON.parse(invalidStatus.text())).toMatchObject({ error: { code: "CLI_QUESTION_STATUS_INVALID" } });
+
+    const invalidLimit = outputCapture();
+    expect(await runCli(["ai", "questions", "list", "work-1", "--limit", "0", "--config", configPath], {
+      fetchImpl, stdout: invalidLimit.stream, stderr: invalidLimit.stream
+    })).toBe(1);
+    expect(JSON.parse(invalidLimit.text())).toMatchObject({ error: { code: "CLI_QUESTION_LIMIT_INVALID" } });
+  });
 });


### PR DESCRIPTION
## Summary

- add `ai rename` and `ai questions list/get/answer/reject` CLI commands for the new AI conversation rename and batched author question features
- extend the API key CLI scope allowlist with the corresponding endpoints
- update CLI help text and schema notes (cross-work IM stays interactive-session only)
- cover the commands with unit tests and real CLI E2E (rename, list, scope denial)

## Test

- `npm run typecheck`
- `npx vitest run tests/unit` (742 passed)
- `npm run test:e2e:cli` (isolated server, all sections passed)