### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "1.0.1";
+export const APP_VERSION = "1.0.2";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 将 Scriverse 包版本与运行时版本从 `1.0.1` 更新为 `1.0.2`。
- 同步 `package.json`、`package-lock.json` 和 `src/version.ts`。

## 验证

- 版本一致性测试通过：2 项。
- 全量测试通过：275 个测试文件、1,480 项测试。
- `npm run typecheck`、`npm run build`、数据库升级测试和真实 CLI E2E 通过。
- 隔离服务 `/api/health` 返回 `1.0.2`；SQLite 完整性与外键检查通过。
