### PR TITLE
MUXUE-113: publish v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.10",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "0.9.10",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "0.9.10",
+  "version": "1.0.0",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "0.9.10";
+export const APP_VERSION = "1.0.0";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 发布内容

- 将已在 `develop` 合并的 `1.0.0` 版本标识发布到 `main`
- `develop` 相对 `main` 仅修改 `package.json`、`package-lock.json` 和 `src/version.ts` 的版本字段
- API、请求响应、认证权限、导入导出与 CLI 契约均无差异，不需要额外 CLI 同步

## 验证

- `npm test -- tests/unit/version.test.ts`：2 项通过
- `npm run check`：273 个测试文件、1471 项测试通过，类型检查和生产构建通过
- 隔离生产启动：`/api/health` 的应用、服务端和 Web 资源版本均为 `1.0.0`
- 隔离 SQLite：`PRAGMA integrity_check` 返回 `ok`，`foreign_key_check` 无异常

关联 MUXUE-113；合并后将核验 `main` 合并提交并创建 `v1.0.0` tag 与 GitHub Release。
