### PR TITLE
chore(release): publish server v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musnows/scriverse",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1102.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musnows/scriverse",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Command-line client and local server for the Scriverse long-form fiction workspace",
   "license": "AGPL-3.0-only",
   "author": "musnows",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "1.0.5";
+export const APP_VERSION = "1.0.6";
 
 export const SCRIVERSE_BETA_COMMIT_ENV = "SCRIVERSE_BETA_COMMIT";
 


### PR DESCRIPTION
发布 Server v1.0.6，与修复更新包 CPU 架构选择的 Desktop v1.0.6 保持版本一致。Server 相对 v1.0.5 仅同步版本，没有功能或 CLI/API 契约变化。

本地验证：281 个测试文件 / 1527 项测试、类型检查、生产构建、真实 CLI E2E、隔离健康检查和数据库完整性/外键检查全部通过。四处版本值均为 1.0.6。

合入后将在实际 main 合并提交上核对版本并创建 v1.0.6 tag 与正式 Release，验证 npm 和双架构 Docker 发布后再发布客户端。
