### PR TITLE
chore(release): bump server version to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "1.0.4";
+export const APP_VERSION = "1.0.5";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
将 Server 包版本、锁文件顶层和根包版本、运行时 APP_VERSION 同步升级为 1.0.5，准备发布已合入 develop 的权限与数据完整性修复和可展开 toast 堆叠。

CLI 兼容性审计未发现需要新增命令或更新请求/响应契约的变化。版本一致性测试及类型检查通过；全量发布验证正在运行，正式发布 PR 将在验证通过后创建。
