### PR TITLE
chore(release): bump version to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "1.0.2";
+export const APP_VERSION = "1.0.3";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 顶层与根包版本、`src/version.ts` 同步更新为 `1.0.3`。
- 已审计 v1.0.2 之后的 CLI 契约；现有 JSON API 与 CLI 命令保持兼容，无需 CLI 补充改动。

## 验证

- `tests/unit/version.test.ts`：2 项通过
- 全量测试：276 个文件、1499 项通过
- `npm run typecheck`
- `npm run build`
- `npm run test:database-upgrade`
- `npm run test:e2e:cli`
- 生产模式隔离健康检查：v1.0.3
- SQLite `integrity_check` 与 `foreign_key_check` 通过