### PR TITLE
chore(release): bump server version to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "1.0.3";
+export const APP_VERSION = "1.0.4";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
## 变更

- 将 `package.json`、`package-lock.json` 顶层及根包版本、`src/version.ts` 同步更新为 `1.0.4`
- 本次 `develop` 相对 `main` 的 API/CLI 契约审计确认无需新增 CLI 命令

## 验证

- `npm run typecheck`
- `npm test`：277 个测试文件、1506 个用例通过
- `npm run build`
- `npm run test:e2e:cli`
- 隔离服务 `/api/health` 返回 `1.0.4`
- 隔离 SQLite `PRAGMA integrity_check` 与 `foreign_key_check` 通过