### PR TITLE
MUXUE-113: bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.10",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.9.10",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.10",
+  "version": "1.0.0",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.9.10";
+export const APP_VERSION = "1.0.0";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 同步 `package.json`、`package-lock.json` 与 `src/version.ts` 的版本为 `1.0.0`
- 保持运行时版本与包版本一致，为 `develop` → `main` 正式发布做准备

## 验证

- `npm test -- tests/unit/version.test.ts`：2 项通过
- `npm run check`：273 个测试文件、1471 项测试通过，类型检查和生产构建通过
- 隔离生产启动：`/api/health` 返回 `1.0.0`
- 隔离 SQLite：`PRAGMA integrity_check` 返回 `ok`，`foreign_key_check` 无异常

关联 MUXUE-113。
